### PR TITLE
Ensure header title updates when party name is updated

### DIFF
--- a/components/DropdownMenuContent/index.scss
+++ b/components/DropdownMenuContent/index.scss
@@ -4,7 +4,8 @@
   border-radius: 6px;
   box-shadow: 0 1px 4px rgb(0 0 0 / 8%);
   box-sizing: border-box;
-  min-width: 30vw;
+  width: 30vw;
+  max-width: 180px;
   margin: 0 $unit-2x;
   // top: $unit-8x; // This shouldn't be hardcoded. How to calculate it?
   // Also, add space that doesn't make the menu disappear if you move your mouse slowly

--- a/components/DropdownMenuContent/index.scss
+++ b/components/DropdownMenuContent/index.scss
@@ -7,8 +7,6 @@
   width: 30vw;
   max-width: 180px;
   margin: 0 $unit-2x;
-  // top: $unit-8x; // This shouldn't be hardcoded. How to calculate it?
-  // Also, add space that doesn't make the menu disappear if you move your mouse slowly
   z-index: 15;
 
   @include breakpoint(phone) {

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -68,13 +68,6 @@ const Header = () => {
 
   useEffect(() => () => unsubscribe(), [])
 
-  // Subscribe to router changes
-  useEffect(() => {
-    router.events.on('routeChangeStart', (url, { shallow }) => {
-      console.log(`routing to ${url}`, `is shallow routing: ${shallow}`)
-    })
-  }, [])
-
   // Methods: Event handlers (Buttons)
   function handleLeftMenuButtonClicked() {
     setLeftMenuOpen(!leftMenuOpen)

--- a/components/PartyDetails/index.scss
+++ b/components/PartyDetails/index.scss
@@ -339,6 +339,18 @@
           font-size: $font-small;
         }
 
+        a:visited:not(.fire):not(.water):not(.wind):not(.earth):not(.dark):not(
+            .light
+          ) {
+          color: var(--text-primary);
+        }
+
+        a:hover:not(.fire):not(.water):not(.wind):not(.earth):not(.dark):not(
+            .light
+          ) {
+          color: $blue;
+        }
+
         & > *:not(:last-child):after {
           content: ' · ';
           margin: 0 calc($unit / 2);

--- a/components/PartyDetails/index.scss
+++ b/components/PartyDetails/index.scss
@@ -37,7 +37,6 @@
 
       &.Visible {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
       }
 
       fieldset {

--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -35,8 +35,7 @@ const NewRoute: React.FC<Props> = ({
   const router = useRouter()
 
   function callback(path: string) {
-    // This is scuffed, how do we do this natively?
-    window.history.replaceState(null, `Grid Tool`, `${path}`)
+    router.push(path, undefined, { shallow: true })
   }
 
   useEffect(() => {


### PR DESCRIPTION
If you were on a party page, the new header title doesn't update when you change the party name. It updates on save now, but not in real time like the bottom title. 

In order to enable them to both be "live" fields, we'd have to store the input value in state somewhere, which is too much work for right now.

In summary, this fixes:
* Header title not updating when party is updated
* Header title not updating when new party is created
* State not completely clearing when a new party is created
* PartyDetails grid CSS
* Dropdown menu width
* Blue links

This fixes #181, #189 