### PR TITLE
Allow editing of unauth teams

### DIFF
--- a/components/CharacterGrid/index.tsx
+++ b/components/CharacterGrid/index.tsx
@@ -23,6 +23,7 @@ import './index.scss'
 // Props
 interface Props {
   new: boolean
+  editable: boolean
   characters?: GridCharacter[]
   createParty: (details?: DetailsObject) => Promise<Party>
   pushHistory?: (path: string) => void
@@ -75,17 +76,6 @@ const CharacterGrid = (props: Props) => {
       [key: number]: number | undefined
     }>({})
 
-  // Set the editable flag only on first load
-  useEffect(() => {
-    // If user is logged in and matches
-    if (
-      (accountData && party.user && accountData.userId === party.user.id) ||
-      props.new
-    )
-      appState.party.editable = true
-    else appState.party.editable = false
-  }, [props.new, accountData, party])
-
   useEffect(() => {
     setJob(appState.party.job)
     setJobSkills(appState.party.jobSkills)
@@ -115,7 +105,7 @@ const CharacterGrid = (props: Props) => {
           .catch((error) => console.error(error))
       })
     } else {
-      if (party.editable)
+      if (props.editable)
         saveCharacter(party.id, character, position)
           .then((response) => handleCharacterResponse(response.data))
           .catch((error) => {
@@ -232,7 +222,7 @@ const CharacterGrid = (props: Props) => {
   }
 
   function saveJobSkill(skill: JobSkill, position: number) {
-    if (party.id && appState.party.editable) {
+    if (party.id && props.editable) {
       const positionedKey = `skill${position}_id`
 
       let skillObject: {
@@ -522,7 +512,7 @@ const CharacterGrid = (props: Props) => {
           job={job}
           jobSkills={jobSkills}
           jobAccessory={jobAccessory}
-          editable={party.editable}
+          editable={props.editable}
           saveJob={saveJob}
           saveSkill={saveJobSkill}
           saveAccessory={saveAccessory}
@@ -541,7 +531,7 @@ const CharacterGrid = (props: Props) => {
               <li key={`grid_unit_${i}`}>
                 <CharacterUnit
                   gridCharacter={grid.characters[i]}
-                  editable={party.editable}
+                  editable={props.editable}
                   position={i}
                   updateObject={receiveCharacterFromSearch}
                   updateUncap={initiateUncapUpdate}

--- a/components/LoginModal/index.tsx
+++ b/components/LoginModal/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import axios, { AxiosError, AxiosResponse } from 'axios'
 
 import api from '~utils/api'
-import setUserToken from '~utils/setUserToken'
+import { setHeaders } from '~utils/userToken'
 import { accountState } from '~utils/accountState'
 
 import Button from '~components/Button'
@@ -147,7 +147,7 @@ const LoginModal = (props: Props) => {
     setCookie('account', cookieObj, { path: '/', expires: expiresAt })
 
     // Set Axios default headers
-    setUserToken()
+    setHeaders()
   }
 
   function storeUserInfo(response: AxiosResponse) {

--- a/components/Party/index.tsx
+++ b/components/Party/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { getCookie } from 'cookies-next'
 import { useRouter } from 'next/router'
 import { useSnapshot } from 'valtio'
 import clonedeep from 'lodash.clonedeep'
@@ -61,6 +62,7 @@ const Party = (props: Props) => {
       : null
 
     let editable = false
+    unsetEditKey()
 
     if (props.new) editable = true
 

--- a/components/Party/index.tsx
+++ b/components/Party/index.tsx
@@ -59,7 +59,7 @@ const Party = (props: Props) => {
     if (details) payload = formatDetailsObject(details)
 
     return await api.endpoints.parties
-      .create(payload)
+      .create({ ...payload, ...localId() })
       .then((response) => storeParty(response.data.party))
   }
 
@@ -67,6 +67,14 @@ const Party = (props: Props) => {
   async function updateDetails(details: DetailsObject) {
     if (!appState.party.id) return await createParty(details)
     else updateParty(details)
+  }
+
+  function localId() {
+    const cookie = accountCookie()
+    const parsed = JSON.parse(cookie as string)
+    if (parsed && !parsed.token) {
+      return { local_id: parsed.userId }
+    } else return {}
   }
 
   function formatDetailsObject(details: DetailsObject) {

--- a/components/Party/index.tsx
+++ b/components/Party/index.tsx
@@ -73,7 +73,11 @@ const Party = (props: Props) => {
       } else {
         // Not authenticated
         if (!props.team.user && accountData.userId === props.team.local_id) {
+          // Set editable
           editable = true
+
+          // Also set edit key header
+          setEditKey(props.team.id, props.team.user)
         }
       }
     }
@@ -101,14 +105,6 @@ const Party = (props: Props) => {
   async function updateDetails(details: DetailsObject) {
     if (!appState.party.id) return await createParty(details)
     else updateParty(details)
-  }
-
-  function localId() {
-    const cookie = accountCookie()
-    const parsed = JSON.parse(cookie as string)
-    if (parsed && !parsed.token) {
-      return { local_id: parsed.userId }
-    } else return {}
   }
 
   function formatDetailsObject(details: DetailsObject) {
@@ -205,7 +201,10 @@ const Party = (props: Props) => {
     appState.party.detailsVisible = false
 
     // Store the edit key in local storage
-    if (team.edit_key) storeEditKey(team.id, team.edit_key)
+    if (team.edit_key) {
+      storeEditKey(team.id, team.edit_key)
+      setEditKey(team.id, team.user)
+    }
 
     // Populate state
     storeCharacters(team.characters)
@@ -287,6 +286,15 @@ const Party = (props: Props) => {
       default:
         break
     }
+  }
+
+  // Methods: Unauth validation
+  function localId() {
+    const cookie = accountCookie()
+    const parsed = JSON.parse(cookie as string)
+    if (parsed && !parsed.token) {
+      return { local_id: parsed.userId }
+    } else return {}
   }
 
   // Render: JSX components

--- a/components/Party/index.tsx
+++ b/components/Party/index.tsx
@@ -14,11 +14,11 @@ import api from '~utils/api'
 import { appState, initialAppState } from '~utils/appState'
 import { GridType } from '~utils/enums'
 import { retrieveCookies } from '~utils/retrieveCookies'
+import { accountCookie, setEditKey, unsetEditKey } from '~utils/userToken'
+
 import type { DetailsObject } from '~types'
 
 import './index.scss'
-import { accountCookie } from '~utils/userToken'
-import { getCookie } from 'cookies-next'
 
 // Props
 interface Props {
@@ -103,7 +103,7 @@ const Party = (props: Props) => {
 
   // Methods: Updating the party's details
   async function updateDetails(details: DetailsObject) {
-    if (!appState.party.id) return await createParty(details)
+    if (!props.team) return await createParty(details)
     else updateParty(details)
   }
 
@@ -130,9 +130,9 @@ const Party = (props: Props) => {
   async function updateParty(details: DetailsObject) {
     const payload = formatDetailsObject(details)
 
-    if (appState.party.id) {
+    if (props.team && props.team.id) {
       return await api.endpoints.parties
-        .update(appState.party.id, payload)
+        .update(props.team.id, payload)
         .then((response) => storeParty(response.data.party))
     }
   }
@@ -141,8 +141,8 @@ const Party = (props: Props) => {
     appState.party.extra = event.target.checked
 
     // Only save if this is a saved party
-    if (appState.party.id) {
-      api.endpoints.parties.update(appState.party.id, {
+    if (props.team && props.team.id) {
+      api.endpoints.parties.update(props.team.id, {
         party: { extra: event.target.checked },
       })
     }
@@ -150,9 +150,9 @@ const Party = (props: Props) => {
 
   // Deleting the party
   function deleteTeam() {
-    if (appState.party.editable && appState.party.id) {
+    if (props.team && editable) {
       api.endpoints.parties
-        .destroy({ id: appState.party.id })
+        .destroy({ id: props.team.id })
         .then(() => {
           // Push to route
           if (cookies && cookies.account.username) {

--- a/components/Party/index.tsx
+++ b/components/Party/index.tsx
@@ -147,7 +147,7 @@ const Party = (props: Props) => {
   }
 
   // Methods: Storing party data
-  const storeParty = function (team: Party) {
+  const storeParty = function (team: any) {
     // Store the important party and state-keeping values in global state
     appState.party.name = team.name
     appState.party.description = team.description
@@ -170,6 +170,9 @@ const Party = (props: Props) => {
 
     appState.party.detailsVisible = false
 
+    // Store the edit key in local storage
+    if (team.edit_key) storeEditKey(team.id, team.edit_key)
+
     // Populate state
     storeCharacters(team.characters)
     storeWeapons(team.weapons)
@@ -189,6 +192,10 @@ const Party = (props: Props) => {
     }
 
     return team
+  }
+
+  const storeEditKey = (id: string, key: string) => {
+    ls(id, key)
   }
 
   const storeCharacters = (list: Array<GridCharacter>) => {

--- a/components/SignupModal/index.tsx
+++ b/components/SignupModal/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'next-i18next'
 import { AxiosResponse } from 'axios'
 
 import api from '~utils/api'
-import setUserToken from '~utils/setUserToken'
+import { setHeaders } from '~utils/userToken'
 import { accountState } from '~utils/accountState'
 
 import Button from '~components/Button'
@@ -103,7 +103,7 @@ const SignupModal = (props: Props) => {
     setCookie('account', cookieObj, { path: '/', expires: expiresAt })
 
     // Set Axios default headers
-    setUserToken()
+    setHeaders()
   }
 
   function fetchUserInfo(id: string) {

--- a/components/SummonGrid/index.tsx
+++ b/components/SummonGrid/index.tsx
@@ -21,6 +21,7 @@ import './index.scss'
 // Props
 interface Props {
   new: boolean
+  editable: boolean
   summons?: GridSummon[]
   createParty: (details?: DetailsObject) => Promise<Party>
   pushHistory?: (path: string) => void
@@ -54,17 +55,6 @@ const SummonGrid = (props: Props) => {
     useState<{
       [key: number]: number
     }>({})
-
-  // Set the editable flag only on first load
-  useEffect(() => {
-    // If user is logged in and matches
-    if (
-      (accountData && party.user && accountData.userId === party.user.id) ||
-      props.new
-    )
-      appState.party.editable = true
-    else appState.party.editable = false
-  }, [props.new, accountData, party])
 
   // Initialize an array of current uncap values for each summon
   useEffect(() => {
@@ -100,7 +90,7 @@ const SummonGrid = (props: Props) => {
         )
       })
     } else {
-      if (party.editable)
+      if (props.editable)
         saveSummon(party.id, summon, position)
           .then((response) => handleSummonResponse(response.data))
           .catch((error) => {
@@ -401,7 +391,7 @@ const SummonGrid = (props: Props) => {
       <div className="Label">{t('summons.main')}</div>
       <SummonUnit
         gridSummon={grid.summons.mainSummon}
-        editable={party.editable}
+        editable={props.editable}
         key="grid_main_summon"
         position={-1}
         unitType={0}
@@ -418,7 +408,7 @@ const SummonGrid = (props: Props) => {
       <div className="Label Friend">{t('summons.friend')}</div>
       <SummonUnit
         gridSummon={grid.summons.friendSummon}
-        editable={party.editable}
+        editable={props.editable}
         key="grid_friend_summon"
         position={6}
         unitType={2}
@@ -439,7 +429,7 @@ const SummonGrid = (props: Props) => {
             <li key={`grid_unit_${i}`}>
               <SummonUnit
                 gridSummon={grid.summons.allSummons[i]}
-                editable={party.editable}
+                editable={props.editable}
                 position={i}
                 unitType={1}
                 removeSummon={removeSummon}
@@ -457,7 +447,7 @@ const SummonGrid = (props: Props) => {
   const subAuraSummonElement = (
     <ExtraSummons
       grid={grid.summons.allSummons}
-      editable={party.editable}
+      editable={props.editable}
       exists={false}
       offset={numSummons}
       removeSummon={removeSummon}

--- a/components/WeaponGrid/index.tsx
+++ b/components/WeaponGrid/index.tsx
@@ -23,6 +23,7 @@ import './index.scss'
 // Props
 interface Props {
   new: boolean
+  editable: boolean
   weapons?: GridWeapon[]
   createParty: (details: DetailsObject) => Promise<Party>
   pushHistory?: (path: string) => void
@@ -60,17 +61,6 @@ const WeaponGrid = (props: Props) => {
     [key: number]: number
   }>({})
 
-  // Set the editable flag only on first load
-  useEffect(() => {
-    // If user is logged in and matches
-    if (
-      (accountData && party.user && accountData.userId === party.user.id) ||
-      props.new
-    )
-      appState.party.editable = true
-    else appState.party.editable = false
-  }, [props.new, accountData, party])
-
   // Initialize an array of current uncap values for each weapon
   useEffect(() => {
     let initialPreviousUncapValues: { [key: number]: number } = {}
@@ -99,7 +89,7 @@ const WeaponGrid = (props: Props) => {
         })
       })
     } else {
-      if (party.editable)
+      if (props.editable)
         saveWeapon(party.id, weapon, position)
           .then((response) => {
             if (response) handleWeaponResponse(response.data)
@@ -337,7 +327,7 @@ const WeaponGrid = (props: Props) => {
   const mainhandElement = (
     <WeaponUnit
       gridWeapon={appState.grid.weapons.mainWeapon}
-      editable={party.editable}
+      editable={props.editable}
       key="grid_mainhand"
       position={-1}
       unitType={0}
@@ -352,7 +342,7 @@ const WeaponGrid = (props: Props) => {
       <li key={`grid_unit_${i}`}>
         <WeaponUnit
           gridWeapon={appState.grid.weapons.allWeapons[i]}
-          editable={party.editable}
+          editable={props.editable}
           position={i}
           unitType={1}
           removeWeapon={removeWeapon}
@@ -366,7 +356,7 @@ const WeaponGrid = (props: Props) => {
   const extraGridElement = (
     <ExtraWeapons
       grid={appState.grid.weapons.allWeapons}
-      editable={party.editable}
+      editable={props.editable}
       offset={numWeapons}
       removeWeapon={removeWeapon}
       updateObject={receiveWeaponFromSearch}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "i18next": "^21.6.13",
         "i18next-browser-languagedetector": "^6.1.3",
         "i18next-http-backend": "^1.3.2",
+        "local-storage": "^2.0.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.debounce": "^4.0.8",
         "meyer-reset-scss": "^2.0.4",
@@ -5654,6 +5655,11 @@
       "bin": {
         "json5": "lib/cli.js"
       }
+    },
+    "node_modules/local-storage": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/local-storage/-/local-storage-2.0.0.tgz",
+      "integrity": "sha512-/0sRoeijw7yr/igbVVygDuq6dlYCmtsuTmmpnweVlVtl/s10pf5BCq8LWBxW/AMyFJ3MhMUuggMZiYlx6qr9tw=="
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -11397,6 +11403,11 @@
           }
         }
       }
+    },
+    "local-storage": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/local-storage/-/local-storage-2.0.0.tgz",
+      "integrity": "sha512-/0sRoeijw7yr/igbVVygDuq6dlYCmtsuTmmpnweVlVtl/s10pf5BCq8LWBxW/AMyFJ3MhMUuggMZiYlx6qr9tw=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "sanitize-html": "^2.8.1",
         "sass": "^1.49.0",
         "usehooks-ts": "^2.9.1",
+        "uuid": "^9.0.0",
         "valtio": "^1.3.0",
         "youtube-api-v3-wrapper": "^2.3.0"
       },
@@ -59,6 +60,7 @@
         "@types/react-linkify": "^1.0.1",
         "@types/react-scroll": "^1.8.3",
         "@types/sanitize-html": "^2.8.0",
+        "@types/uuid": "^9.0.0",
         "eslint": "8.7.0",
         "eslint-config-next": "12.0.8",
         "eslint-plugin-valtio": "^0.4.1",
@@ -3153,6 +3155,12 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.47.1",
@@ -7309,6 +7317,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -9575,6 +9591,12 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "@types/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
+      "dev": true
     },
     "@typescript-eslint/parser": {
       "version": "5.47.1",
@@ -12506,6 +12528,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "sanitize-html": "^2.8.1",
     "sass": "^1.49.0",
     "usehooks-ts": "^2.9.1",
+    "uuid": "^9.0.0",
     "valtio": "^1.3.0",
     "youtube-api-v3-wrapper": "^2.3.0"
   },
@@ -64,6 +65,7 @@
     "@types/react-linkify": "^1.0.1",
     "@types/react-scroll": "^1.8.3",
     "@types/sanitize-html": "^2.8.0",
+    "@types/uuid": "^9.0.0",
     "eslint": "8.7.0",
     "eslint-config-next": "12.0.8",
     "eslint-plugin-valtio": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "i18next": "^21.6.13",
     "i18next-browser-languagedetector": "^6.1.3",
     "i18next-http-backend": "^1.3.2",
+    "local-storage": "^2.0.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
     "meyer-reset-scss": "^2.0.4",

--- a/pages/[username].tsx
+++ b/pages/[username].tsx
@@ -9,7 +9,7 @@ import api from '~utils/api'
 import extractFilters from '~utils/extractFilters'
 import fetchLatestVersion from '~utils/fetchLatestVersion'
 import organizeRaids from '~utils/organizeRaids'
-import setUserToken from '~utils/setUserToken'
+import { setHeaders } from '~utils/userToken'
 import useDidMountEffect from '~utils/useDidMountEffect'
 import { appState } from '~utils/appState'
 import { elements, allElement } from '~data/elements'
@@ -329,7 +329,7 @@ export const getServerSidePaths = async () => {
 // prettier-ignore
 export const getServerSideProps = async ({ req, res, locale, query }: { req: NextApiRequest, res: NextApiResponse, locale: string, query: { [index: string]: string } }) => {
   // Set headers for server-side requests
-  setUserToken(req, res)
+  setHeaders(req, res)
 
   // Fetch latest version
   const version = await fetchLatestVersion()

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,7 +7,7 @@ import type { AppProps } from 'next/app'
 import Layout from '~components/Layout'
 
 import { accountState } from '~utils/accountState'
-import setUserToken from '~utils/setUserToken'
+import { setHeaders } from '~utils/userToken'
 
 import '../styles/globals.scss'
 import { ToastProvider, Viewport } from '@radix-ui/react-toast'
@@ -23,9 +23,9 @@ function MyApp({ Component, pageProps }: AppProps) {
   }
 
   useEffect(() => {
-    setUserToken()
 
     if (accountCookie) {
+    setHeaders()
       console.log(`Logged in as user "${cookieData.account.username}"`)
 
       accountState.account.authorized = true

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,9 +23,8 @@ function MyApp({ Component, pageProps }: AppProps) {
   }
 
   useEffect(() => {
-
-    if (accountCookie) {
     setHeaders()
+    if (cookieData.account && cookieData.account.token) {
       console.log(`Logged in as user "${cookieData.account.username}"`)
 
       accountState.account.authorized = true

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 import { AboutTabs } from '~utils/enums'
-import setUserToken from '~utils/setUserToken'
+import { setHeaders } from '~utils/userToken'
 
 import AboutPage from '~components/AboutPage'
 import UpdatesPage from '~components/UpdatesPage'
@@ -160,7 +160,7 @@ export const getServerSidePaths = async () => {
 // prettier-ignore
 export const getServerSideProps = async ({ req, res, locale, query }: { req: NextApiRequest, res: NextApiResponse, locale: string, query: { [index: string]: string } }) => {
   // Set headers for server-side requests
-  setUserToken(req, res)
+  setHeaders(req, res)
 
   // Fetch and organize raids
   return {

--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -10,7 +10,7 @@ import NewHead from '~components/NewHead'
 import api from '~utils/api'
 import fetchLatestVersion from '~utils/fetchLatestVersion'
 import organizeRaids from '~utils/organizeRaids'
-import setUserToken from '~utils/setUserToken'
+import { accountCookie, setHeaders } from '~utils/userToken'
 import { appState, initialAppState } from '~utils/appState'
 import { groupWeaponKeys } from '~utils/groupWeaponKeys'
 
@@ -119,8 +119,8 @@ export const getServerSidePaths = async () => {
 
 // prettier-ignore
 export const getServerSideProps = async ({ req, res, locale, query }: { req: NextApiRequest, res: NextApiResponse, locale: string, query: { [index: string]: string } }) => {
-  // Set headers for server-side requests
-  setUserToken(req, res)
+  // Set headers for API calls
+  setHeaders(req, res)
 
   // Fetch latest version
   const version = await fetchLatestVersion()

--- a/pages/p/[party].tsx
+++ b/pages/p/[party].tsx
@@ -10,7 +10,7 @@ import api from '~utils/api'
 import elementEmoji from '~utils/elementEmoji'
 import fetchLatestVersion from '~utils/fetchLatestVersion'
 import organizeRaids from '~utils/organizeRaids'
-import setUserToken from '~utils/setUserToken'
+import { setHeaders } from '~utils/userToken'
 import { appState } from '~utils/appState'
 import { groupWeaponKeys } from '~utils/groupWeaponKeys'
 
@@ -108,7 +108,7 @@ export const getServerSidePaths = async () => {
 // prettier-ignore
 export const getServerSideProps = async ({ req, res, locale, query }: { req: NextApiRequest, res: NextApiResponse, locale: string, query: { [index: string]: string } }) => {
   // Set headers for server-side requests
-  setUserToken(req, res)
+  setHeaders(req, res)
 
   // Fetch latest version
   const version = await fetchLatestVersion()

--- a/pages/saved.tsx
+++ b/pages/saved.tsx
@@ -7,7 +7,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import clonedeep from 'lodash.clonedeep'
 
 import api from '~utils/api'
-import setUserToken from '~utils/setUserToken'
+import { setHeaders } from '~utils/userToken'
 import extractFilters from '~utils/extractFilters'
 import fetchLatestVersion from '~utils/fetchLatestVersion'
 import organizeRaids from '~utils/organizeRaids'
@@ -363,7 +363,7 @@ export const getServerSidePaths = async () => {
 // prettier-ignore
 export const getServerSideProps = async ({ req, res, locale, query }: { req: NextApiRequest, res: NextApiResponse, locale: string, query: { [index: string]: string } }) => {
   // Set headers for server-side requests
-  setUserToken(req, res)
+  setHeaders(req, res)
 
   // Fetch latest version
   const version = await fetchLatestVersion()

--- a/pages/teams.tsx
+++ b/pages/teams.tsx
@@ -7,7 +7,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import clonedeep from 'lodash.clonedeep'
 
 import api from '~utils/api'
-import setUserToken from '~utils/setUserToken'
+import { setHeaders } from '~utils/userToken'
 import extractFilters from '~utils/extractFilters'
 import fetchLatestVersion from '~utils/fetchLatestVersion'
 import organizeRaids from '~utils/organizeRaids'
@@ -363,7 +363,7 @@ export const getServerSidePaths = async () => {
 // prettier-ignore
 export const getServerSideProps = async ({ req, res, locale, query }: { req: NextApiRequest, res: NextApiResponse, locale: string, query: { [index: string]: string } }) => {
   // Set headers for server-side requests
-  setUserToken(req, res)
+  setHeaders(req, res)
 
   // Fetch latest version
   const version = await fetchLatestVersion()

--- a/types/Party.d.ts
+++ b/types/Party.d.ts
@@ -29,6 +29,7 @@ interface Party {
   weapons: Array<GridWeapon>
   summons: Array<GridSummon>
   user: User
+  local_id?: string
   remix: boolean
   remixes: Party[]
   created_at: string

--- a/utils/userToken.tsx
+++ b/utils/userToken.tsx
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import ls, { get, set } from 'local-storage'
 import { getCookie } from 'cookies-next'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
@@ -23,4 +24,18 @@ export const setHeaders = (
   } else {
     delete axios.defaults.headers.common['Authorization']
   }
+}
+
+export const setEditKey = (id: string, user?: User) => {
+  if (!user) {
+    const edit_key = get<string>(id)
+    console.log('Setting header...', edit_key)
+    axios.defaults.headers.common['X-Edit-Key'] = edit_key
+  } else {
+    unsetEditKey()
+  }
+}
+
+export const unsetEditKey = () => {
+  delete axios.defaults.headers.common['X-Edit-Key']
 }

--- a/utils/userToken.tsx
+++ b/utils/userToken.tsx
@@ -2,17 +2,24 @@ import axios from 'axios'
 import { getCookie } from 'cookies-next'
 import type { NextApiRequest, NextApiResponse } from 'next'
 
-export default (
+export const accountCookie = (
   req: NextApiRequest | undefined = undefined,
   res: NextApiResponse | undefined = undefined
 ) => {
-  // Set up cookies
   const options = req && res ? { req, res } : {}
   const cookie = getCookie('account', options)
+  return cookie ? cookie : undefined
+}
+
+export const setHeaders = (
+  req: NextApiRequest | undefined = undefined,
+  res: NextApiResponse | undefined = undefined
+) => {
+  const cookie = accountCookie(req, res)
   if (cookie) {
-    axios.defaults.headers.common['Authorization'] = `Bearer ${
-      JSON.parse(cookie as string).token
-    }`
+    const parsed = JSON.parse(cookie as string)
+    if (parsed.token)
+      axios.defaults.headers.common['Authorization'] = `Bearer ${parsed.token}`
   } else {
     delete axios.defaults.headers.common['Authorization']
   }

--- a/utils/userToken.tsx
+++ b/utils/userToken.tsx
@@ -29,7 +29,6 @@ export const setHeaders = (
 export const setEditKey = (id: string, user?: User) => {
   if (!user) {
     const edit_key = get<string>(id)
-    console.log('Setting header...', edit_key)
     axios.defaults.headers.common['X-Edit-Key'] = edit_key
   } else {
     unsetEditKey()


### PR DESCRIPTION
This PR revamps how we handle unauth teams and is part bug fix and part new feature.

### New strategy
1. The client creates a UUID if there is no `user` object stored in cookies when visiting `/new`. This should only happen once (unless the cookie expires or is cleared)
2. The UUID is sent to the server as the `local_id` with the party payload as it is being created. On create, the party creates itself an `edit_key`—essentially a party-specific access token—if it does not have a `User` association. It is stored alongside the party and only sent back **once** (with the party's `201` response) and the client is responsible for storing it.
3. The client stores the edit key in the browser's local storage alongside the party ID as its key.
4. When requesting party data, the client checks the `user_id` in its cookies with the `local_id` in the party payload. However, the `edit_key` must be sent with any PUT or DELETE requests as `X-Edit-Key` in order to validate that the user can truly edit that party. It is retrieved from local storage with the party's ID.

### Result
- Unauthorized users can now edit and delete their parties as long as their cookies and local storage remain intact
- Unauthorized users have a path to signing up for a profile while keeping their parties intact (to be implemented)
- This fixes #210 
- This fixes #102 