### PR TITLE
Fix issues with auth and editable state

### DIFF
--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import api from '~utils/api'
 import { accountState, initialAccountState } from '~utils/accountState'
 import { appState, initialAppState } from '~utils/appState'
+import { getLocalId } from '~utils/localId'
 import { retrieveLocaleCookies } from '~utils/retrieveCookies'
 
 import {
@@ -189,12 +190,16 @@ const Header = () => {
   function remixTeam() {
     setOriginalName(partySnapshot.name ? partySnapshot.name : t('no_title'))
 
-    if (partySnapshot.shortcode)
-      api.remix(partySnapshot.shortcode).then((response) => {
-        const remix = response.data.party
-        router.push(`/p/${remix.shortcode}`)
-        setRemixToastOpen(true)
-      })
+    if (partySnapshot.shortcode) {
+      const body = getLocalId()
+      api
+        .remix({ shortcode: partySnapshot.shortcode, body: body })
+        .then((response) => {
+          const remix = response.data.party
+          router.push(`/p/${remix.shortcode}`)
+          setRemixToastOpen(true)
+        })
+    }
   }
 
   function toggleFavorite() {

--- a/components/Party/index.tsx
+++ b/components/Party/index.tsx
@@ -12,15 +12,16 @@ import SummonGrid from '~components/SummonGrid'
 import CharacterGrid from '~components/CharacterGrid'
 
 import api from '~utils/api'
+import { accountState } from '~utils/accountState'
 import { appState, initialAppState } from '~utils/appState'
+import { getLocalId } from '~utils/localId'
 import { GridType } from '~utils/enums'
 import { retrieveCookies } from '~utils/retrieveCookies'
-import { accountCookie, setEditKey, unsetEditKey } from '~utils/userToken'
+import { setEditKey, unsetEditKey } from '~utils/userToken'
 
 import type { DetailsObject } from '~types'
 
 import './index.scss'
-import { accountState } from '~utils/accountState'
 
 // Props
 interface Props {
@@ -109,7 +110,7 @@ const Party = (props: Props) => {
     if (details) payload = formatDetailsObject(details)
 
     return await api.endpoints.parties
-      .create({ ...payload, ...localId() })
+      .create({ ...payload, ...getLocalId() })
       .then((response) => storeParty(response.data.party))
   }
 
@@ -298,15 +299,6 @@ const Party = (props: Props) => {
       default:
         break
     }
-  }
-
-  // Methods: Unauth validation
-  function localId() {
-    const cookie = accountCookie()
-    const parsed = JSON.parse(cookie as string)
-    if (parsed && !parsed.token) {
-      return { local_id: parsed.userId }
-    } else return {}
   }
 
   // Render: JSX components

--- a/components/Party/index.tsx
+++ b/components/Party/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { getCookie } from 'cookies-next'
 import { useRouter } from 'next/router'
-import { useSnapshot } from 'valtio'
+import { subscribe, useSnapshot } from 'valtio'
 import clonedeep from 'lodash.clonedeep'
 import ls from 'local-storage'
 
@@ -20,6 +20,7 @@ import { accountCookie, setEditKey, unsetEditKey } from '~utils/userToken'
 import type { DetailsObject } from '~types'
 
 import './index.scss'
+import { accountState } from '~utils/accountState'
 
 // Props
 interface Props {
@@ -42,6 +43,7 @@ const Party = (props: Props) => {
   const { party } = useSnapshot(appState)
   const [editable, setEditable] = useState(false)
   const [currentTab, setCurrentTab] = useState<GridType>(GridType.Weapon)
+  const [refresh, setRefresh] = useState(false)
 
   // Retrieve cookies
   const cookies = retrieveCookies()
@@ -52,6 +54,14 @@ const Party = (props: Props) => {
     appState.grid = resetState.grid
     if (props.team) storeParty(props.team)
   }, [])
+
+  // Subscribe to app state to listen for account changes and
+  // unsubscribe when component is unmounted
+  const unsubscribe = subscribe(accountState, () => {
+    setRefresh(true)
+  })
+
+  useEffect(() => () => unsubscribe(), [])
 
   // Set editable on first load
   useEffect(() => {
@@ -86,7 +96,7 @@ const Party = (props: Props) => {
 
     appState.party.editable = editable
     setEditable(editable)
-  })
+  }, [refresh])
 
   // Set selected tab from props
   useEffect(() => {

--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react'
-import { useRouter } from 'next/router'
+import { getCookie, setCookie } from 'cookies-next'
+import { get, set } from 'local-storage'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useRouter } from 'next/router'
 import { v4 as uuidv4 } from 'uuid'
 import clonedeep from 'lodash.clonedeep'
 
@@ -19,7 +21,6 @@ import type { AxiosError } from 'axios'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import type { PageContextObj, ResponseStatus } from '~types'
 import { GridType } from '~utils/enums'
-import { setCookie } from 'cookies-next'
 
 interface Props {
   context?: PageContextObj
@@ -58,6 +59,13 @@ const NewRoute: React.FC<Props> = ({
         break
     }
   }, [router.asPath])
+
+  // Persist generated userId in storage
+  useEffect(() => {
+    const cookie = getCookie('account')
+    const data: AccountCookie = JSON.parse(cookie as string)
+    if (!get('userId') && data && !data.token) set('userId', data.userId)
+  }, [])
 
   useEffect(() => {
     if (context && context.jobs && context.jobSkills) {

--- a/utils/api.tsx
+++ b/utils/api.tsx
@@ -120,9 +120,9 @@ class Api {
     return axios.get(resourceUrl, params)
   }
 
-  remix(shortcode: string, params?: {}) {
+  remix({ shortcode, body, params}: { shortcode: string, body?: {}, params?: {} }) {
     const resourceUrl = `${this.url}/parties/${shortcode}/remix`
-    return axios.post(resourceUrl, params)
+    return axios.post(resourceUrl, body, params)
   }
 
   savedTeams(params: {}) {

--- a/utils/localId.tsx
+++ b/utils/localId.tsx
@@ -1,0 +1,9 @@
+import { accountCookie } from './userToken'
+
+export function getLocalId() {
+  const cookie = accountCookie()
+  const parsed = JSON.parse(cookie as string)
+  if (parsed && !parsed.token) {
+    return { local_id: parsed.userId }
+  } else return {}
+}


### PR DESCRIPTION
This fixes several issues with auth state and whether a party is editable:

* **If a user creates a party without logging in, and then logs in, the party no longer _appears_ as editable.** 
It wasn't editable before because of server checks, but now users won't be able to open search interfaces, etc. only to get a 401 error

* **Logging in and logging out no longer erases your `local_id`.** 
Logging in would overwrite `user_id` in cookies, then logging out again erases that `user_id`. The `edit_key`s were still in LocalStorage but the association was broken. Now, we store `user_id` in LocalStorage and restore it when the user logs out again. This will be made moot because we will be implement a change that migrates all edit_keys to a user account when the user signs up or logs in very soon.

* **If a user remixes a party without logging in, we now send the `local_id` so they can edit it later**

This bug still persists, I'm too tired to figure it out and it seems unimportant because of the caveat in bugfix #2:
* When a user logs out while viewing an anonymous team they have the edit key for, it does not appear editable until a refresh.