### PR TITLE
Fix server side error when no filters cookie present

### DIFF
--- a/pages/teams.tsx
+++ b/pages/teams.tsx
@@ -384,6 +384,7 @@ export const getServerSideProps = async ({ req, res, locale, query }: { req: Nex
   // Fetch user's advanced filters
   const filtersCookie = getCookie('filters', { req: req, res: res })
   const advancedFilters = filtersCookie ? JSON.parse(filtersCookie as string) : undefined
+  const convertedFilters = advancedFilters ? convertAdvancedFilters(advancedFilters) : undefined
   
   try {
     // Fetch and organize raids
@@ -394,7 +395,7 @@ export const getServerSideProps = async ({ req, res, locale, query }: { req: Nex
     // Create filter object
     const filters: FilterObject = extractFilters(query, raidGroups)
     const params = {
-      params: { ...filters, ...convertAdvancedFilters(advancedFilters) },
+      params: { ...filters, ...convertedFilters },
     }
 
     // Set up empty variables


### PR DESCRIPTION
This was clown town, but when the user _doesn't_ have any filters, the teams page would not load at all.