### PR TITLE
Fix job dropdown not showing entries

### DIFF
--- a/components/CharacterGrid/index.tsx
+++ b/components/CharacterGrid/index.tsx
@@ -47,7 +47,6 @@ const CharacterGrid = (props: Props) => {
 
   // Set up state for view management
   const { party, grid } = useSnapshot(appState)
-  const [slug, setSlug] = useState()
   const [modalOpen, setModalOpen] = useState(false)
 
   // Set up state for conflict management

--- a/components/JobSection/index.tsx
+++ b/components/JobSection/index.tsx
@@ -115,7 +115,7 @@ const JobSection = (props: Props) => {
 
   const canEditSkill = (skill?: JobSkill) => {
     // If there is a job and a skill present in the slot
-    if (job) {
+    if (job && job.id !== '-1') {
       // If the skill's job is one of the job's main skill
       if (skill && skill.job.id === job.id && skill.main) return false
 

--- a/components/JobSection/index.tsx
+++ b/components/JobSection/index.tsx
@@ -10,7 +10,6 @@ import SearchModal from '~components/SearchModal'
 
 import api from '~utils/api'
 import { appState } from '~utils/appState'
-import { ACCESSORY_JOB_IDS } from '~utils/jobsWithAccessories'
 import type { JobSkillObject, SearchableObject } from '~types'
 
 import './index.scss'

--- a/components/SummonGrid/index.tsx
+++ b/components/SummonGrid/index.tsx
@@ -45,7 +45,6 @@ const SummonGrid = (props: Props) => {
 
   // Set up state for view management
   const { party, grid } = useSnapshot(appState)
-  const [slug, setSlug] = useState()
 
   // Create a temporary state to store previous weapon uncap values and transcendence stages
   const [previousUncapValues, setPreviousUncapValues] = useState<{

--- a/components/WeaponGrid/index.tsx
+++ b/components/WeaponGrid/index.tsx
@@ -48,7 +48,6 @@ const WeaponGrid = (props: Props) => {
 
   // Set up state for view management
   const { party, grid } = useSnapshot(appState)
-  const [slug, setSlug] = useState()
   const [modalOpen, setModalOpen] = useState(false)
 
   // Set up state for conflict management

--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -65,14 +65,19 @@ const NewRoute: React.FC<Props> = ({
       appState.weaponKeys = context.weaponKeys
     }
     appState.version = version
-  }, [])
+  }, [context, version])
 
   useEffect(() => {
     // Clean state
     const resetState = clonedeep(initialAppState)
-    Object.keys(resetState).forEach((key) => {
-      appState[key] = resetState[key]
-    })
+    appState.party = resetState.party
+    appState.grid = resetState.grid
+
+    // Old method kept in case we need it later
+    // Object.keys(resetState).forEach((key) => {
+    //   appState[key] = resetState[key]
+    // })
+
     // Set party to be editable
     appState.party.editable = true
   }, [])


### PR DESCRIPTION
This was happening due to two bugs in the `New` route:
* The `useEffect` hook that was responsible for persisting data from our server API call was not being updated properly
* Application state was being completely reset when we were trying to clean it for a new party, but that includes static values like raids and jobs. It's unclear why this was *only* affecting the Job dropdown.

This fixes #191 