### PR TITLE
Adds job icons to display and dropdown

### DIFF
--- a/components/JobDropdown/index.tsx
+++ b/components/JobDropdown/index.tsx
@@ -91,7 +91,12 @@ const JobDropdown = React.forwardRef<HTMLSelectElement, Props>(
           .sort((a, b) => a.order - b.order)
           .map((item, i) => {
             return (
-              <SelectItem key={i} value={item.id}>
+              <SelectItem
+                key={i}
+                value={item.id}
+                altText={item.name[locale]}
+                iconSrc={`/images/job-icons/${item.granblue_id}.png`}
+              >
                 {item.name[locale]}
               </SelectItem>
             )
@@ -109,6 +114,10 @@ const JobDropdown = React.forwardRef<HTMLSelectElement, Props>(
     return (
       <Select
         value={currentJob ? currentJob.id : 'no-job'}
+        altText={currentJob ? currentJob.name[locale] : ''}
+        iconSrc={
+          currentJob ? `/images/job-icons/${currentJob.granblue_id}.png` : ''
+        }
         open={open}
         onClick={openJobSelect}
         onOpenChange={() => setOpen(!open)}

--- a/components/JobSection/index.scss
+++ b/components/JobSection/index.scss
@@ -28,10 +28,20 @@
     flex-direction: column;
     width: 100%;
 
-    h3 {
-      font-size: $font-medium;
-      font-weight: $medium;
+    .JobName {
+      align-items: center;
+      display: flex;
+      gap: $unit-half;
       padding: $unit 0 $unit * 2;
+
+      h3 {
+        font-size: $font-medium;
+        font-weight: $medium;
+      }
+
+      img {
+        width: $unit-4x;
+      }
     }
 
     select {

--- a/components/JobSection/index.tsx
+++ b/components/JobSection/index.tsx
@@ -146,7 +146,13 @@ const JobSection = (props: Props) => {
             ref={selectRef}
           />
         ) : (
-          <h3>{party.job ? party.job.name[locale] : t('no_job')}</h3>
+          <div className="JobName">
+            <img
+              alt={party.job.name[locale]}
+              src={`/images/job-icons/${party.job.granblue_id}.png`}
+            />
+            <h3>{party.job ? party.job.name[locale] : t('no_job')}</h3>
+          </div>
         )}
 
         <ul className="JobSkills">

--- a/components/Select/index.scss
+++ b/components/Select/index.scss
@@ -4,6 +4,7 @@
   border-radius: $input-corner;
   border: none;
   display: flex;
+  gap: $unit;
   padding: $unit-2x $unit-2x;
 
   &.modal {
@@ -54,6 +55,11 @@
 
   &.Table {
     min-width: $unit * 30;
+  }
+
+  img {
+    width: $unit-4x;
+    height: auto;
   }
 
   .SelectIcon {

--- a/components/Select/index.scss
+++ b/components/Select/index.scss
@@ -5,7 +5,7 @@
   border: none;
   display: flex;
   gap: $unit;
-  padding: $unit-2x $unit-2x;
+  padding: ($unit * 1.5) $unit-2x;
 
   &.modal {
     background-color: var(--select-modal-bg);

--- a/components/Select/index.tsx
+++ b/components/Select/index.tsx
@@ -14,6 +14,8 @@ interface Props
     React.SelectHTMLAttributes<HTMLSelectElement>,
     HTMLSelectElement
   > {
+  altText?: string
+  iconSrc?: string
   open: boolean
   trigger?: React.ReactNode
   children?: React.ReactNode
@@ -79,6 +81,7 @@ const Select = React.forwardRef<HTMLButtonElement, Props>(function Select(
         placeholder={props.placeholder}
         ref={forwardedRef}
       >
+        {props.iconSrc ? <img alt={props.altText} src={props.iconSrc} /> : ''}
         <RadixSelect.Value placeholder={props.placeholder} />
         {!props.disabled ? (
           <RadixSelect.Icon className="SelectIcon">

--- a/components/SelectItem/index.scss
+++ b/components/SelectItem/index.scss
@@ -1,4 +1,5 @@
 .SelectItem {
+  align-items: center;
   border-radius: $item-corner;
   border: 2px solid transparent;
   color: var(--text-tertiary);

--- a/components/SelectItem/index.scss
+++ b/components/SelectItem/index.scss
@@ -2,6 +2,8 @@
   border-radius: $item-corner;
   border: 2px solid transparent;
   color: var(--text-tertiary);
+  display: flex;
+  gap: $unit;
   font-size: $font-regular;
   padding: ($unit * 1.5) $unit-2x;
 
@@ -23,5 +25,10 @@
 
   &:last-child {
     margin-bottom: $unit;
+  }
+
+  img {
+    width: $unit-4x;
+    height: auto;
   }
 }

--- a/components/SelectItem/index.tsx
+++ b/components/SelectItem/index.tsx
@@ -6,6 +6,8 @@ import classNames from 'classnames'
 
 interface Props extends ComponentProps<'div'> {
   value: string | number
+  iconSrc?: string
+  altText?: string
 }
 
 const SelectItem = React.forwardRef<HTMLDivElement, Props>(function selectItem(
@@ -19,6 +21,7 @@ const SelectItem = React.forwardRef<HTMLDivElement, Props>(function selectItem(
       ref={forwardedRef}
       value={`${props.value}`}
     >
+      {props.iconSrc ? <img alt={props.altText} src={props.iconSrc} /> : ''}
       <Select.ItemText>{children}</Select.ItemText>
     </Select.Item>
   )

--- a/types/Job.d.ts
+++ b/types/Job.d.ts
@@ -1,5 +1,6 @@
 interface Job {
   id: string
+  granblue_id: string
   row: string
   ml: boolean
   order: number


### PR DESCRIPTION
This PR adds job icons to the display of Jobs in these places:

* The read-only display of a team's Job
* The `SelectTrigger` of `JobDropdown`
* Each `SelectItem` inside of `JobDropdown`

This fixes #153 

https://user-images.githubusercontent.com/383021/213981156-7faf3723-76bb-4de8-bbeb-fc59ed921459.mp4

