### PR TITLE
Fix language switch in logged-out menu

### DIFF
--- a/components/HeaderMenu/index.scss
+++ b/components/HeaderMenu/index.scss
@@ -88,8 +88,9 @@
         display: block;
         height: $diameter;
         width: $diameter;
-        transition: transform 100ms;
-        transform: translateX(-2px);
+        position: absolute;
+        top: 3px;
+        left: 3px;
         z-index: 3;
 
         &:hover {
@@ -98,7 +99,7 @@
 
         &[data-state='checked'] {
           background: $grey-100;
-          transform: translateX(17px);
+          left: 23px;
         }
       }
 

--- a/types/GranblueCookie.d.ts
+++ b/types/GranblueCookie.d.ts
@@ -1,5 +1,5 @@
 interface GranblueCookie {
-  account: AccountCookie
-  user: UserCookie
+  account?: AccountCookie
+  user?: UserCookie
   locale: string
 }

--- a/utils/retrieveCookies.tsx
+++ b/utils/retrieveCookies.tsx
@@ -6,18 +6,20 @@ export default function retrieveCookies(
   res?: NextApiResponse
 ): GranblueCookie | undefined {
   const cookies = getCookies({ req, res })
-  if (!cookies) return undefined
-
   const {
     account: accountData,
     user: userData,
     NEXT_LOCALE: localeData,
   } = cookies
-  if (!accountData || !userData) return undefined
 
-  const account = JSON.parse(decodeURIComponent(accountData)) ?? undefined
-  const user = JSON.parse(decodeURIComponent(userData)) ?? undefined
-  const locale = localeData as string
+  if ((!accountData || !userData) && localeData)
+    return { account: undefined, user: undefined, locale: localeData }
 
-  return { account, user, locale }
+  if (accountData && userData) {
+    const account = JSON.parse(decodeURIComponent(accountData)) ?? undefined
+    const user = JSON.parse(decodeURIComponent(userData)) ?? undefined
+    const locale = localeData as string
+
+    return { account, user, locale }
+  }
 }


### PR DESCRIPTION
* Fix toggle not working in general.
This was because `retrieveCookies` was not returning anything if `account` or `user` were undefined—not sending the locale to the client at all.

This PR closes #80 