### PR TITLE
(Hotfix) Don't always show scrollbars on Editor

### DIFF
--- a/components/common/Editor/index.module.scss
+++ b/components/common/Editor/index.module.scss
@@ -24,7 +24,8 @@
     flex-grow: 1;
     font-size: $font-regular;
     line-height: 1.4;
-    overflow: scroll;
+    overflow-y: auto;
+    overflow-x: hidden;
     padding: $unit * 1.5 $unit-2x;
     white-space: pre-wrap;
     width: 100%;


### PR DESCRIPTION
Bad CSS made it so that scrollbars always showed up in descriptions and the editor. I didn't see it because I am usually working on a Mac with display scrollbars off. Anyway, it's fixed now.