### PR TITLE
Refactor party creation

### DIFF
--- a/components/LabelledInput/index.tsx
+++ b/components/LabelledInput/index.tsx
@@ -26,7 +26,7 @@ const LabelledInput = React.forwardRef<HTMLInputElement, Props>(function Input(
 
   // Classes
   const classes = classNames({ Input: true }, props.className)
-  const { defaultValue, ...inputProps } = props
+  const { defaultValue, visible, ...inputProps } = props
 
   // Change value when prop updates
   useEffect(() => {

--- a/components/Party/index.tsx
+++ b/components/Party/index.tsx
@@ -59,44 +59,60 @@ const Party = (props: Props) => {
     }
   }
 
-  function updateDetails(details: DetailsObject) {
+  async function updateDetails(details: DetailsObject) {
     if (
       appState.party.name !== details.name ||
       appState.party.description !== details.description ||
       appState.party.raid?.id !== details.raid?.id
     ) {
-      if (appState.party.id)
-        api.endpoints.parties
-          .update(appState.party.id, {
-            party: {
-              name: details.name,
-              description: details.description,
-              raid_id: details.raid?.id,
-              charge_attack: details.chargeAttack,
-              full_auto: details.fullAuto,
-              auto_guard: details.autoGuard,
-              clear_time: details.clearTime,
-              button_count: details.buttonCount,
-              chain_count: details.chainCount,
-              turn_count: details.turnCount,
-            },
-          })
-          .then(() => {
-            appState.party.name = details.name
-            appState.party.description = details.description
-            appState.party.raid = details.raid
+      if (!appState.party.id)
+        await createParty().then((response) => {
+          // If the party has no ID, create a new party
+          const party = response.data.party
+          storeParty(party)
 
-            appState.party.chargeAttack = details.chargeAttack
-            appState.party.fullAuto = details.fullAuto
-            appState.party.autoGuard = details.autoGuard
+          // Then, push the browser history to the new party's URL
+          if (props.pushHistory) props.pushHistory(`/p/${party.shortcode}`)
+        })
 
-            appState.party.clearTime = details.clearTime
-            appState.party.buttonCount = details.buttonCount
-            appState.party.chainCount = details.chainCount
-            appState.party.turnCount = details.turnCount
+      // Update the party
+      await sendUpdate(details)
+    }
+  }
 
-            appState.party.updated_at = party.updated_at
-          })
+  async function sendUpdate(details: DetailsObject) {
+    if (appState.party.id) {
+      return await api.endpoints.parties
+        .update(appState.party.id, {
+          party: {
+            name: details.name,
+            description: details.description,
+            raid_id: details.raid?.id,
+            charge_attack: details.chargeAttack,
+            full_auto: details.fullAuto,
+            auto_guard: details.autoGuard,
+            clear_time: details.clearTime,
+            button_count: details.buttonCount,
+            chain_count: details.chainCount,
+            turn_count: details.turnCount,
+          },
+        })
+        .then(() => {
+          appState.party.name = details.name
+          appState.party.description = details.description
+          appState.party.raid = details.raid
+
+          appState.party.chargeAttack = details.chargeAttack
+          appState.party.fullAuto = details.fullAuto
+          appState.party.autoGuard = details.autoGuard
+
+          appState.party.clearTime = details.clearTime
+          appState.party.buttonCount = details.buttonCount
+          appState.party.chainCount = details.chainCount
+          appState.party.turnCount = details.turnCount
+
+          appState.party.updated_at = party.updated_at
+        })
     }
   }
 

--- a/components/PartyDetails/index.tsx
+++ b/components/PartyDetails/index.tsx
@@ -252,11 +252,14 @@ const PartyDetails = (props: Props) => {
   }
 
   function toggleDetails() {
-    if (name !== party.name) {
-      const resetName = party.name ? party.name : 'Untitled'
-      setName(resetName)
-      if (nameInput.current) nameInput.current.value = resetName
-    }
+    // Enabling this code will make live updates not work,
+    // but I'm not sure why it's here, so we're not going to remove it.
+
+    // if (name !== party.name) {
+    //   const resetName = party.name ? party.name : ''
+    //   setName(resetName)
+    //   if (nameInput.current) nameInput.current.value = resetName
+    // }
     setOpen(!open)
   }
 
@@ -270,7 +273,6 @@ const PartyDetails = (props: Props) => {
   }
 
   function updateDetails(event: React.MouseEvent) {
-    const nameValue = nameInput.current?.value
     const descriptionValue = descriptionInput.current?.value
     const raid = raids.find((raid) => raid.slug === raidSlug)
 
@@ -282,7 +284,7 @@ const PartyDetails = (props: Props) => {
       buttonCount: buttonCount,
       turnCount: turnCount,
       chainCount: chainCount,
-      name: nameValue,
+      name: name,
       description: descriptionValue,
       raid: raid,
     }

--- a/components/SummonGrid/index.tsx
+++ b/components/SummonGrid/index.tsx
@@ -13,7 +13,7 @@ import ExtraSummons from '~components/ExtraSummons'
 import api from '~utils/api'
 import { appState } from '~utils/appState'
 import { accountState } from '~utils/accountState'
-import type { SearchableObject } from '~types'
+import type { DetailsObject, SearchableObject } from '~types'
 
 import './index.scss'
 
@@ -21,7 +21,7 @@ import './index.scss'
 interface Props {
   new: boolean
   summons?: GridSummon[]
-  createParty: () => Promise<AxiosResponse<any, any>>
+  createParty: (details?: DetailsObject) => Promise<Party>
   pushHistory?: (path: string) => void
 }
 
@@ -86,14 +86,8 @@ const SummonGrid = (props: Props) => {
     const summon = object as Summon
 
     if (!party.id) {
-      props.createParty().then((response) => {
-        const party = response.data.party
-        appState.party.id = party.id
-        setSlug(party.shortcode)
-
-        if (props.pushHistory) props.pushHistory(`/p/${party.shortcode}`)
-
-        saveSummon(party.id, summon, position).then((response) =>
+      props.createParty().then((team) => {
+        saveSummon(team.id, summon, position).then((response) =>
           storeGridSummon(response.data)
         )
       })

--- a/components/SummonUnit/index.scss
+++ b/components/SummonUnit/index.scss
@@ -91,7 +91,7 @@
   img {
     position: relative;
     width: 100%;
-    z-index: 0;
+    z-index: 2;
 
     &.Placeholder {
       opacity: 0;

--- a/components/WeaponGrid/index.tsx
+++ b/components/WeaponGrid/index.tsx
@@ -13,7 +13,7 @@ import ExtraWeapons from '~components/ExtraWeapons'
 import api from '~utils/api'
 import { appState } from '~utils/appState'
 
-import type { SearchableObject } from '~types'
+import type { DetailsObject, SearchableObject } from '~types'
 
 import './index.scss'
 import WeaponConflictModal from '~components/WeaponConflictModal'
@@ -24,7 +24,7 @@ import { accountState } from '~utils/accountState'
 interface Props {
   new: boolean
   weapons?: GridWeapon[]
-  createParty: (extra: boolean) => Promise<AxiosResponse<any, any>>
+  createParty: (details: DetailsObject) => Promise<Party>
   pushHistory?: (path: string) => void
 }
 
@@ -89,16 +89,11 @@ const WeaponGrid = (props: Props) => {
     if (position == 1) appState.party.element = weapon.element
 
     if (!party.id) {
-      props.createParty(party.extra).then((response) => {
-        const party = response.data.party
-        appState.party.id = party.id
-        setSlug(party.shortcode)
-
-        if (props.pushHistory) props.pushHistory(`/p/${party.shortcode}`)
-
-        saveWeapon(party.id, weapon, position).then((response) =>
+      const payload: DetailsObject = { extra: party.extra }
+      props.createParty(payload).then((team) => {
+        saveWeapon(team.id, weapon, position).then((response) => {
           storeGridWeapon(response.data.grid_weapon)
-        )
+        })
       })
     } else {
       if (party.editable)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,14 +22,16 @@ export type PaginationObject = {
 
 export type DetailsObject = {
   [key: string]: boolean | number | string | Raid | undefined
-  fullAuto: boolean
-  autoGuard: boolean
-  chargeAttack: boolean
-  clearTime: number
+  fullAuto?: boolean
+  autoGuard?: boolean
+  chargeAttack?: boolean
+  clearTime?: number
   buttonCount?: number
   turnCount?: number
   chainCount?: number
   name?: string
   description?: string
   raid?: Raid
+  job?: Job
+  extra?: boolean
 }


### PR DESCRIPTION
This PR lets you create any object in a party, including the details first. The side effect is that there will be exponentially more empty parties, but this is a bug that has been reported many times.

There is still a bug where if you create a party from a weapon in the Additional Weapons slots, it will not display them after the party is created until you refresh. We will fix this after Guild Wars.

This also fixes issues with saving names for parties after the change to make the title reactive.