### PR TITLE
Fix tab URLs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,18 @@ module.exports = {
         destination: '/new',
       },
       {
+        source: '/characters',
+        destination: '/new',
+      },
+      {
+        source: '/summons',
+        destination: '/new',
+      },
+      {
+        source: '/weapons',
+        destination: '/new',
+      },
+      {
         source: '/p/:shortcode/characters',
         destination: '/p/:shortcode',
       },


### PR DESCRIPTION
The app was crashing when you went to another tab on new pages because the rewrites were only configured for URLs with shortcodes