### PR TITLE
Fix SuggestionDetailItem reference error in metadata sections

### DIFF
--- a/src/lib/features/database/characters/sections/CharacterMetadataSection.svelte
+++ b/src/lib/features/database/characters/sections/CharacterMetadataSection.svelte
@@ -67,27 +67,19 @@
 
 <DetailsContainer title="Metadata">
   {#if editMode}
-    <SuggestionDetailItem
+    <DetailItem
       label="Name (EN)"
       bind:value={editData.name}
       editable={true}
       type="text"
       placeholder="English name"
-      suggestion={suggestions?.nameEn}
-      dismissedSuggestion={dismissedSuggestions?.has('name')}
-      onAcceptSuggestion={() => onAcceptSuggestion?.('name', suggestions?.nameEn)}
-      onDismissSuggestion={() => onDismissSuggestion?.('name')}
     />
-    <SuggestionDetailItem
+    <DetailItem
       label="Name (JP)"
       bind:value={editData.nameJp}
       editable={true}
       type="text"
       placeholder="日本語名"
-      suggestion={suggestions?.nameJp}
-      dismissedSuggestion={dismissedSuggestions?.has('nameJp')}
-      onAcceptSuggestion={() => onAcceptSuggestion?.('nameJp', suggestions?.nameJp)}
-      onDismissSuggestion={() => onDismissSuggestion?.('nameJp')}
     />
     <DetailItem
       label="Rarity"
@@ -96,16 +88,12 @@
       type="select"
       options={rarityOptions}
     />
-    <SuggestionDetailItem
+    <DetailItem
       label="Granblue ID"
       bind:value={editData.granblueId}
       editable={true}
       type="text"
       placeholder="Granblue ID"
-      suggestion={suggestions?.granblueId}
-      dismissedSuggestion={dismissedSuggestions?.has('granblueId')}
-      onAcceptSuggestion={() => onAcceptSuggestion?.('granblueId', suggestions?.granblueId)}
-      onDismissSuggestion={() => onDismissSuggestion?.('granblueId')}
     />
     <DetailItem
       label="Character ID"

--- a/src/lib/features/database/summons/sections/SummonMetadataSection.svelte
+++ b/src/lib/features/database/summons/sections/SummonMetadataSection.svelte
@@ -23,27 +23,19 @@
 
 <DetailsContainer title="Metadata">
   {#if editMode}
-    <SuggestionDetailItem
+    <DetailItem
       label="Name (EN)"
       bind:value={editData.name}
       editable={true}
       type="text"
       placeholder="English name"
-      suggestion={suggestions?.nameEn}
-      dismissedSuggestion={dismissedSuggestions?.has('name')}
-      onAcceptSuggestion={() => onAcceptSuggestion?.('name', suggestions?.nameEn)}
-      onDismissSuggestion={() => onDismissSuggestion?.('name')}
     />
-    <SuggestionDetailItem
+    <DetailItem
       label="Name (JP)"
       bind:value={editData.nameJp}
       editable={true}
       type="text"
       placeholder="日本語名"
-      suggestion={suggestions?.nameJp}
-      dismissedSuggestion={dismissedSuggestions?.has('nameJp')}
-      onAcceptSuggestion={() => onAcceptSuggestion?.('nameJp', suggestions?.nameJp)}
-      onDismissSuggestion={() => onDismissSuggestion?.('nameJp')}
     />
     <DetailItem
       label="Rarity"

--- a/src/lib/features/database/weapons/sections/WeaponMetadataSection.svelte
+++ b/src/lib/features/database/weapons/sections/WeaponMetadataSection.svelte
@@ -23,27 +23,19 @@
 
 <DetailsContainer title="Metadata">
   {#if editMode}
-    <SuggestionDetailItem
+    <DetailItem
       label="Name (EN)"
       bind:value={editData.name}
       editable={true}
       type="text"
       placeholder="English name"
-      suggestion={suggestions?.nameEn}
-      dismissedSuggestion={dismissedSuggestions?.has('name')}
-      onAcceptSuggestion={() => onAcceptSuggestion?.('name', suggestions?.nameEn)}
-      onDismissSuggestion={() => onDismissSuggestion?.('name')}
     />
-    <SuggestionDetailItem
+    <DetailItem
       label="Name (JP)"
       bind:value={editData.nameJp}
       editable={true}
       type="text"
       placeholder="日本語名"
-      suggestion={suggestions?.nameJp}
-      dismissedSuggestion={dismissedSuggestions?.has('nameJp')}
-      onAcceptSuggestion={() => onAcceptSuggestion?.('nameJp', suggestions?.nameJp)}
-      onDismissSuggestion={() => onDismissSuggestion?.('nameJp')}
     />
     <DetailItem
       label="Rarity"


### PR DESCRIPTION
## Summary
- Replaced stale `SuggestionDetailItem` references with `DetailItem` in character, summon, and weapon metadata sections
- `SuggestionDetailItem` was deleted in #451 but these three files weren't updated, causing a runtime crash when editing database entries