### PR TITLE
(Hotfix) (Temporary) nuclear option for raid population

### DIFF
--- a/components/filters/FilterBar/index.tsx
+++ b/components/filters/FilterBar/index.tsx
@@ -22,6 +22,7 @@ interface Props {
   scrolled: boolean
   element?: number
   raid?: string
+  raidGroups: RaidGroup[]
   recency?: number
   onFilter: (filters: FilterSet) => void
   onAdvancedFilter: (filters: FilterSet) => void
@@ -147,6 +148,7 @@ const FilterBar = (props: Props) => {
           <RaidCombobox
             currentRaid={currentRaid}
             showAllRaidsOption={true}
+            raidGroups={props.raidGroups}
             minimal={true}
             size="small"
             onChange={raidSelectChanged}

--- a/components/party/EditPartyModal/index.tsx
+++ b/components/party/EditPartyModal/index.tsx
@@ -33,12 +33,14 @@ import styles from './index.module.scss'
 interface Props extends DialogProps {
   open: boolean
   party?: Party
+  raidGroups: RaidGroup[]
   onOpenChange?: (open: boolean) => void
   updateParty: (details: DetailsObject) => Promise<any>
 }
 
 const EditPartyModal = ({
   open,
+  raidGroups,
   updateParty,
   onOpenChange,
   ...props
@@ -425,6 +427,7 @@ const EditPartyModal = ({
     <RaidCombobox
       showAllRaidsOption={false}
       currentRaid={raid}
+      raidGroups={raidGroups}
       onChange={receiveRaid}
     />
   )

--- a/components/party/Party/index.tsx
+++ b/components/party/Party/index.tsx
@@ -28,6 +28,7 @@ interface Props {
   new?: boolean
   team?: Party
   selectedTab: GridType
+  raidGroups: RaidGroup[]
   handleTabChanged: (value: string) => void
   pushHistory?: (path: string) => void
 }
@@ -440,6 +441,7 @@ const Party = (props: Props) => {
         party={props.team}
         new={props.new || false}
         editable={props.new ? true : party.editable}
+        raidGroups={props.raidGroups}
         deleteCallback={deleteTeam}
         remixCallback={remixTeam}
         updateCallback={updateDetails}
@@ -453,6 +455,7 @@ const Party = (props: Props) => {
         party={props.team}
         new={props.new || false}
         editable={party.editable}
+        raidGroups={props.raidGroups}
         remixCallback={remixTeam}
         updateCallback={updateDetails}
       />

--- a/components/party/PartyFooter/index.tsx
+++ b/components/party/PartyFooter/index.tsx
@@ -33,6 +33,7 @@ interface Props {
   party?: Party
   new: boolean
   editable: boolean
+  raidGroups: RaidGroup[]
   remixCallback: () => void
   updateCallback: (details: DetailsObject) => Promise<any>
 }
@@ -225,6 +226,7 @@ const PartyFooter = (props: Props) => {
             <EditPartyModal
               open={detailsOpen}
               party={props.party}
+              raidGroups={props.raidGroups}
               onOpenChange={handleDetailsOpenChange}
               updateParty={props.updateCallback}
             >

--- a/components/party/PartyHeader/index.tsx
+++ b/components/party/PartyHeader/index.tsx
@@ -33,6 +33,7 @@ interface Props {
   party?: Party
   new: boolean
   editable: boolean
+  raidGroups: RaidGroup[]
   deleteCallback: () => void
   remixCallback: () => void
   updateCallback: (details: DetailsObject) => Promise<any>
@@ -383,6 +384,7 @@ const PartyHeader = (props: Props) => {
               <EditPartyModal
                 open={detailsOpen}
                 party={props.party}
+                raidGroups={props.raidGroups}
                 onOpenChange={handleDetailsOpenChange}
                 updateParty={props.updateCallback}
               >

--- a/components/raids/RaidCombobox/index.tsx
+++ b/components/raids/RaidCombobox/index.tsx
@@ -1,4 +1,4 @@
-import { createRef, useCallback, useEffect, useState, useRef } from 'react'
+import { createRef, useCallback, useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'react-i18next'
 import classNames from 'classnames'
@@ -9,20 +9,6 @@ import SegmentedControl from '~components/common/SegmentedControl'
 import Segment from '~components/common/Segment'
 import RaidItem from '~components/raids/RaidItem'
 import Tooltip from '~components/common/Tooltip'
-
-import api from '~utils/api'
-import { appState } from '~utils/appState'
-
-interface Props {
-  showAllRaidsOption: boolean
-  currentRaid?: Raid
-  defaultRaid?: Raid
-  minimal?: boolean
-  tabIndex?: number
-  size?: 'small' | 'medium' | 'large'
-  onChange?: (raid?: Raid) => void
-  onBlur?: (event: React.ChangeEvent<HTMLSelectElement>) => void
-}
 
 import Button from '~components/common/Button'
 import ArrowIcon from '~public/icons/Arrow.svg'
@@ -65,6 +51,18 @@ const allRaidsOption: Raid = {
   slug: 'all',
   level: 0,
   element: 0,
+}
+
+interface Props {
+  showAllRaidsOption: boolean
+  currentRaid?: Raid
+  defaultRaid?: Raid
+  raidGroups: RaidGroup[]
+  minimal?: boolean
+  tabIndex?: number
+  size?: 'small' | 'medium' | 'large'
+  onChange?: (raid?: Raid) => void
+  onBlur?: (event: React.ChangeEvent<HTMLSelectElement>) => void
 }
 
 const RaidCombobox = (props: Props) => {
@@ -114,12 +112,12 @@ const RaidCombobox = (props: Props) => {
   useEffect(() => {
     const sections: [RaidGroup[], RaidGroup[], RaidGroup[]] = [[], [], []]
 
-    appState.raidGroups.forEach((group) => {
+    props.raidGroups.forEach((group) => {
       if (group.section > 0) sections[group.section - 1].push(group)
     })
 
-    if (appState.raidGroups[0]) {
-      setFarmingRaid(appState.raidGroups[0].raids[0])
+    if (props.raidGroups[0]) {
+      setFarmingRaid(props.raidGroups[0].raids[0])
     }
 
     setSections(sections)
@@ -521,13 +519,6 @@ const RaidCombobox = (props: Props) => {
   // ----------------------------------------------
   // Methods: Utility
   // ----------------------------------------------
-  function slugToRaid(slug: string) {
-    return appState.raidGroups
-      .filter((group) => group.section > 0)
-      .flatMap((group) => group.raids)
-      .find((raid) => raid.slug === slug)
-  }
-
   const linkClass = classNames({
     wind: currentRaid && currentRaid.element == 1,
     fire: currentRaid && currentRaid.element == 2,

--- a/components/raids/RaidCombobox/index.tsx
+++ b/components/raids/RaidCombobox/index.tsx
@@ -112,15 +112,26 @@ const RaidCombobox = (props: Props) => {
 
   // Fetch all raids on mount
   useEffect(() => {
-    sortGroups(appState.raidGroups)
+    const sections: [RaidGroup[], RaidGroup[], RaidGroup[]] = [[], [], []]
+
+    appState.raidGroups.forEach((group) => {
+      if (group.section > 0) sections[group.section - 1].push(group)
+    })
+
+    if (appState.raidGroups[0]) {
+      setFarmingRaid(appState.raidGroups[0].raids[0])
+    }
+
+    setSections(sections)
   }, [])
 
   // Set current section when the current raid changes
   useEffect(() => {
-    console.log('Raid has changed')
     if (props.currentRaid) {
+      setCurrentRaid(props.currentRaid)
       setCurrentSection(props.currentRaid.group.section)
     } else {
+      setCurrentRaid(undefined)
       setCurrentSection(1)
     }
   }, [props.currentRaid])
@@ -200,24 +211,6 @@ const RaidCombobox = (props: Props) => {
     if (sort === Sort.ASCENDING) setSort(Sort.DESCENDING)
     else setSort(Sort.ASCENDING)
   }
-
-  // Sorts the raid groups into sections
-  const sortGroups = useCallback(
-    (groups: RaidGroup[]) => {
-      const sections: [RaidGroup[], RaidGroup[], RaidGroup[]] = [[], [], []]
-
-      groups.forEach((group) => {
-        if (group.section > 0) sections[group.section - 1].push(group)
-      })
-
-      if (groups[0]) {
-        setFarmingRaid(groups[0].raids[0])
-      }
-
-      setSections(sections)
-    },
-    [setSections]
-  )
 
   const handleSortButtonKeyDown = (
     event: React.KeyboardEvent<HTMLButtonElement>

--- a/pages/[username].tsx
+++ b/pages/[username].tsx
@@ -278,6 +278,7 @@ const ProfileRoute: React.FC<Props> = ({
           scrolled={scrolled}
           element={element}
           raid={raid}
+          raidGroups={context.raidGroups}
           recency={recency}
         >
           <UserInfo user={context.user!} />

--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -150,6 +150,7 @@ const NewRoute: React.FC<Props> = ({
           new={true}
           pushHistory={callback}
           selectedTab={selectedTab}
+          raidGroups={context.raidGroups}
           handleTabChanged={handleTabChange}
         />
       </React.Fragment>

--- a/pages/p/[party].tsx
+++ b/pages/p/[party].tsx
@@ -128,6 +128,7 @@ const PartyRoute: React.FC<Props> = ({
         <Party
           team={context.party}
           selectedTab={selectedTab}
+          raidGroups={context.raidGroups}
           handleTabChanged={handleTabChange}
         />
       </React.Fragment>

--- a/pages/saved.tsx
+++ b/pages/saved.tsx
@@ -318,6 +318,7 @@ const SavedRoute: React.FC<Props> = ({
           scrolled={scrolled}
           element={element}
           raid={raid}
+          raidGroups={context.raidGroups}
           recency={recency}
         >
           <h1>{t('saved.title')}</h1>

--- a/pages/teams.tsx
+++ b/pages/teams.tsx
@@ -329,6 +329,7 @@ const TeamsRoute: React.FC<Props> = ({
           scrolled={scrolled}
           element={element}
           raid={raid}
+          raidGroups={context.raidGroups}
           recency={recency}
         >
           <h1>{t('teams.title')}</h1>


### PR DESCRIPTION
No matter what I do, raids won't populate from state specifically in production. I will have to investigate this more, but for now we are going with the nuclear option of passing raids down from the context object we get from SSR through all components into RaidCombobox