### PR TITLE
Fix ability for non-owners to change team visibility

### DIFF
--- a/components/party/Party/index.tsx
+++ b/components/party/Party/index.tsx
@@ -143,7 +143,7 @@ const Party = (props: Props) => {
   // Methods: Updating the party's details
   async function updateDetails(details: DetailsObject) {
     if (!props.team) return await createParty(details)
-    else return await updateParty(details)
+    else if (party.editable) return await updateParty(details)
   }
 
   function formatDetailsObject(details: DetailsObject) {

--- a/components/party/PartyHeader/index.tsx
+++ b/components/party/PartyHeader/index.tsx
@@ -345,13 +345,15 @@ const PartyHeader = (props: Props) => {
           text={t('party.notices.buttons.copy_link')}
           onClick={copyToClipboard}
         />
-        <Button
-          bound={true}
-          className="notice no-shrink"
-          key="change_visibility"
-          text={t('party.notices.buttons.change_visibility')}
-          onClick={() => handleVisibilityDialogChange(true)}
-        />
+        {party.editable && (
+          <Button
+            bound={true}
+            className="notice no-shrink"
+            key="change_visibility"
+            text={t('party.notices.buttons.change_visibility')}
+            onClick={() => handleVisibilityDialogChange(true)}
+          />
+        )}
       </div>
     </div>
   )
@@ -362,15 +364,17 @@ const PartyHeader = (props: Props) => {
         <PrivateIcon />
       </div>
       <p>{t('party.notices.private')}</p>
-      <div className={styles.buttons}>
-        <Button
-          bound={true}
-          className="notice"
-          key="change_visibility"
-          text={t('party.notices.buttons.change_visibility')}
-          onClick={() => handleVisibilityDialogChange(true)}
-        />
-      </div>
+      {party.editable && (
+        <div className={styles.buttons}>
+          <Button
+            bound={true}
+            className="notice"
+            key="change_visibility"
+            text={t('party.notices.buttons.change_visibility')}
+            onClick={() => handleVisibilityDialogChange(true)}
+          />
+        </div>
+      )}
     </div>
   )
 


### PR DESCRIPTION
This fixes #384 

* Hides "Change party visibility" button when a user is viewing an unlisted team they did not create
* Prevents updating team at all if the `editable` flag is not set (which might break something else for anonymous teams... we'll see)