### PR TITLE
Fix various issues - UncapStars, Radix update changes, React key warnings

### DIFF
--- a/components/AwakeningSelect/index.tsx
+++ b/components/AwakeningSelect/index.tsx
@@ -187,7 +187,7 @@ const AwakeningSelect = (props: Props) => {
             max={maxValue}
             step="1"
             onChange={handleInputChange}
-            visible={awakeningType !== -1}
+            visible={`${awakeningType !== -1}`}
             ref={awakeningLevelInput}
           />
         </div>

--- a/components/CharacterGrid/index.tsx
+++ b/components/CharacterGrid/index.tsx
@@ -15,6 +15,7 @@ import type { JobSkillObject, SearchableObject } from '~types'
 
 import api from '~utils/api'
 import { appState } from '~utils/appState'
+import { accountState } from '~utils/accountState'
 
 import './index.scss'
 
@@ -283,10 +284,16 @@ const CharacterGrid = (props: Props) => {
     position: number,
     uncapLevel: number
   ) {
-    memoizeAction(id, position, uncapLevel)
+    if (
+      party.user &&
+      accountState.account.user &&
+      party.user.id === accountState.account.user.id
+    ) {
+      memoizeAction(id, position, uncapLevel)
 
-    // Optimistically update UI
-    updateUncapLevel(position, uncapLevel)
+      // Optimistically update UI
+      updateUncapLevel(position, uncapLevel)
+    }
   }
 
   const memoizeAction = useCallback(

--- a/components/SearchFilterCheckboxItem/index.tsx
+++ b/components/SearchFilterCheckboxItem/index.tsx
@@ -13,8 +13,12 @@ interface Props {
 }
 
 const SearchFilterCheckboxItem = (props: Props) => {
-  function handleCheckedChange(checked: boolean) {
-    props.onCheckedChange(checked, props.valueKey)
+  function handleCheckedChange(checked: string | boolean) {
+    if (typeof checked === 'boolean') {
+      props.onCheckedChange(checked, props.valueKey)
+    } else {
+      props.onCheckedChange(false, props.valueKey)
+    }
   }
 
   return (

--- a/components/SummonGrid/index.tsx
+++ b/components/SummonGrid/index.tsx
@@ -12,6 +12,7 @@ import ExtraSummons from '~components/ExtraSummons'
 
 import api from '~utils/api'
 import { appState } from '~utils/appState'
+import { accountState } from '~utils/accountState'
 import type { SearchableObject } from '~types'
 
 import './index.scss'
@@ -156,10 +157,16 @@ const SummonGrid = (props: Props) => {
     position: number,
     uncapLevel: number
   ) {
-    memoizeAction(id, position, uncapLevel)
+    if (
+      party.user &&
+      accountState.account.user &&
+      party.user.id === accountState.account.user.id
+    ) {
+      memoizeAction(id, position, uncapLevel)
 
-    // Optimistically update UI
-    updateUncapLevel(position, uncapLevel)
+      // Optimistically update UI
+      updateUncapLevel(position, uncapLevel)
+    }
   }
 
   const memoizeAction = useCallback(

--- a/components/WeaponSearchFilterBar/index.tsx
+++ b/components/WeaponSearchFilterBar/index.tsx
@@ -137,7 +137,7 @@ const WeaponSearchFilterBar = (props: Props) => {
 
   const renderWeaponSeriesGroup = (index: number) => {
     return (
-      <DropdownMenu.Group className="Group">
+      <DropdownMenu.Group className="Group" key={`Group-${index}`}>
         {weaponSeries
           .slice(
             index * Math.ceil(weaponSeries.length / 3),


### PR DESCRIPTION
This build fixes a few bugs:
* Users can no longer update uncap stars for characters or summons that aren't in parties they made
* Fix React warning for list items not having a key in WeaponKeyDropdown
* Fix build errors relating to updating Radix libraries