### PR TITLE
Fix double overlay on Selects

### DIFF
--- a/components/AxSelect/index.tsx
+++ b/components/AxSelect/index.tsx
@@ -410,6 +410,7 @@ const AXSelect = (props: Props) => {
             onOpenChange={() => openSelect(1)}
             onValueChange={handleAX1SelectChange}
             triggerClass="modal"
+            overlayVisible={false}
           >
             {generateOptions(0)}
           </Select>
@@ -439,6 +440,7 @@ const AXSelect = (props: Props) => {
             onValueChange={handleAX2SelectChange}
             triggerClass="modal"
             ref={secondaryAxModifierSelect}
+            overlayVisible={false}
           >
             {generateOptions(1)}
           </Select>

--- a/components/DropdownMenuContent/index.scss
+++ b/components/DropdownMenuContent/index.scss
@@ -4,7 +4,7 @@
   border-radius: 6px;
   box-shadow: 0 1px 4px rgb(0 0 0 / 8%);
   box-sizing: border-box;
-  min-width: 15vw;
+  min-width: 30vw;
   margin: 0 $unit-2x;
   // top: $unit-8x; // This shouldn't be hardcoded. How to calculate it?
   // Also, add space that doesn't make the menu disappear if you move your mouse slowly

--- a/components/ExtendedMasterySelect/index.tsx
+++ b/components/ExtendedMasterySelect/index.tsx
@@ -135,6 +135,7 @@ const ExtendedMasterySelect = ({
         onOpenChange={() => changeOpen('left')}
         onClose={onClose}
         triggerClass="Left modal"
+        overlayVisible={false}
       >
         {generateLeftOptions()}
       </Select>
@@ -146,6 +147,7 @@ const ExtendedMasterySelect = ({
         onValueChange={handleRightSelectChange}
         onOpenChange={() => changeOpen('right')}
         onClose={onClose}
+        overlayVisible={false}
         triggerClass={classNames({
           Right: true,
           modal: true,

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -225,6 +225,7 @@ const Header = () => {
   const urlCopyToast = () => {
     return (
       <Toast
+        altText={t('toasts.copied')}
         open={copyToastOpen}
         duration={2400}
         type="foreground"
@@ -238,6 +239,7 @@ const Header = () => {
   const remixToast = () => {
     return (
       <Toast
+        altText={t('toasts.remixed', { title: originalName })}
         open={remixToastOpen}
         duration={2400}
         type="foreground"

--- a/components/JobSkillSearchFilterBar/index.tsx
+++ b/components/JobSkillSearchFilterBar/index.tsx
@@ -44,6 +44,7 @@ const JobSkillSearchFilterBar = (props: Props) => {
         value={-1}
         triggerClass="Bound"
         open={open}
+        overlayVisible={false}
         onValueChange={onChange}
         onOpenChange={openSelect}
       >

--- a/components/Overlay/index.scss
+++ b/components/Overlay/index.scss
@@ -6,9 +6,6 @@
   right: 0;
   bottom: 0;
   left: 0;
-  backdrop-filter: blur(5px) saturate(100%) brightness(80%) opacity(0);
-  animation: 0.24s ease-in fadeInFilter;
-  animation-fill-mode: forwards;
 
   &.Job {
     animation: none;
@@ -16,6 +13,9 @@
   }
 
   &.Visible {
+    animation: 0.24s ease-in fadeInFilter;
+    animation-fill-mode: forwards;
+    backdrop-filter: blur(5px) saturate(100%) brightness(80%) opacity(0);
     background: rgba(0, 0, 0, 0.6);
   }
 }

--- a/components/Select/index.tsx
+++ b/components/Select/index.tsx
@@ -23,6 +23,7 @@ interface Props
   onValueChange?: (value: string) => void
   onClose?: () => void
   triggerClass?: string
+  overlayVisible?: boolean
 }
 
 const Select = React.forwardRef<HTMLButtonElement, Props>(function Select(
@@ -94,7 +95,10 @@ const Select = React.forwardRef<HTMLButtonElement, Props>(function Select(
 
       <RadixSelect.Portal className="Select">
         <>
-          <Overlay open={open} visible={false} />
+          <Overlay
+            open={open}
+            visible={props.overlayVisible != null ? props.overlayVisible : true}
+          />
 
           <RadixSelect.Content
             className="Select"
@@ -115,5 +119,9 @@ const Select = React.forwardRef<HTMLButtonElement, Props>(function Select(
     </RadixSelect.Root>
   )
 })
+
+Select.defaultProps = {
+  overlayVisible: true,
+}
 
 export default Select

--- a/components/SelectTableField/index.tsx
+++ b/components/SelectTableField/index.tsx
@@ -59,6 +59,7 @@ const SelectTableField = (props: Props) => {
           onClose={props.onClose}
           triggerClass={classNames({ Bound: true, Table: true })}
           value={value}
+          overlayVisible={false}
         >
           {props.children}
         </Select>

--- a/components/SelectWithInput/index.tsx
+++ b/components/SelectWithInput/index.tsx
@@ -173,6 +173,7 @@ const SelectWithInput = ({
           onOpenChange={changeOpen}
           onClose={onClose}
           triggerClass="modal"
+          overlayVisible={false}
         >
           {generateOptions()}
         </Select>

--- a/components/Toast/index.tsx
+++ b/components/Toast/index.tsx
@@ -5,6 +5,7 @@ import * as ToastPrimitive from '@radix-ui/react-toast'
 import './index.scss'
 
 interface Props extends ToastPrimitive.ToastProps {
+  altText: string
   className?: string
   title?: string
   content: React.ReactNode
@@ -12,6 +13,7 @@ interface Props extends ToastPrimitive.ToastProps {
 }
 
 const Toast = ({
+  altText,
   children,
   title,
   content,
@@ -39,7 +41,7 @@ const Toast = ({
         <p>{content}</p>
       </ToastPrimitive.Description>
       {children && (
-        <ToastPrimitive.Action asChild altText="">
+        <ToastPrimitive.Action asChild altText={altText}>
           {children}
         </ToastPrimitive.Action>
       )}

--- a/components/UpdateToast/index.tsx
+++ b/components/UpdateToast/index.tsx
@@ -54,6 +54,7 @@ const UpdateToast = ({
 
   return (
     <Toast
+      altText={t(`toasts.description.${updateType}`)}
       className={classes}
       title={t(`toasts.title`)}
       content={t(`toasts.description.${updateType}`)}

--- a/components/WeaponKeySelect/index.tsx
+++ b/components/WeaponKeySelect/index.tsx
@@ -130,6 +130,7 @@ const WeaponKeySelect = React.forwardRef<HTMLButtonElement, Props>(
         onValueChange={handleChange}
         ref={ref}
         triggerClass="modal"
+        overlayVisible={false}
       >
         <SelectItem key="no-key" value="no-key">
           {emptyOption()}


### PR DESCRIPTION
Selects would display their overlays on top of each other. This is obviously bad because we have modals that show overlays that contain selects that have overlays.

Select now takes an optional property `overlayVisible`—which defaults to `true`—that will toggle the visible elements of its Overlay so that it doesn't show up when it shouldn't. Unfortunately we have to remember to set this manually.

This fixes #172 