### PR TITLE
Fix ESLint errors causing Railway deployment failure

### DIFF
--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -18,7 +18,7 @@ export default function Error({ error, reset }: ErrorPageProps) {
     <div className="error-container">
       <div className="error-content">
         <h1>Internal Server Error</h1>
-        <p>The server reported a problem that we couldn't automatically recover from.</p>
+        <p>The server reported a problem that we couldn&apos;t automatically recover from.</p>
         <div className="error-message">
           <p>{error.message || 'An unexpected error occurred'}</p>
           {error.digest && <p className="error-digest">Error ID: {error.digest}</p>}

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -14,7 +14,7 @@ export default async function NotFound() {
     <div className="error-container">
       <div className="error-content">
         <h1>Not Found</h1>
-        <p>The page you're looking for couldn't be found</p>
+        <p>The page you&apos;re looking for couldn&apos;t be found</p>
         <div className="error-actions">
           <Link href="/new" className="button primary">
             Create a new party

--- a/app/[locale]/unauthorized/page.tsx
+++ b/app/[locale]/unauthorized/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 
 export const metadata: Metadata = {
   title: 'Unauthorized / granblue.team',
-  description: 'You don\'t have permission to perform that action'
+  description: "You don't have permission to perform that action"
 }
 
 export default function UnauthorizedPage() {
@@ -11,7 +11,7 @@ export default function UnauthorizedPage() {
     <div className="error-container">
       <div className="error-content">
         <h1>Unauthorized</h1>
-        <p>You don't have permission to perform that action</p>
+        <p>You don&apos;t have permission to perform that action</p>
         <div className="error-actions">
           <Link href="/teams" className="button primary">
             Browse teams


### PR DESCRIPTION
## Summary
- Fixed unescaped apostrophes in JSX text that were causing ESLint errors
- These errors were preventing the production build from completing on Railway

## Changes
- `app/[locale]/error.tsx`: Escaped apostrophe in "couldn't"
- `app/[locale]/not-found.tsx`: Escaped apostrophes in "you're" and "couldn't"  
- `app/[locale]/unauthorized/page.tsx`: Escaped apostrophe in "don't"

## Test plan
- [x] ESLint errors resolved locally
- [ ] Railway deployment succeeds after merge

🤖 Generated with [Claude Code](https://claude.ai/code)