### PR TITLE
Add granblue_id to weapon keys

### DIFF
--- a/components/WeaponKeySelect/index.tsx
+++ b/components/WeaponKeySelect/index.tsx
@@ -79,7 +79,11 @@ const WeaponKeySelect = React.forwardRef<HTMLButtonElement, Props>(
         keys[index].length > 0 &&
         keys[index].sort(sortByOrder).map((item, i) => {
           return (
-            <SelectItem key={i} value={item.id}>
+            <SelectItem
+              key={i}
+              value={item.id}
+              data-granblue-id={item.granblue_id}
+            >
               {item.name.en}
             </SelectItem>
           )

--- a/types/WeaponKey.d.ts
+++ b/types/WeaponKey.d.ts
@@ -1,5 +1,6 @@
 interface WeaponKey {
   id: string
+  granblue_id: string
   name: {
     [key: string]: string
     en: string


### PR DESCRIPTION
This adds `granblue_id` to the `WeaponKey` definition and also exposes it as `data-granblue-id` in the dropdown.