### PR TITLE
Don't send users to weapons tab when creating a new party

### DIFF
--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -488,7 +488,7 @@ const Header = () => {
             <DropdownMenuItem className="MenuItem">
               <Link href="/new">
                 <a onClick={(e: React.MouseEvent) => handleNewParty(e, '/new')}>
-                  New party
+                  {t('menu.new')}
                 </a>
               </Link>
             </DropdownMenuItem>

--- a/components/Party/index.tsx
+++ b/components/Party/index.tsx
@@ -167,8 +167,18 @@ const Party = (props: Props) => {
     storeWeapons(team.weapons)
     storeSummons(team.summons)
 
+    // Create a string to send the user back to the tab they're currently on
+    let tab = ''
+    if (currentTab === GridType.Character) {
+      tab = 'characters'
+    } else if (currentTab === GridType.Summon) {
+      tab = 'summons'
+    }
+
     // Then, push the browser history to the new party's URL
-    if (props.pushHistory) props.pushHistory(`/p/${team.shortcode}`)
+    if (props.pushHistory) {
+      props.pushHistory(`/p/${team.shortcode}/${tab}`)
+    }
 
     return team
   }

--- a/utils/enums.tsx
+++ b/utils/enums.tsx
@@ -5,7 +5,6 @@ export enum ButtonType {
 }
 
 export enum GridType {
-  Class,
   Character,
   Weapon,
   Summon,


### PR DESCRIPTION
We changed the method in the `New` route to use the Next.js Router, which is causing us to navigate to the `Party` route and causing issues. This change makes it so that users stay on the same tab when they reach their destination. 

Unauth users are still unable to keep editing their party as of this PR.

This fixes #195 