### PR TITLE
Use party.id to query embed image instead of shortcode

### DIFF
--- a/components/party/PartyHead/index.tsx
+++ b/components/party/PartyHead/index.tsx
@@ -19,7 +19,7 @@ const PartyHead = ({ party, meta }: Props) => {
   const router = useRouter()
   const locale =
     router.locale && ['en', 'ja'].includes(router.locale) ? router.locale : 'en'
-  const previewUrl = api.previewUrl(party.shortcode)
+  const previewUrl = api.previewUrl(party.id)
 
   return (
     <Head>

--- a/utils/api.tsx
+++ b/utils/api.tsx
@@ -139,8 +139,8 @@ class Api {
     return axios.get(resourceUrl, params)
   }
 
-  previewUrl(shortcode: string): string {
-    return `${this.url}/parties/${shortcode}/preview`
+  previewUrl(id: string): string {
+    return `${this.url}/parties/${id}/preview`
   }
 
   raidGroups(params?: {}) {


### PR DESCRIPTION
The API doesn't understand shortcodes as indexes