### PR TITLE
Add adapter, auth, and cache helper tests

### DIFF
--- a/src/lib/api/adapters/__tests__/artifact.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/artifact.adapter.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ArtifactAdapter } from '../artifact.adapter'
+import { API, EXPECTED } from './fixtures/artifact.fixtures'
+import { mockApiResponse } from './fixtures/helpers'
+
+describe('ArtifactAdapter', () => {
+	let adapter: ArtifactAdapter
+	let originalFetch: typeof global.fetch
+
+	beforeEach(() => {
+		originalFetch = global.fetch
+		adapter = new ArtifactAdapter({ baseURL: 'https://api.example.com' })
+	})
+
+	afterEach(() => {
+		global.fetch = originalFetch
+		vi.clearAllTimers()
+	})
+
+	describe('reference data', () => {
+		it('should unwrap artifacts from response', async () => {
+			global.fetch = mockApiResponse(API.listArtifacts)
+
+			const result = await adapter.listArtifacts()
+
+			expect(result).toEqual(EXPECTED.listArtifacts)
+		})
+
+		it('should unwrap artifactSkills from response', async () => {
+			global.fetch = mockApiResponse(API.listSkills)
+
+			const result = await adapter.listSkills()
+
+			expect(result).toEqual(EXPECTED.listSkills)
+		})
+	})
+
+	describe('slot mapping', () => {
+		beforeEach(() => {
+			global.fetch = mockApiResponse(API.listSkills)
+		})
+
+		it('should map slot 1 to group_i', async () => {
+			await adapter.getSkillsForSlot(1)
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('group=group_i')
+		})
+
+		it('should map slot 2 to group_i', async () => {
+			await adapter.getSkillsForSlot(2)
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('group=group_i')
+		})
+
+		it('should map slot 3 to group_ii', async () => {
+			await adapter.getSkillsForSlot(3)
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('group=group_ii')
+		})
+
+		it('should map slot 4 to group_iii', async () => {
+			await adapter.getSkillsForSlot(4)
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('group=group_iii')
+		})
+
+		it('should throw for invalid slot 5', async () => {
+			await expect(adapter.getSkillsForSlot(5)).rejects.toThrow('Invalid slot number: 5')
+		})
+
+		it('should throw for invalid slot 0', async () => {
+			await expect(adapter.getSkillsForSlot(0)).rejects.toThrow('Invalid slot number: 0')
+		})
+	})
+
+	describe('collection artifacts', () => {
+		it('should handle artifacts response key', async () => {
+			global.fetch = mockApiResponse(API.listCollectionArtifacts)
+
+			const result = await adapter.listCollectionArtifacts('user-1')
+
+			expect(result).toEqual(EXPECTED.listCollectionArtifacts)
+		})
+
+		it('should handle collectionArtifacts response key', async () => {
+			global.fetch = mockApiResponse(API.listCollectionArtifactsAlt)
+
+			const result = await adapter.listCollectionArtifacts('user-1')
+
+			expect(result).toEqual(EXPECTED.listCollectionArtifactsAlt)
+		})
+	})
+
+	describe('grid artifacts', () => {
+		it('should build correct URL and body for createGridArtifact', async () => {
+			global.fetch = mockApiResponse({ id: 'ga-1' })
+
+			await adapter.createGridArtifact({
+				partyId: 'party-1',
+				gridCharacterId: 'gc-1',
+				artifactId: 'art-1',
+				element: 1,
+				level: 3,
+				rerollSlot: 2,
+				proficiency: 1,
+				skill1: 10,
+				skill2: 20,
+				skill3: 30,
+				skill4: 40
+			})
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				'https://api.example.com/parties/party-1/grid_characters/gc-1/artifact',
+				expect.objectContaining({
+					method: 'POST',
+					body: JSON.stringify({
+						grid_artifact: {
+							artifact_id: 'art-1',
+							element: 1,
+							level: 3,
+							reroll_slot: 2,
+							proficiency: 1,
+							skill1: 10,
+							skill2: 20,
+							skill3: 30,
+							skill4: 40
+						}
+					})
+				})
+			)
+		})
+
+		it('should unwrap gridArtifact from sync response', async () => {
+			global.fetch = mockApiResponse(API.syncGridArtifact)
+
+			const result = await adapter.syncGridArtifact('ga-1')
+
+			expect(result).toEqual(EXPECTED.syncGridArtifact)
+			expect(global.fetch).toHaveBeenCalledWith(
+				'https://api.example.com/grid_artifacts/ga-1/sync',
+				expect.objectContaining({ method: 'POST' })
+			)
+		})
+	})
+
+	describe('batch operations', () => {
+		it('should return empty array without fetching for empty batch create', async () => {
+			global.fetch = vi.fn()
+
+			const result = await adapter.createCollectionArtifactsBatch([])
+
+			expect(result).toEqual({ artifacts: [] })
+			expect(global.fetch).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/src/lib/api/adapters/__tests__/base.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/base.adapter.test.ts
@@ -227,9 +227,9 @@ describe('BaseAdapter', () => {
 			const calledUrl = (global.fetch as any).mock.calls[0][0]
 			expect(calledUrl).toContain('query=test')
 			expect(calledUrl).toContain('page=2')
-			expect(calledUrl).toContain('filters=1')
-			expect(calledUrl).toContain('filters=2')
-			expect(calledUrl).toContain('filters=3')
+			// Arrays are serialized as comma-separated values
+			const parsedUrl = new URL(calledUrl)
+			expect(parsedUrl.searchParams.get('filters')).toBe('1,2,3')
 		})
 
 		it('should handle error responses', async () => {
@@ -445,12 +445,12 @@ describe('BaseAdapter', () => {
 
 			// Make first request with caching
 			const result1 = await adapter.testRequest('/cached', {
-				cache: 60000 // 1 minute
+				cacheTime: 60000 // 1 minute
 			})
 
 			// Make second request (should use cache)
 			const result2 = await adapter.testRequest('/cached', {
-				cache: 60000
+				cacheTime: 60000
 			})
 
 			// Only one fetch should have been made
@@ -472,14 +472,14 @@ describe('BaseAdapter', () => {
 			// Make first POST request with cache
 			const result1 = await adapter.testRequest('/data', {
 				method: 'POST',
-				cache: 60000,
+				cacheTime: 60000,
 				body: JSON.stringify({ test: true })
 			})
 
 			// Make second POST request with same body (should use cache)
 			const result2 = await adapter.testRequest('/data', {
 				method: 'POST',
-				cache: 60000,
+				cacheTime: 60000,
 				body: JSON.stringify({ test: true })
 			})
 
@@ -490,7 +490,7 @@ describe('BaseAdapter', () => {
 			// Make POST request with different body (should not use cache)
 			await adapter.testRequest('/data', {
 				method: 'POST',
-				cache: 60000,
+				cacheTime: 60000,
 				body: JSON.stringify({ test: false })
 			})
 
@@ -510,13 +510,13 @@ describe('BaseAdapter', () => {
 			})
 
 			// Make cached request
-			await adapter.testRequest('/cached', { cache: 60000 })
+			await adapter.testRequest('/cached', { cacheTime: 60000 })
 
 			// Clear cache
 			adapter.testClearCache()
 
 			// Make request again (should fetch again)
-			await adapter.testRequest('/cached', { cache: 60000 })
+			await adapter.testRequest('/cached', { cacheTime: 60000 })
 
 			expect(fetchCount).toBe(2)
 		})
@@ -533,15 +533,15 @@ describe('BaseAdapter', () => {
 			})
 
 			// Cache multiple endpoints
-			await adapter.testRequest('/users/1', { cache: 60000 })
-			await adapter.testRequest('/posts/1', { cache: 60000 })
+			await adapter.testRequest('/users/1', { cacheTime: 60000 })
+			await adapter.testRequest('/posts/1', { cacheTime: 60000 })
 
 			// Clear only user cache
 			adapter.testClearCache('users')
 
 			// Users should refetch, posts should use cache
-			await adapter.testRequest('/users/1', { cache: 60000 })
-			await adapter.testRequest('/posts/1', { cache: 60000 })
+			await adapter.testRequest('/users/1', { cacheTime: 60000 })
+			await adapter.testRequest('/posts/1', { cacheTime: 60000 })
 
 			// 3 total fetches: initial 2 + 1 refetch for users
 			expect(fetchCount).toBe(3)

--- a/src/lib/api/adapters/__tests__/collection.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/collection.adapter.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { CollectionAdapter } from '../collection.adapter'
+import { API, EXPECTED } from './fixtures/collection.fixtures'
+import { mockApiResponse } from './fixtures/helpers'
+
+describe('CollectionAdapter', () => {
+	let adapter: CollectionAdapter
+	let originalFetch: typeof global.fetch
+
+	beforeEach(() => {
+		originalFetch = global.fetch
+		adapter = new CollectionAdapter({ baseURL: 'https://api.example.com' })
+	})
+
+	afterEach(() => {
+		global.fetch = originalFetch
+		vi.clearAllTimers()
+	})
+
+	describe('characters', () => {
+		it('should transform listCharacters response', async () => {
+			global.fetch = mockApiResponse(API.listCharacters)
+
+			const result = await adapter.listCharacters('user-1')
+
+			expect(result).toEqual(EXPECTED.listCharacters)
+		})
+
+		it('should return empty without fetching for addCharacters with empty input', async () => {
+			global.fetch = vi.fn()
+
+			const result = await adapter.addCharacters([])
+
+			expect(result).toEqual([])
+			expect(global.fetch).not.toHaveBeenCalled()
+		})
+
+		it('should return { deleted: 0 } without fetching for removeCharactersBatch with empty ids', async () => {
+			global.fetch = vi.fn()
+
+			const result = await adapter.removeCharactersBatch([])
+
+			expect(result).toEqual({ deleted: 0 })
+			expect(global.fetch).not.toHaveBeenCalled()
+		})
+
+		it('should fetch single page for getCollectedCharacterIds', async () => {
+			global.fetch = mockApiResponse(API.collectedCharactersSinglePage)
+
+			const result = await adapter.getCollectedCharacterIds('user-1')
+
+			expect(result).toEqual(EXPECTED.collectedCharacterIdsSinglePage)
+			expect(global.fetch).toHaveBeenCalledTimes(1)
+		})
+
+		it('should fetch all pages for getCollectedCharacterIds', async () => {
+			let callCount = 0
+			global.fetch = vi.fn().mockImplementation(async () => {
+				callCount++
+				if (callCount === 1) {
+					return {
+						ok: true,
+						json: async () => API.collectedCharactersPage1
+					}
+				}
+				return {
+					ok: true,
+					json: async () => API.collectedCharactersPage2
+				}
+			})
+
+			const result = await adapter.getCollectedCharacterIds('user-1')
+
+			expect(result).toEqual(EXPECTED.collectedCharacterIdsMultiPage)
+			expect(global.fetch).toHaveBeenCalledTimes(2)
+		})
+	})
+
+	describe('weapons', () => {
+		it('should handle weapons response key in listWeapons', async () => {
+			global.fetch = mockApiResponse(API.listWeapons)
+
+			const result = await adapter.listWeapons('user-1')
+
+			expect(result.results).toEqual(EXPECTED.listWeapons.results)
+		})
+
+		it('should handle collectionWeapons response key in listWeapons', async () => {
+			global.fetch = mockApiResponse(API.listWeaponsAlt)
+
+			const result = await adapter.listWeapons('user-1')
+
+			expect(result.results).toEqual(EXPECTED.listWeaponsAlt.results)
+		})
+
+		it('should expand quantity in addWeapons', async () => {
+			global.fetch = mockApiResponse({
+				weapons: [{ id: 'cw-1' }, { id: 'cw-2' }, { id: 'cw-3' }],
+				meta: { created: 3, errors: [] }
+			})
+
+			await adapter.addWeapons([{ weaponId: 'w1', quantity: 3 } as any])
+
+			const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+			// BaseAdapter transforms collectionWeapons → collection_weapons
+			const items = body.collection_weapons
+			expect(items).toHaveLength(3)
+			items.forEach((item: any) => {
+				expect(item.quantity).toBeUndefined()
+				expect(item.weapon_id).toBe('w1')
+			})
+		})
+
+		it('should handle mixed quantities in addWeapons', async () => {
+			global.fetch = mockApiResponse({
+				weapons: [{ id: 'cw-1' }, { id: 'cw-2' }, { id: 'cw-3' }, { id: 'cw-4' }],
+				meta: { created: 4, errors: [] }
+			})
+
+			await adapter.addWeapons([
+				{ weaponId: 'w1', quantity: 3 } as any,
+				{ weaponId: 'w2' } as any // quantity defaults to 1
+			])
+
+			const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+			const items = body.collection_weapons
+			expect(items).toHaveLength(4)
+		})
+
+		it('should return empty without fetching for addWeapons with empty input', async () => {
+			global.fetch = vi.fn()
+
+			const result = await adapter.addWeapons([])
+
+			expect(result).toEqual([])
+			expect(global.fetch).not.toHaveBeenCalled()
+		})
+
+		it('should return { deleted: 0 } without fetching for removeWeaponsBatch with empty ids', async () => {
+			global.fetch = vi.fn()
+
+			const result = await adapter.removeWeaponsBatch([])
+
+			expect(result).toEqual({ deleted: 0 })
+			expect(global.fetch).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('summons', () => {
+		it('should handle summons response key in listSummons', async () => {
+			global.fetch = mockApiResponse(API.listSummons)
+
+			const result = await adapter.listSummons('user-1')
+
+			expect(result.results).toEqual(EXPECTED.listSummons.results)
+		})
+
+		it('should handle collectionSummons response key in listSummons', async () => {
+			global.fetch = mockApiResponse(API.listSummonsAlt)
+
+			const result = await adapter.listSummons('user-1')
+
+			expect(result.results).toEqual(EXPECTED.listSummonsAlt.results)
+		})
+
+		it('should expand quantity in addSummons', async () => {
+			global.fetch = mockApiResponse({
+				summons: [{ id: 'cs-1' }, { id: 'cs-2' }],
+				meta: { created: 2, errors: [] }
+			})
+
+			await adapter.addSummons([{ summonId: 's1', quantity: 2 } as any])
+
+			const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+			const items = body.collection_summons
+			expect(items).toHaveLength(2)
+			items.forEach((item: any) => {
+				expect(item.quantity).toBeUndefined()
+			})
+		})
+
+		it('should return empty without fetching for addSummons with empty input', async () => {
+			global.fetch = vi.fn()
+
+			const result = await adapter.addSummons([])
+
+			expect(result).toEqual([])
+			expect(global.fetch).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('job accessories', () => {
+		it('should unwrap jobAccessories from listJobAccessories response', async () => {
+			global.fetch = mockApiResponse(API.listJobAccessories)
+
+			const result = await adapter.listJobAccessories()
+
+			expect(result).toEqual(EXPECTED.listJobAccessories)
+		})
+	})
+})

--- a/src/lib/api/adapters/__tests__/crew.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/crew.adapter.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { CrewAdapter } from '../crew.adapter'
+import { API, EXPECTED } from './fixtures/crew.fixtures'
+import { mockApiResponse } from './fixtures/helpers'
+
+describe('CrewAdapter', () => {
+	let adapter: CrewAdapter
+	let originalFetch: typeof global.fetch
+
+	beforeEach(() => {
+		originalFetch = global.fetch
+		adapter = new CrewAdapter({ baseURL: 'https://api.example.com' })
+	})
+
+	afterEach(() => {
+		global.fetch = originalFetch
+		vi.clearAllTimers()
+	})
+
+	describe('crew operations', () => {
+		it('should unwrap crew from getMyCrew response', async () => {
+			global.fetch = mockApiResponse(API.getMyCrew)
+
+			const result = await adapter.getMyCrew()
+
+			expect(result).toEqual(EXPECTED.getMyCrew)
+		})
+
+		it('should send page and per_page params in getSharedParties', async () => {
+			global.fetch = mockApiResponse(API.getSharedParties)
+
+			await adapter.getSharedParties(2, 20)
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('page=2')
+			expect(url).toContain('per_page=20')
+		})
+
+		it('should clear dual cache on leave', async () => {
+			global.fetch = mockApiResponse({})
+			const clearSpy = vi.spyOn(adapter as any, 'clearCache')
+
+			await adapter.leave()
+
+			expect(clearSpy).toHaveBeenCalledWith('/crew')
+			expect(clearSpy).toHaveBeenCalledWith('/crew/members')
+		})
+
+		it('should send user_id in transferCaptain body', async () => {
+			global.fetch = mockApiResponse(API.transferCaptain)
+
+			await adapter.transferCaptain('crew-1', 'user-2')
+
+			const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+			expect(body.user_id).toBe('user-2')
+		})
+	})
+
+	describe('members', () => {
+		it('should not send filter param for default active members', async () => {
+			global.fetch = mockApiResponse(API.getMembers)
+
+			await adapter.getMembers()
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).not.toContain('filter')
+		})
+
+		it('should send filter param for retired members', async () => {
+			global.fetch = mockApiResponse(API.getMembers)
+
+			await adapter.getMembers('retired')
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('filter=retired')
+		})
+
+		it('should build full query string for getRoster', async () => {
+			global.fetch = mockApiResponse(API.getRoster)
+
+			await adapter.getRoster({
+				characterIds: ['c1', 'c2'],
+				weaponIds: ['w1'],
+				summonIds: ['s1']
+			})
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('character_ids')
+			expect(url).toContain('c1')
+			expect(url).toContain('c2')
+			expect(url).toContain('weapon_ids')
+			expect(url).toContain('w1')
+			expect(url).toContain('summon_ids')
+			expect(url).toContain('s1')
+		})
+
+		it('should send no query string for empty getRoster', async () => {
+			global.fetch = mockApiResponse(API.getRoster)
+
+			await adapter.getRoster({})
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('/crew/roster')
+			expect(url).not.toContain('?')
+		})
+	})
+
+	describe('invitations', () => {
+		it('should send user_id and unwrap invitation from sendInvitation', async () => {
+			global.fetch = mockApiResponse(API.sendInvitation)
+
+			const result = await adapter.sendInvitation('crew-1', 'user-2')
+
+			const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+			expect(body.user_id).toBe('user-2')
+			expect(result).toEqual(EXPECTED.sendInvitation)
+		})
+
+		it('should clear dual cache on acceptInvitation', async () => {
+			global.fetch = mockApiResponse(API.acceptInvitation)
+			const clearSpy = vi.spyOn(adapter as any, 'clearCache')
+
+			await adapter.acceptInvitation('inv-1')
+
+			expect(clearSpy).toHaveBeenCalledWith('/crew')
+			expect(clearSpy).toHaveBeenCalledWith('/invitations/pending')
+		})
+	})
+
+	describe('phantom players', () => {
+		it('should unwrap phantomPlayer from createPhantom response', async () => {
+			global.fetch = mockApiResponse(API.createPhantom)
+
+			const result = await adapter.createPhantom('crew-1', { name: 'Ghost' } as any)
+
+			expect(result).toEqual(EXPECTED.createPhantom)
+		})
+
+		it('should unwrap phantomPlayers from bulkCreatePhantoms response', async () => {
+			global.fetch = mockApiResponse(API.bulkCreatePhantoms)
+
+			const result = await adapter.bulkCreatePhantoms('crew-1', [{ name: 'Ghost1' }, { name: 'Ghost2' }] as any)
+
+			expect(result).toEqual(EXPECTED.bulkCreatePhantoms)
+		})
+
+		it('should clear dual cache on declinePhantomClaim', async () => {
+			global.fetch = mockApiResponse(API.declinePhantomClaim)
+			const clearSpy = vi.spyOn(adapter as any, 'clearCache')
+
+			await adapter.declinePhantomClaim('crew-1', 'p1')
+
+			expect(clearSpy).toHaveBeenCalledWith('/crew/members')
+			expect(clearSpy).toHaveBeenCalledWith('/pending_phantom_claims')
+		})
+
+		it('should unwrap phantomClaims from getPendingPhantomClaims', async () => {
+			global.fetch = mockApiResponse(API.getPendingPhantomClaims)
+
+			const result = await adapter.getPendingPhantomClaims()
+
+			expect(result).toEqual(EXPECTED.getPendingPhantomClaims)
+		})
+	})
+})

--- a/src/lib/api/adapters/__tests__/fixtures/artifact.fixtures.ts
+++ b/src/lib/api/adapters/__tests__/fixtures/artifact.fixtures.ts
@@ -1,0 +1,50 @@
+/**
+ * Artifact adapter test fixtures
+ *
+ * API = what Rails sends (snake_case, from ArtifactBlueprint)
+ * EXPECTED = what callers receive (camelCase, post-adapter transform)
+ */
+
+import { apiMeta } from './helpers'
+
+// What the Rails API returns
+export const API = {
+	listArtifacts: {
+		artifacts: [{ id: 'a1', name: 'Sword' }]
+	},
+	listSkills: {
+		artifact_skills: [{ id: 's1', name: 'ATK Up' }]
+	},
+	listCollectionArtifacts: {
+		artifacts: [{ id: 'ca-1' }],
+		meta: apiMeta()
+	},
+	listCollectionArtifactsAlt: {
+		collection_artifacts: [{ id: 'ca-2' }],
+		meta: apiMeta()
+	},
+	syncGridArtifact: {
+		grid_artifact: { id: 'ga-1', artifact_id: 'art-1' }
+	}
+}
+
+// What the adapter returns to callers
+export const EXPECTED = {
+	listArtifacts: [{ id: 'a1', name: 'Sword' }],
+	listSkills: [{ id: 's1', name: 'ATK Up' }],
+	listCollectionArtifacts: {
+		results: [{ id: 'ca-1' }],
+		page: 1,
+		total: 1,
+		totalPages: 1,
+		perPage: 20
+	},
+	listCollectionArtifactsAlt: {
+		results: [{ id: 'ca-2' }],
+		page: 1,
+		total: 1,
+		totalPages: 1,
+		perPage: 20
+	},
+	syncGridArtifact: { id: 'ga-1', artifactId: 'art-1' }
+}

--- a/src/lib/api/adapters/__tests__/fixtures/collection.fixtures.ts
+++ b/src/lib/api/adapters/__tests__/fixtures/collection.fixtures.ts
@@ -1,0 +1,65 @@
+/**
+ * Collection adapter test fixtures
+ *
+ * API = what Rails sends (snake_case, from CollectionBlueprints)
+ * EXPECTED = what callers receive (camelCase, post-adapter transform)
+ */
+
+import { apiMeta } from './helpers'
+
+// What the Rails API returns
+export const API = {
+	listCharacters: {
+		characters: [{ id: 'cc-1', character: { id: 'c1' } }],
+		meta: apiMeta()
+	},
+	listWeapons: {
+		weapons: [{ id: 'cw-1' }],
+		meta: apiMeta()
+	},
+	listWeaponsAlt: {
+		collection_weapons: [{ id: 'cw-2' }],
+		meta: apiMeta()
+	},
+	listSummons: {
+		summons: [{ id: 'cs-1' }],
+		meta: apiMeta()
+	},
+	listSummonsAlt: {
+		collection_summons: [{ id: 'cs-2' }],
+		meta: apiMeta()
+	},
+	listJobAccessories: {
+		job_accessories: [{ id: 'ja-1', name: 'Shield' }]
+	},
+	collectedCharactersSinglePage: {
+		characters: [{ character: { id: 'c1' } }, { character: { id: 'c2' } }],
+		meta: apiMeta({ count: 2, per_page: 100 })
+	},
+	collectedCharactersPage1: {
+		characters: [{ character: { id: 'c1' } }, { character: { id: 'c2' } }],
+		meta: apiMeta({ count: 4, total_pages: 2, per_page: 2 })
+	},
+	collectedCharactersPage2: {
+		characters: [{ character: { id: 'c3' } }, { character: { id: 'c4' } }],
+		meta: apiMeta({ count: 4, total_pages: 2, per_page: 2, current_page: 2 })
+	}
+}
+
+// What the adapter returns to callers
+export const EXPECTED = {
+	listCharacters: {
+		results: [{ id: 'cc-1', character: { id: 'c1' } }],
+		page: 1,
+		total: 1,
+		totalPages: 1,
+		perPage: 20
+	},
+	listWeapons: { results: [{ id: 'cw-1' }] },
+	listWeaponsAlt: { results: [{ id: 'cw-2' }] },
+	listSummons: { results: [{ id: 'cs-1' }] },
+	listSummonsAlt: { results: [{ id: 'cs-2' }] },
+	listJobAccessories: [{ id: 'ja-1', name: 'Shield' }],
+	collectedCharacterIdsSinglePage: ['c1', 'c2'],
+	collectedCharacterIdsMultiPage: ['c1', 'c2', 'c3', 'c4']
+}

--- a/src/lib/api/adapters/__tests__/fixtures/crew.fixtures.ts
+++ b/src/lib/api/adapters/__tests__/fixtures/crew.fixtures.ts
@@ -1,0 +1,54 @@
+/**
+ * Crew adapter test fixtures
+ *
+ * API = what Rails sends (snake_case, from CrewBlueprint + PhantomPlayerBlueprint)
+ * EXPECTED = what callers receive (camelCase, post-adapter transform)
+ */
+
+// What the Rails API returns
+export const API = {
+	getMyCrew: {
+		crew: { id: 'crew-1', name: 'Test Crew' }
+	},
+	getSharedParties: {
+		parties: [{ id: 'p1' }],
+		meta: { page: 2, total_pages: 3, count: 50, per_page: 20 }
+	},
+	getMembers: {
+		members: [],
+		phantom_players: []
+	},
+	getRoster: {
+		members: []
+	},
+	transferCaptain: {
+		crew: { id: 'crew-1' }
+	},
+	sendInvitation: {
+		invitation: { id: 'inv-1', status: 'pending' }
+	},
+	acceptInvitation: {
+		membership: { id: 'mem-1' }
+	},
+	createPhantom: {
+		phantom_player: { id: 'p1', name: 'Ghost' }
+	},
+	bulkCreatePhantoms: {
+		phantom_players: [{ id: 'p1' }, { id: 'p2' }]
+	},
+	declinePhantomClaim: {
+		phantom_player: { id: 'p1' }
+	},
+	getPendingPhantomClaims: {
+		phantom_claims: [{ id: 'p1', name: 'Ghost' }]
+	}
+}
+
+// What the adapter returns to callers
+export const EXPECTED = {
+	getMyCrew: { id: 'crew-1', name: 'Test Crew' },
+	sendInvitation: { id: 'inv-1', status: 'pending' },
+	createPhantom: { id: 'p1', name: 'Ghost' },
+	bulkCreatePhantoms: [{ id: 'p1' }, { id: 'p2' }],
+	getPendingPhantomClaims: [{ id: 'p1', name: 'Ghost' }]
+}

--- a/src/lib/api/adapters/__tests__/fixtures/gw.fixtures.ts
+++ b/src/lib/api/adapters/__tests__/fixtures/gw.fixtures.ts
@@ -1,0 +1,66 @@
+/**
+ * GW (Guild War) adapter test fixtures
+ *
+ * API = what Rails sends (snake_case, from GwEventBlueprint + CrewGwParticipationBlueprint)
+ * EXPECTED = what callers receive (camelCase, post-adapter transform)
+ */
+
+// What the Rails API returns
+export const API = {
+	getEvents: {
+		gw_events: [{ id: 'gw-1', event_number: 78 }]
+	},
+	getEvent: {
+		gw_event: { id: 'gw-1', event_number: 78 }
+	},
+	createEvent: {
+		gw_event: { id: 'gw-new' }
+	},
+	getEventWithParticipation: {
+		gw_event: { id: 'gw-1' },
+		crew_gw_participation: { id: 'part-1' },
+		members_during_event: [{ id: 'm1', retired: false }],
+		phantom_players: [{ id: 'p1', name: 'Ghost', retired: true }]
+	},
+	getEventWithParticipationEmpty: {
+		gw_event: null,
+		crew_gw_participation: null
+		// members_during_event and phantom_players missing
+	},
+	joinEvent: {
+		participation: { id: 'part-1' }
+	},
+	getParticipation: {
+		crew_gw_participation: { id: 'part-1', crew_scores: [] }
+	},
+	addIndividualScore: {
+		individual_score: { id: 'is-1' }
+	},
+	batchAddIndividualScores: {
+		individual_scores: [{ id: 'is-1' }]
+	},
+	addCrewScore: {
+		crew_score: { id: 'cs-1' }
+	}
+}
+
+// What the adapter returns to callers
+export const EXPECTED = {
+	getEvents: [{ id: 'gw-1', eventNumber: 78 }],
+	getEvent: { id: 'gw-1', eventNumber: 78 },
+	createEvent: { id: 'gw-new' },
+	getEventWithParticipation: {
+		gwEvent: { id: 'gw-1' },
+		participation: { id: 'part-1' },
+		membersDuringEvent: [{ id: 'm1', retired: false }],
+		phantomPlayers: [{ id: 'p1', name: 'Ghost', retired: true }]
+	},
+	getEventWithParticipationEmpty: {
+		gwEvent: null,
+		participation: null,
+		membersDuringEvent: [],
+		phantomPlayers: []
+	},
+	joinEvent: { id: 'part-1' },
+	getParticipation: { id: 'part-1', crewScores: [] }
+}

--- a/src/lib/api/adapters/__tests__/fixtures/helpers.ts
+++ b/src/lib/api/adapters/__tests__/fixtures/helpers.ts
@@ -1,0 +1,31 @@
+import { vi } from 'vitest'
+
+/** Creates a mock fetch that returns the given data as JSON */
+export function mockApiResponse(data: any) {
+	return vi.fn().mockResolvedValue({
+		ok: true,
+		json: async () => data
+	})
+}
+
+/**
+ * Standard pagination meta matching Rails pagination_meta() output.
+ * Rails returns { count, total_pages, per_page } from api_controller.rb.
+ * Some controllers also include current_page.
+ */
+export function apiMeta(
+	overrides?: Partial<{
+		count: number
+		total_pages: number
+		per_page: number
+		current_page: number
+	}>
+) {
+	return {
+		count: 1,
+		total_pages: 1,
+		per_page: 20,
+		current_page: 1,
+		...overrides
+	}
+}

--- a/src/lib/api/adapters/__tests__/fixtures/job.fixtures.ts
+++ b/src/lib/api/adapters/__tests__/fixtures/job.fixtures.ts
@@ -1,0 +1,46 @@
+/**
+ * Job adapter test fixtures
+ *
+ * API = what Rails sends (snake_case, from JobBlueprint + SearchController)
+ * EXPECTED = what callers receive (camelCase, post-adapter transform)
+ */
+
+// What the Rails API returns
+export const API = {
+	searchSkills: {
+		results: [{ id: 'skill-1', name: { en: 'Rage' } }],
+		meta: { count: 42, total_pages: 5, per_page: 10 }
+	},
+	searchSkillsEmpty: {
+		results: [],
+		meta: { count: 0, total_pages: 1, per_page: 10 }
+	},
+	searchSkillsNoMeta: {
+		results: []
+	}
+}
+
+// What the adapter returns to callers
+export const EXPECTED = {
+	searchSkills: {
+		results: [{ id: 'skill-1', name: { en: 'Rage' } }],
+		total: 42,
+		page: 1,
+		totalPages: 5,
+		meta: { count: 42, page: 1, perPage: 10, totalPages: 5 }
+	},
+	searchSkillsEmpty: {
+		results: [],
+		total: 0,
+		page: 1,
+		totalPages: 1,
+		meta: { count: 0, page: 1, perPage: 10, totalPages: 1 }
+	},
+	searchSkillsNoMeta: {
+		results: [],
+		total: 0,
+		page: 1,
+		totalPages: 1,
+		meta: undefined
+	}
+}

--- a/src/lib/api/adapters/__tests__/fixtures/raid.fixtures.ts
+++ b/src/lib/api/adapters/__tests__/fixtures/raid.fixtures.ts
@@ -1,0 +1,32 @@
+/**
+ * Raid adapter test fixtures
+ *
+ * API = what Rails sends (snake_case, from RaidBlueprint)
+ * EXPECTED = what callers receive (camelCase, post-BaseAdapter transform)
+ */
+
+// What the Rails API returns
+export const API = {
+	downloadStatus: {
+		status: 'completed',
+		progress: 100,
+		images_downloaded: 4,
+		images_total: 4,
+		raid_id: 'raid-1',
+		slug: 'proto-bahamut',
+		updated_at: '2024-01-01T00:00:00Z'
+	}
+}
+
+// What the adapter returns to callers
+export const EXPECTED = {
+	downloadStatus: {
+		status: 'completed',
+		progress: 100,
+		imagesDownloaded: 4,
+		imagesTotal: 4,
+		raidId: 'raid-1',
+		slug: 'proto-bahamut',
+		updatedAt: '2024-01-01T00:00:00Z'
+	}
+}

--- a/src/lib/api/adapters/__tests__/grid.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/grid.adapter.test.ts
@@ -111,7 +111,7 @@ describe('GridAdapter', () => {
 		it('should create a grid weapon', async () => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => mockGridWeapon
+				json: async () => ({ gridWeapon: mockGridWeapon })
 			})
 
 			const result = await adapter.createWeapon({
@@ -127,10 +127,12 @@ describe('GridAdapter', () => {
 				expect.objectContaining({
 					method: 'POST',
 					body: JSON.stringify({
-						party_id: 'party-1',
-						weapon_id: 'weapon-1',
-						position: 1,
-						mainhand: true
+						weapon: {
+							party_id: 'party-1',
+							weapon_id: 'weapon-1',
+							position: 1,
+							mainhand: true
+						}
 					})
 				})
 			)
@@ -139,7 +141,7 @@ describe('GridAdapter', () => {
 		it('should update a grid weapon', async () => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => ({ ...mockGridWeapon, uncapLevel: 6 })
+				json: async () => ({ gridWeapon: { ...mockGridWeapon, uncapLevel: 6 } })
 			})
 
 			const result = await adapter.updateWeapon('gw-1', {
@@ -151,7 +153,7 @@ describe('GridAdapter', () => {
 				'https://api.example.com/grid_weapons/gw-1',
 				expect.objectContaining({
 					method: 'PUT',
-					body: JSON.stringify({ uncap_level: 6 })
+					body: JSON.stringify({ weapon: { uncap_level: 6 } })
 				})
 			)
 		})
@@ -167,14 +169,11 @@ describe('GridAdapter', () => {
 				partyId: 'party-1'
 			})
 
+			// ID-based delete uses REST-style URL with no body
 			expect(global.fetch).toHaveBeenCalledWith(
-				'https://api.example.com/grid_weapons',
+				'https://api.example.com/grid_weapons/gw-1',
 				expect.objectContaining({
-					method: 'DELETE',
-					body: JSON.stringify({
-						id: 'gw-1',
-						party_id: 'party-1'
-					})
+					method: 'DELETE'
 				})
 			)
 		})
@@ -182,7 +181,7 @@ describe('GridAdapter', () => {
 		it('should update weapon uncap level', async () => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => ({ ...mockGridWeapon, uncapLevel: 6 })
+				json: async () => ({ gridWeapon: { ...mockGridWeapon, uncapLevel: 6 } })
 			})
 
 			const result = await adapter.updateWeaponUncap({
@@ -198,10 +197,12 @@ describe('GridAdapter', () => {
 				expect.objectContaining({
 					method: 'POST',
 					body: JSON.stringify({
-						id: 'gw-1',
-						party_id: 'party-1',
-						uncap_level: 6,
-						transcendence_step: 1
+						weapon: {
+							id: 'gw-1',
+							party_id: 'party-1',
+							uncap_level: 6,
+							transcendence_step: 1
+						}
 					})
 				})
 			)
@@ -210,7 +211,7 @@ describe('GridAdapter', () => {
 		it('should resolve weapon conflicts', async () => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => mockGridWeapon
+				json: async () => ({ gridWeapon: mockGridWeapon })
 			})
 
 			const result = await adapter.resolveWeaponConflict({
@@ -226,10 +227,12 @@ describe('GridAdapter', () => {
 				expect.objectContaining({
 					method: 'POST',
 					body: JSON.stringify({
-						party_id: 'party-1',
-						incoming_id: 'weapon-2',
-						position: 1,
-						conflicting_ids: ['gw-1']
+						resolve: {
+							party_id: 'party-1',
+							incoming_id: 'weapon-2',
+							position: 1,
+							conflicting_ids: ['gw-1']
+						}
 					})
 				})
 			)
@@ -238,7 +241,7 @@ describe('GridAdapter', () => {
 		it('should update weapon position', async () => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => ({ ...mockGridWeapon, position: 2 })
+				json: async () => ({ gridWeapon: { ...mockGridWeapon, position: 2 } })
 			})
 
 			const result = await adapter.updateWeaponPosition({
@@ -292,7 +295,7 @@ describe('GridAdapter', () => {
 		it('should create a grid character', async () => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => mockGridCharacter
+				json: async () => ({ gridCharacter: mockGridCharacter })
 			})
 
 			const result = await adapter.createCharacter({
@@ -307,9 +310,11 @@ describe('GridAdapter', () => {
 				expect.objectContaining({
 					method: 'POST',
 					body: JSON.stringify({
-						party_id: 'party-1',
-						character_id: 'char-1',
-						position: 1
+						character: {
+							party_id: 'party-1',
+							character_id: 'char-1',
+							position: 1
+						}
 					})
 				})
 			)
@@ -318,7 +323,7 @@ describe('GridAdapter', () => {
 		it('should update character position', async () => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => ({ ...mockGridCharacter, position: 2 })
+				json: async () => ({ gridCharacter: { ...mockGridCharacter, position: 2 } })
 			})
 
 			const result = await adapter.updateCharacterPosition({
@@ -372,7 +377,7 @@ describe('GridAdapter', () => {
 		it('should create a grid summon', async () => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => mockGridSummon
+				json: async () => ({ gridSummon: mockGridSummon })
 			})
 
 			const result = await adapter.createSummon({
@@ -388,10 +393,12 @@ describe('GridAdapter', () => {
 				expect.objectContaining({
 					method: 'POST',
 					body: JSON.stringify({
-						party_id: 'party-1',
-						summon_id: 'summon-1',
-						position: 1,
-						quick_summon: true
+						summon: {
+							party_id: 'party-1',
+							summon_id: 'summon-1',
+							position: 1,
+							quick_summon: true
+						}
 					})
 				})
 			)
@@ -426,7 +433,7 @@ describe('GridAdapter', () => {
 		it('should update summon position', async () => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => ({ ...mockGridSummon, position: 2 })
+				json: async () => ({ gridSummon: { ...mockGridSummon, position: 2 } })
 			})
 
 			const result = await adapter.updateSummonPosition({

--- a/src/lib/api/adapters/__tests__/gw.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/gw.adapter.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { GwAdapter } from '../gw.adapter'
+import { API, EXPECTED } from './fixtures/gw.fixtures'
+import { mockApiResponse } from './fixtures/helpers'
+
+describe('GwAdapter', () => {
+	let adapter: GwAdapter
+	let originalFetch: typeof global.fetch
+
+	beforeEach(() => {
+		originalFetch = global.fetch
+		adapter = new GwAdapter({ baseURL: 'https://api.example.com' })
+	})
+
+	afterEach(() => {
+		global.fetch = originalFetch
+		vi.clearAllTimers()
+	})
+
+	describe('events', () => {
+		it('should unwrap gwEvents from getEvents response', async () => {
+			global.fetch = mockApiResponse(API.getEvents)
+
+			const result = await adapter.getEvents()
+
+			expect(result).toEqual(EXPECTED.getEvents)
+		})
+
+		it('should unwrap gwEvent from getEvent response', async () => {
+			global.fetch = mockApiResponse(API.getEvent)
+
+			const result = await adapter.getEvent('gw-1')
+
+			expect(result).toEqual(EXPECTED.getEvent)
+		})
+
+		it('should wrap body in gw_event for createEvent', async () => {
+			global.fetch = mockApiResponse(API.createEvent)
+			const clearSpy = vi.spyOn(adapter as any, 'clearCache')
+
+			await adapter.createEvent({ event_number: 79 } as any)
+
+			const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+			expect(body.gw_event).toBeDefined()
+			expect(clearSpy).toHaveBeenCalledWith('/gw_events')
+		})
+	})
+
+	describe('participation', () => {
+		it('should map getEventWithParticipation response', async () => {
+			global.fetch = mockApiResponse(API.getEventWithParticipation)
+
+			const result = await adapter.getEventWithParticipation('gw-1')
+
+			expect(result).toEqual(EXPECTED.getEventWithParticipation)
+		})
+
+		it('should default missing arrays to empty in getEventWithParticipation', async () => {
+			global.fetch = mockApiResponse(API.getEventWithParticipationEmpty)
+
+			const result = await adapter.getEventWithParticipation('gw-99')
+
+			expect(result).toEqual(EXPECTED.getEventWithParticipationEmpty)
+		})
+
+		it('should use number param in getEventWithParticipation URL', async () => {
+			global.fetch = mockApiResponse(API.getEventWithParticipationEmpty)
+
+			await adapter.getEventWithParticipation(78)
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('/crew/gw_participations/by_event/78')
+		})
+
+		it('should unwrap participation from joinEvent and clear cache', async () => {
+			global.fetch = mockApiResponse(API.joinEvent)
+			const clearSpy = vi.spyOn(adapter as any, 'clearCache')
+
+			const result = await adapter.joinEvent('gw-1')
+
+			expect(result).toEqual(EXPECTED.joinEvent)
+			expect(clearSpy).toHaveBeenCalledWith('/crew/gw_participations')
+		})
+
+		it('should unwrap crewGwParticipation from getParticipation', async () => {
+			global.fetch = mockApiResponse(API.getParticipation)
+
+			const result = await adapter.getParticipation('part-1')
+
+			expect(result).toEqual(EXPECTED.getParticipation)
+		})
+	})
+
+	describe('scores', () => {
+		it('should POST addIndividualScoreByEvent to correct URL', async () => {
+			global.fetch = mockApiResponse(API.addIndividualScore)
+
+			await adapter.addIndividualScoreByEvent('gw-1', { round: 1, score: 100000 } as any)
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('/crew/gw_events/gw-1/individual_scores')
+			expect((global.fetch as any).mock.calls[0][1].method).toBe('POST')
+		})
+
+		it('should POST batchAddIndividualScoresByEvent to correct URL', async () => {
+			global.fetch = mockApiResponse(API.batchAddIndividualScores)
+
+			await adapter.batchAddIndividualScoresByEvent('gw-1', { scores: [] } as any)
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('/crew/gw_events/gw-1/individual_scores/batch')
+			expect((global.fetch as any).mock.calls[0][1].method).toBe('POST')
+		})
+
+		it('should wrap body in crew_score for addCrewScore and clear participation cache', async () => {
+			global.fetch = mockApiResponse(API.addCrewScore)
+			const clearSpy = vi.spyOn(adapter as any, 'clearCache')
+
+			await adapter.addCrewScore('part-1', { round: 1, score: 500000 } as any)
+
+			const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+			expect(body.crew_score).toBeDefined()
+			expect(clearSpy).toHaveBeenCalledWith('/crew/gw_participations/part-1')
+		})
+	})
+})

--- a/src/lib/api/adapters/__tests__/job.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/job.adapter.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { JobAdapter } from '../job.adapter'
+import { API, EXPECTED } from './fixtures/job.fixtures'
+import { mockApiResponse } from './fixtures/helpers'
+
+describe('JobAdapter', () => {
+	let adapter: JobAdapter
+	let originalFetch: typeof global.fetch
+
+	beforeEach(() => {
+		originalFetch = global.fetch
+		adapter = new JobAdapter({ baseURL: 'https://api.example.com' })
+	})
+
+	afterEach(() => {
+		global.fetch = originalFetch
+		vi.clearAllTimers()
+	})
+
+	describe('searchSkills', () => {
+		it('should send full search params with jobId mapped to job', async () => {
+			global.fetch = mockApiResponse(API.searchSkillsEmpty)
+
+			await adapter.searchSkills({
+				query: 'rage',
+				jobId: 'job-1',
+				page: 2,
+				locale: 'ja',
+				filters: { group: 1 }
+			})
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				'https://api.example.com/search/job_skills',
+				expect.objectContaining({
+					method: 'POST',
+					body: JSON.stringify({
+						search: {
+							query: 'rage',
+							job: 'job-1',
+							page: 2,
+							locale: 'ja',
+							filters: { group: 1 }
+						}
+					})
+				})
+			)
+		})
+
+		it('should use defaults for optional params', async () => {
+			global.fetch = mockApiResponse({ results: [], meta: {} })
+
+			await adapter.searchSkills({ jobId: 'job-1' })
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				'https://api.example.com/search/job_skills',
+				expect.objectContaining({
+					body: JSON.stringify({
+						search: {
+							query: '',
+							job: 'job-1',
+							page: 1,
+							locale: 'en',
+							filters: {}
+						}
+					})
+				})
+			)
+		})
+
+		it('should transform meta response fields correctly', async () => {
+			global.fetch = mockApiResponse(API.searchSkills)
+
+			const result = await adapter.searchSkills({ jobId: 'job-1' })
+
+			expect(result.total).toBe(EXPECTED.searchSkills.total)
+			expect(result.page).toBe(EXPECTED.searchSkills.page)
+			expect(result.totalPages).toBe(EXPECTED.searchSkills.totalPages)
+			expect(result.meta).toEqual(EXPECTED.searchSkills.meta)
+		})
+
+		it('should transform empty results with meta correctly', async () => {
+			global.fetch = mockApiResponse(API.searchSkillsEmpty)
+
+			const result = await adapter.searchSkills({ jobId: 'job-1' })
+
+			expect(result.results).toEqual(EXPECTED.searchSkillsEmpty.results)
+			expect(result.total).toBe(EXPECTED.searchSkillsEmpty.total)
+			expect(result.totalPages).toBe(EXPECTED.searchSkillsEmpty.totalPages)
+			expect(result.meta).toEqual(EXPECTED.searchSkillsEmpty.meta)
+		})
+
+		it('should fall back when meta is missing', async () => {
+			global.fetch = mockApiResponse(API.searchSkillsNoMeta)
+
+			const result = await adapter.searchSkills({ jobId: 'job-1' })
+
+			expect(result.total).toBe(EXPECTED.searchSkillsNoMeta.total)
+			expect(result.totalPages).toBe(EXPECTED.searchSkillsNoMeta.totalPages)
+			expect(result.meta).toBe(EXPECTED.searchSkillsNoMeta.meta)
+		})
+	})
+
+	describe('updatePartyJobSkills', () => {
+		it('should map slots 0 and 2 to skill1_id and skill3_id', async () => {
+			global.fetch = mockApiResponse({})
+
+			await adapter.updatePartyJobSkills('party-1', [
+				{ id: 'skill-a', slot: 0 },
+				{ id: 'skill-b', slot: 2 }
+			])
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				'https://api.example.com/parties/party-1/job_skills',
+				expect.objectContaining({
+					method: 'PUT',
+					body: JSON.stringify({
+						party: {
+							skill1_id: 'skill-a',
+							skill2_id: null,
+							skill3_id: 'skill-b',
+							skill4_id: null
+						}
+					})
+				})
+			)
+		})
+
+		it('should populate all 4 slots', async () => {
+			global.fetch = mockApiResponse({})
+
+			await adapter.updatePartyJobSkills('party-1', [
+				{ id: 's1', slot: 0 },
+				{ id: 's2', slot: 1 },
+				{ id: 's3', slot: 2 },
+				{ id: 's4', slot: 3 }
+			])
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					body: JSON.stringify({
+						party: {
+							skill1_id: 's1',
+							skill2_id: 's2',
+							skill3_id: 's3',
+							skill4_id: 's4'
+						}
+					})
+				})
+			)
+		})
+
+		it('should set all slots to null when empty', async () => {
+			global.fetch = mockApiResponse({})
+
+			await adapter.updatePartyJobSkills('party-1', [])
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					body: JSON.stringify({
+						party: {
+							skill1_id: null,
+							skill2_id: null,
+							skill3_id: null,
+							skill4_id: null
+						}
+					})
+				})
+			)
+		})
+	})
+
+	describe('removePartyJobSkill', () => {
+		it('should DELETE with slot in body', async () => {
+			global.fetch = mockApiResponse({})
+
+			await adapter.removePartyJobSkill('party-1', 2)
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				'https://api.example.com/parties/party-1/job_skills',
+				expect.objectContaining({
+					method: 'DELETE',
+					body: JSON.stringify({ slot: 2 })
+				})
+			)
+		})
+	})
+
+	describe('getAllAccessories', () => {
+		it('should include accessory_type query param when provided', async () => {
+			global.fetch = mockApiResponse([])
+
+			await adapter.getAllAccessories(1)
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('/job_accessories?accessory_type=1')
+		})
+
+		it('should not include query param when type is omitted', async () => {
+			global.fetch = mockApiResponse([])
+
+			await adapter.getAllAccessories()
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toBe('https://api.example.com/job_accessories')
+		})
+	})
+
+	describe('cache clearing', () => {
+		it('should clear both job list and detail cache on updateJob', async () => {
+			global.fetch = mockApiResponse({ id: 'job-1' })
+			const clearSpy = vi.spyOn(adapter as any, 'clearCache')
+
+			await adapter.updateJob('gbf-100', { name_en: 'Updated' })
+
+			expect(clearSpy).toHaveBeenCalledWith('/jobs')
+			expect(clearSpy).toHaveBeenCalledWith('/jobs/gbf-100')
+		})
+
+		it('should clear all job-related caches with clearJobCache', () => {
+			const clearSpy = vi.spyOn(adapter as any, 'clearCache')
+
+			adapter.clearJobCache()
+
+			expect(clearSpy).toHaveBeenCalledWith('/jobs')
+			expect(clearSpy).toHaveBeenCalledWith('/search/job_skills')
+			expect(clearSpy).toHaveBeenCalledWith('/job_accessories')
+		})
+	})
+})

--- a/src/lib/api/adapters/__tests__/party.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/party.adapter.test.ts
@@ -69,7 +69,7 @@ describe('PartyAdapter', () => {
 		it('should create a new party', async () => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => mockParty
+				json: async () => ({ party: mockParty })
 			})
 
 			const result = await adapter.create({
@@ -97,7 +97,7 @@ describe('PartyAdapter', () => {
 		it('should get a party by shortcode', async () => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => mockParty
+				json: async () => ({ party: mockParty })
 			})
 
 			const result = await adapter.getByShortcode('ABC123')
@@ -113,7 +113,7 @@ describe('PartyAdapter', () => {
 			const updatedParty = { ...mockParty, name: 'Updated Party' }
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => updatedParty
+				json: async () => ({ party: updatedParty })
 			})
 
 			const result = await adapter.update({
@@ -154,7 +154,7 @@ describe('PartyAdapter', () => {
 			const remixedParty = { ...mockParty, id: '456', shortcode: 'DEF456' }
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => remixedParty
+				json: async () => ({ party: remixedParty })
 			})
 
 			const result = await adapter.remix('ABC123')
@@ -308,7 +308,9 @@ describe('PartyAdapter', () => {
 				expect.objectContaining({
 					method: 'PUT',
 					body: JSON.stringify({
-						job_id: 'job-2'
+						party: {
+							job_id: 'job-2'
+						}
 					})
 				})
 			)
@@ -345,10 +347,10 @@ describe('PartyAdapter', () => {
 				expect.objectContaining({
 					method: 'PUT',
 					body: JSON.stringify({
-						skills: [
-							{ id: 'skill-1', slot: 1 },
-							{ id: 'skill-2', slot: 2 }
-						]
+						party: {
+							skill1_id: 'skill-1',
+							skill2_id: 'skill-2'
+						}
 					})
 				})
 			)
@@ -356,26 +358,23 @@ describe('PartyAdapter', () => {
 	})
 
 	describe('cache management', () => {
-		it('should cache party retrieval', async () => {
+		it('should not cache when disableCache is true', async () => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => mockParty
+				json: async () => ({ party: mockParty })
 			})
 
-			// First call
+			// PartyAdapter has disableCache = true, so both calls hit the network
+			await adapter.getByShortcode('ABC123')
 			await adapter.getByShortcode('ABC123')
 
-			// Second call (should use cache)
-			await adapter.getByShortcode('ABC123')
-
-			// Should only call fetch once due to caching
-			expect(global.fetch).toHaveBeenCalledTimes(1)
+			expect(global.fetch).toHaveBeenCalledTimes(2)
 		})
 
 		it('should clear party cache', async () => {
 			global.fetch = vi.fn().mockResolvedValue({
 				ok: true,
-				json: async () => mockParty
+				json: async () => ({ party: mockParty })
 			})
 
 			// First call

--- a/src/lib/api/adapters/__tests__/raid.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/raid.adapter.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { RaidAdapter } from '../raid.adapter'
+import { API, EXPECTED } from './fixtures/raid.fixtures'
+import { mockApiResponse } from './fixtures/helpers'
+
+describe('RaidAdapter', () => {
+	let adapter: RaidAdapter
+	let originalFetch: typeof global.fetch
+
+	beforeEach(() => {
+		originalFetch = global.fetch
+		adapter = new RaidAdapter({ baseURL: 'https://api.example.com' })
+	})
+
+	afterEach(() => {
+		global.fetch = originalFetch
+		vi.clearAllTimers()
+	})
+
+	describe('filter mapping', () => {
+		it('should map all filters to query params', async () => {
+			global.fetch = mockApiResponse([])
+
+			await adapter.getAll({
+				element: 1,
+				groupId: 'grp-1',
+				difficulty: 2,
+				hl: true,
+				extra: false,
+				guidebooks: true
+			})
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('element=1')
+			expect(url).toContain('group_id=grp-1')
+			expect(url).toContain('difficulty=2')
+			expect(url).toContain('hl=true')
+			expect(url).toContain('extra=false')
+			expect(url).toContain('guidebooks=true')
+		})
+
+		it('should not attach query params when no filters', async () => {
+			global.fetch = mockApiResponse([])
+
+			await adapter.getAll()
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toBe('https://api.example.com/raids')
+		})
+
+		it('should only send specified filters', async () => {
+			global.fetch = mockApiResponse([])
+
+			await adapter.getAll({ element: 3, hl: true })
+
+			const url = (global.fetch as any).mock.calls[0][0]
+			expect(url).toContain('element=3')
+			expect(url).toContain('hl=true')
+			expect(url).not.toContain('group_id')
+			expect(url).not.toContain('difficulty')
+			expect(url).not.toContain('extra')
+			expect(url).not.toContain('guidebooks')
+		})
+	})
+
+	describe('download status', () => {
+		it('should map all response fields correctly', async () => {
+			global.fetch = mockApiResponse(API.downloadStatus)
+
+			const result = await adapter.getRaidDownloadStatus('proto-bahamut')
+
+			expect(result).toEqual(EXPECTED.downloadStatus)
+		})
+	})
+
+	describe('image downloads', () => {
+		it('should POST downloadRaidImage with size and force', async () => {
+			global.fetch = mockApiResponse({ success: true })
+
+			await adapter.downloadRaidImage('proto-bahamut', 'thumbnail', true)
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				'https://api.example.com/raids/proto-bahamut/download_image',
+				expect.objectContaining({
+					method: 'POST',
+					body: JSON.stringify({ size: 'thumbnail', force: true })
+				})
+			)
+		})
+
+		it('should POST downloadRaidImages with options wrapper', async () => {
+			global.fetch = mockApiResponse({ status: 'queued', raidId: 'raid-1', message: 'started' })
+
+			await adapter.downloadRaidImages('proto-bahamut', { force: true, size: 'all' })
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				'https://api.example.com/raids/proto-bahamut/download_images',
+				expect.objectContaining({
+					method: 'POST',
+					body: JSON.stringify({ options: { force: true, size: 'all' } })
+				})
+			)
+		})
+	})
+
+	describe('cache clearing', () => {
+		it('should clear both raid list and detail cache on update', async () => {
+			global.fetch = mockApiResponse({ id: 'raid-1', slug: 'proto-bahamut' })
+			const clearSpy = vi.spyOn(adapter as any, 'clearCache')
+
+			await adapter.update('proto-bahamut', { name: { en: 'Updated' } } as any)
+
+			expect(clearSpy).toHaveBeenCalledWith('/raids')
+			expect(clearSpy).toHaveBeenCalledWith('/raids/proto-bahamut')
+		})
+
+		it('should clear both raid list and detail cache on delete', async () => {
+			global.fetch = mockApiResponse({})
+			const clearSpy = vi.spyOn(adapter as any, 'clearCache')
+
+			await adapter.delete('proto-bahamut')
+
+			expect(clearSpy).toHaveBeenCalledWith('/raids')
+			expect(clearSpy).toHaveBeenCalledWith('/raids/proto-bahamut')
+		})
+	})
+})

--- a/src/lib/api/adapters/__tests__/search.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/search.adapter.test.ts
@@ -103,14 +103,15 @@ describe('SearchAdapter', () => {
 			const result = await adapter.searchAll(params)
 
 			expect(global.fetch).toHaveBeenCalledWith(
-				'https://api.example.com/search/all',
+				'https://api.example.com/search',
 				expect.objectContaining({
 					method: 'POST',
-					credentials: 'omit',
 					body: JSON.stringify({
-						locale: 'en',
-						page: 1,
-						query: 'bahamut'
+						search: {
+							locale: 'en',
+							page: 1,
+							query: 'bahamut'
+						}
 					})
 				})
 			)
@@ -139,13 +140,15 @@ describe('SearchAdapter', () => {
 				expect.any(String),
 				expect.objectContaining({
 					body: JSON.stringify({
-						locale: 'en',
-						page: 1,
-						query: 'sword',
-						filters: {
-							element: [1, 2],
-							rarity: [5],
-							extra: true
+						search: {
+							locale: 'en',
+							page: 1,
+							query: 'sword',
+							filters: {
+								element: [1, 2],
+								rarity: [5],
+								extra: true
+							}
 						}
 					})
 				})
@@ -169,10 +172,12 @@ describe('SearchAdapter', () => {
 				expect.any(String),
 				expect.objectContaining({
 					body: JSON.stringify({
-						locale: 'en',
-						page: 1,
-						query: 'test',
-						exclude: ['1', '2', '3']
+						search: {
+							locale: 'en',
+							page: 1,
+							query: 'test',
+							exclude: ['1', '2', '3']
+						}
 					})
 				})
 			)
@@ -232,16 +237,17 @@ describe('SearchAdapter', () => {
 				'https://api.example.com/search/weapons',
 				expect.objectContaining({
 					method: 'POST',
-					credentials: 'omit',
 					body: JSON.stringify({
-						locale: 'en',
-						page: 1,
-						per: 50,
-						query: 'sword',
-						filters: {
-							element: [1],
-							proficiency1: [2],
-							extra: false
+						search: {
+							locale: 'en',
+							page: 1,
+							per: 50,
+							query: 'sword',
+							filters: {
+								element: [1],
+								proficiency1: [2],
+								extra: false
+							}
 						}
 					})
 				})
@@ -291,13 +297,15 @@ describe('SearchAdapter', () => {
 				'https://api.example.com/search/characters',
 				expect.objectContaining({
 					body: JSON.stringify({
-						locale: 'en',
-						page: 1,
-						query: 'katalina',
-						filters: {
-							element: [2],
-							proficiency1: [1],
-							proficiency2: [3]
+						search: {
+							locale: 'en',
+							page: 1,
+							query: 'katalina',
+							filters: {
+								element: [2],
+								proficiency1: [1],
+								proficiency2: [3]
+							}
 						}
 					})
 				})
@@ -327,13 +335,15 @@ describe('SearchAdapter', () => {
 				'https://api.example.com/search/summons',
 				expect.objectContaining({
 					body: JSON.stringify({
-						locale: 'en',
-						page: 1,
-						query: 'bahamut',
-						filters: {
-							element: [6],
-							rarity: [5],
-							subaura: true
+						search: {
+							locale: 'en',
+							page: 1,
+							query: 'bahamut',
+							filters: {
+								element: [6],
+								rarity: [5],
+								subaura: true
+							}
 						}
 					})
 				})
@@ -404,10 +414,12 @@ describe('SearchAdapter', () => {
 				expect.any(String),
 				expect.objectContaining({
 					body: JSON.stringify({
-						locale: 'en',
-						page: 2,
-						per: 20,
-						query: 'test'
+						search: {
+							locale: 'en',
+							page: 2,
+							per: 20,
+							query: 'test'
+						}
 					})
 				})
 			)

--- a/src/lib/api/adapters/__tests__/user.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/user.adapter.test.ts
@@ -266,7 +266,7 @@ describe('UserAdapter', () => {
       const result = await adapter.checkUsernameAvailability('newuser')
 
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/users/check-username'),
+        expect.stringContaining('/check/username'),
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ username: 'newuser' })
@@ -297,7 +297,7 @@ describe('UserAdapter', () => {
       const result = await adapter.checkEmailAvailability('new@example.com')
 
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining('/users/check-email'),
+        expect.stringContaining('/check/email'),
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ email: 'new@example.com' })
@@ -327,10 +327,10 @@ describe('UserAdapter', () => {
         expect.stringContaining('/users/me'),
         expect.objectContaining({
           method: 'PUT',
-          body: JSON.stringify(updates)
+          body: JSON.stringify({ user: updates })
         })
       )
-      expect(result).toEqual(updatedUser)
+      expect(result).toEqual(expect.objectContaining(updatedUser))
     })
 
     it('should handle partial updates', async () => {
@@ -346,7 +346,7 @@ describe('UserAdapter', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('/users/me'),
         expect.objectContaining({
-          body: JSON.stringify(updates)
+          body: JSON.stringify({ user: updates })
         })
       )
     })
@@ -365,7 +365,17 @@ describe('UserAdapter', () => {
         expect.stringContaining('/users/me'),
         expect.any(Object)
       )
-      expect(result).toEqual(mockUserInfo)
+      // transformSettingsResponse adds extra fields from the API response
+      expect(result).toEqual(expect.objectContaining({
+        id: mockUserInfo.id,
+        username: mockUserInfo.username,
+        language: mockUserInfo.language,
+        theme: mockUserInfo.theme,
+        role: mockUserInfo.role,
+        avatar: mockUserInfo.avatar
+      }))
+      // Settings response always includes email
+      expect(result.email).toBe('')
     })
   })
 

--- a/src/lib/api/adapters/crew.adapter.ts
+++ b/src/lib/api/adapters/crew.adapter.ts
@@ -241,7 +241,7 @@ export class CrewAdapter extends BaseAdapter {
     input: CreatePhantomPlayerInput,
     options?: RequestOptions
   ): Promise<PhantomPlayer> {
-    const response = await this.request<{ phantom_player: PhantomPlayer }>(
+    const response = await this.request<{ phantomPlayer: PhantomPlayer }>(
       `/crews/${crewId}/phantom_players`,
       {
         ...options,
@@ -250,7 +250,7 @@ export class CrewAdapter extends BaseAdapter {
       }
     )
     this.clearCache('/crew/members')
-    return response.phantom_player
+    return response.phantomPlayer
   }
 
   /**
@@ -261,7 +261,7 @@ export class CrewAdapter extends BaseAdapter {
     phantoms: CreatePhantomPlayerInput[],
     options?: RequestOptions
   ): Promise<PhantomPlayer[]> {
-    const response = await this.request<{ phantom_players: PhantomPlayer[] }>(
+    const response = await this.request<{ phantomPlayers: PhantomPlayer[] }>(
       `/crews/${crewId}/phantom_players/bulk_create`,
       {
         ...options,
@@ -270,7 +270,7 @@ export class CrewAdapter extends BaseAdapter {
       }
     )
     this.clearCache('/crew/members')
-    return response.phantom_players
+    return response.phantomPlayers
   }
 
   /**
@@ -282,7 +282,7 @@ export class CrewAdapter extends BaseAdapter {
     input: UpdatePhantomPlayerInput,
     options?: RequestOptions
   ): Promise<PhantomPlayer> {
-    const response = await this.request<{ phantom_player: PhantomPlayer }>(
+    const response = await this.request<{ phantomPlayer: PhantomPlayer }>(
       `/crews/${crewId}/phantom_players/${phantomId}`,
       {
         ...options,
@@ -291,7 +291,7 @@ export class CrewAdapter extends BaseAdapter {
       }
     )
     this.clearCache('/crew/members')
-    return response.phantom_player
+    return response.phantomPlayer
   }
 
   /**
@@ -314,7 +314,7 @@ export class CrewAdapter extends BaseAdapter {
     userId: string,
     options?: RequestOptions
   ): Promise<PhantomPlayer> {
-    const response = await this.request<{ phantom_player: PhantomPlayer }>(
+    const response = await this.request<{ phantomPlayer: PhantomPlayer }>(
       `/crews/${crewId}/phantom_players/${phantomId}/assign`,
       {
         ...options,
@@ -323,14 +323,14 @@ export class CrewAdapter extends BaseAdapter {
       }
     )
     this.clearCache('/crew/members')
-    return response.phantom_player
+    return response.phantomPlayer
   }
 
   /**
    * Confirm claim of a phantom player (by the assigned user)
    */
   async confirmPhantomClaim(crewId: string, phantomId: string, options?: RequestOptions): Promise<PhantomPlayer> {
-    const response = await this.request<{ phantom_player: PhantomPlayer }>(
+    const response = await this.request<{ phantomPlayer: PhantomPlayer }>(
       `/crews/${crewId}/phantom_players/${phantomId}/confirm_claim`,
       {
         ...options,
@@ -338,14 +338,14 @@ export class CrewAdapter extends BaseAdapter {
       }
     )
     this.clearCache('/crew/members')
-    return response.phantom_player
+    return response.phantomPlayer
   }
 
   /**
    * Decline claim of a phantom player (by the assigned user)
    */
   async declinePhantomClaim(crewId: string, phantomId: string, options?: RequestOptions): Promise<PhantomPlayer> {
-    const response = await this.request<{ phantom_player: PhantomPlayer }>(
+    const response = await this.request<{ phantomPlayer: PhantomPlayer }>(
       `/crews/${crewId}/phantom_players/${phantomId}/decline_claim`,
       {
         ...options,
@@ -354,7 +354,7 @@ export class CrewAdapter extends BaseAdapter {
     )
     this.clearCache('/crew/members')
     this.clearCache('/pending_phantom_claims')
-    return response.phantom_player
+    return response.phantomPlayer
   }
 
   /**

--- a/src/lib/api/adapters/job.adapter.ts
+++ b/src/lib/api/adapters/job.adapter.ts
@@ -182,8 +182,8 @@ export class JobAdapter extends BaseAdapter {
 			results: JobSkill[]
 			meta?: {
 				count?: number
-				total_pages?: number
-				per_page?: number
+				totalPages?: number
+				perPage?: number
 			}
 		}>('/search/job_skills', {
 			method: 'POST',
@@ -199,17 +199,18 @@ export class JobAdapter extends BaseAdapter {
 			// Note: No caching - filters change frequently and cache key bug causes stale data
 		})
 
-		// Transform the response to match the expected format
+		// BaseAdapter already transforms snake_case → camelCase,
+		// so meta keys are already totalPages, perPage, etc.
 		return {
 			results: response.results,
 			page: params.page || 1,
 			total: response.meta?.count || 0,
-			totalPages: response.meta?.total_pages || 1,
+			totalPages: response.meta?.totalPages || 1,
 			meta: response.meta ? {
 				count: response.meta.count ?? 0,
 				page: params.page || 1,
-				perPage: response.meta.per_page ?? 10,
-				totalPages: response.meta.total_pages ?? 1
+				perPage: response.meta.perPage ?? 10,
+				totalPages: response.meta.totalPages ?? 1
 			} : undefined
 		}
 	}

--- a/src/lib/api/adapters/raid.adapter.ts
+++ b/src/lib/api/adapters/raid.adapter.ts
@@ -146,32 +146,12 @@ export class RaidAdapter extends BaseAdapter {
    * Requires editor role (>= 7)
    */
   async getRaidDownloadStatus(slug: string, options?: RequestOptions): Promise<RaidDownloadStatus> {
-    const response = await this.request<{
-      status: string
-      progress?: number
-      images_downloaded?: number
-      images_total?: number
-      error?: string
-      raid_id?: string
-      slug?: string
-      images?: Record<string, string[]>
-      updated_at?: string
-    }>(`/raids/${slug}/download_status`, {
+    // BaseAdapter already transforms snake_case → camelCase,
+    // so we can return the response directly
+    return this.request<RaidDownloadStatus>(`/raids/${slug}/download_status`, {
       ...options,
       method: 'GET'
     })
-
-    return {
-      status: response.status as RaidDownloadStatus['status'],
-      progress: response.progress,
-      imagesDownloaded: response.images_downloaded,
-      imagesTotal: response.images_total,
-      error: response.error,
-      raidId: response.raid_id,
-      slug: response.slug,
-      images: response.images,
-      updatedAt: response.updated_at
-    }
   }
 
   // ==================== RaidGroup Operations ====================

--- a/src/lib/auth/__tests__/cookies.test.ts
+++ b/src/lib/auth/__tests__/cookies.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+	setAccountCookie,
+	setUserCookie,
+	setRefreshCookie,
+	getAccountFromCookies,
+	getUserFromCookies,
+	getRefreshFromCookies,
+	clearAuthCookies,
+	ACCOUNT_COOKIE,
+	USER_COOKIE,
+	REFRESH_COOKIE
+} from '../cookies'
+import type { AccountCookie } from '$lib/types/AccountCookie'
+import type { UserCookie } from '$lib/types/UserCookie'
+
+function createMockCookies() {
+	const store = new Map<string, string>()
+	const setCalls: Array<{ name: string; value: string; opts: any }> = []
+	const deleteCalls: Array<{ name: string; opts: any }> = []
+
+	return {
+		set: vi.fn((name: string, value: string, opts: any) => {
+			store.set(name, value)
+			setCalls.push({ name, value, opts })
+		}),
+		get: vi.fn((name: string) => store.get(name)),
+		delete: vi.fn((name: string, opts: any) => {
+			store.delete(name)
+			deleteCalls.push({ name, opts })
+		}),
+		setCalls,
+		deleteCalls,
+		store
+	}
+}
+
+const mockAccount: AccountCookie = {
+	userId: 'u1',
+	username: 'grug',
+	token: 'tok-1',
+	role: 0,
+	expires_at: '2025-01-01T00:00:00Z'
+}
+
+const mockUser: UserCookie = {
+	picture: 'avatar.jpg',
+	element: 'fire',
+	language: 'en',
+	gender: 1,
+	theme: 'dark'
+}
+
+describe('setAccountCookie', () => {
+	it('sets httpOnly cookie with correct options', () => {
+		const cookies = createMockCookies()
+		const expires = new Date('2025-03-01')
+
+		setAccountCookie(cookies as any, mockAccount, { secure: true, expires })
+
+		expect(cookies.set).toHaveBeenCalledWith(
+			ACCOUNT_COOKIE,
+			JSON.stringify(mockAccount),
+			expect.objectContaining({
+				path: '/',
+				httpOnly: true,
+				sameSite: 'lax',
+				secure: true,
+				expires,
+				maxAge: 60 * 60 * 24 * 60
+			})
+		)
+	})
+})
+
+describe('setUserCookie', () => {
+	it('sets non-httpOnly cookie (readable by client)', () => {
+		const cookies = createMockCookies()
+		const expires = new Date('2025-03-01')
+
+		setUserCookie(cookies as any, mockUser, { secure: false, expires })
+
+		expect(cookies.set).toHaveBeenCalledWith(
+			USER_COOKIE,
+			JSON.stringify(mockUser),
+			expect.objectContaining({
+				httpOnly: false,
+				secure: false
+			})
+		)
+	})
+})
+
+describe('setRefreshCookie', () => {
+	it('sets httpOnly cookie with refresh token', () => {
+		const cookies = createMockCookies()
+
+		setRefreshCookie(cookies as any, 'ref-tok', { secure: true })
+
+		expect(cookies.set).toHaveBeenCalledWith(
+			REFRESH_COOKIE,
+			'ref-tok',
+			expect.objectContaining({
+				path: '/',
+				httpOnly: true,
+				sameSite: 'lax',
+				secure: true
+			})
+		)
+	})
+
+	it('includes expires when provided', () => {
+		const cookies = createMockCookies()
+		const expires = new Date('2025-06-01')
+
+		setRefreshCookie(cookies as any, 'ref-tok', { secure: true, expires })
+
+		expect(cookies.setCalls[0].opts.expires).toEqual(expires)
+	})
+
+	it('omits expires when not provided', () => {
+		const cookies = createMockCookies()
+
+		setRefreshCookie(cookies as any, 'ref-tok', { secure: true })
+
+		expect(cookies.setCalls[0].opts).not.toHaveProperty('expires')
+	})
+})
+
+describe('getAccountFromCookies', () => {
+	it('parses stored account cookie', () => {
+		const cookies = createMockCookies()
+		cookies.store.set(ACCOUNT_COOKIE, JSON.stringify(mockAccount))
+
+		const result = getAccountFromCookies(cookies as any)
+		expect(result).toEqual(mockAccount)
+	})
+
+	it('returns null when cookie missing', () => {
+		const cookies = createMockCookies()
+		expect(getAccountFromCookies(cookies as any)).toBeNull()
+	})
+
+	it('returns null on invalid JSON', () => {
+		const cookies = createMockCookies()
+		cookies.store.set(ACCOUNT_COOKIE, '{broken')
+
+		expect(getAccountFromCookies(cookies as any)).toBeNull()
+	})
+})
+
+describe('getUserFromCookies', () => {
+	it('parses stored user cookie', () => {
+		const cookies = createMockCookies()
+		cookies.store.set(USER_COOKIE, JSON.stringify(mockUser))
+
+		const result = getUserFromCookies(cookies as any)
+		expect(result).toEqual(mockUser)
+	})
+
+	it('returns null when cookie missing', () => {
+		const cookies = createMockCookies()
+		expect(getUserFromCookies(cookies as any)).toBeNull()
+	})
+})
+
+describe('getRefreshFromCookies', () => {
+	it('returns stored refresh token', () => {
+		const cookies = createMockCookies()
+		cookies.store.set(REFRESH_COOKIE, 'ref-tok')
+
+		expect(getRefreshFromCookies(cookies as any)).toBe('ref-tok')
+	})
+
+	it('returns null when cookie missing', () => {
+		const cookies = createMockCookies()
+		expect(getRefreshFromCookies(cookies as any)).toBeNull()
+	})
+})
+
+describe('clearAuthCookies', () => {
+	it('deletes all three auth cookies', () => {
+		const cookies = createMockCookies()
+
+		clearAuthCookies(cookies as any)
+
+		expect(cookies.delete).toHaveBeenCalledTimes(3)
+		expect(cookies.delete).toHaveBeenCalledWith(ACCOUNT_COOKIE, { path: '/' })
+		expect(cookies.delete).toHaveBeenCalledWith(USER_COOKIE, { path: '/' })
+		expect(cookies.delete).toHaveBeenCalledWith(REFRESH_COOKIE, { path: '/' })
+	})
+})

--- a/src/lib/auth/__tests__/map.test.ts
+++ b/src/lib/auth/__tests__/map.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { buildCookies } from '../map'
+import type { OAuthLoginResponse, UserInfoResponse } from '../oauth'
+
+const mockOAuth: OAuthLoginResponse = {
+	access_token: 'tok-1',
+	token_type: 'Bearer',
+	expires_in: 3600,
+	refresh_token: 'ref-1',
+	created_at: 1700000000,
+	user: { id: 'u1', username: 'grug', role: 0 }
+}
+
+const mockUserInfo: UserInfoResponse = {
+	id: 'u1',
+	username: 'grug',
+	role: 0,
+	avatar: { picture: 'avatar.jpg', element: 'fire' },
+	language: 'en',
+	gender: 1,
+	theme: 'dark',
+	granblueId: 'gbf-123',
+	showCrewGamertag: true
+}
+
+describe('buildCookies', () => {
+	it('maps oauth + user info to cookie data', () => {
+		const result = buildCookies(mockOAuth, mockUserInfo)
+
+		expect(result.account).toEqual({
+			userId: 'u1',
+			username: 'grug',
+			token: 'tok-1',
+			role: 0,
+			expires_at: new Date((1700000000 + 3600) * 1000).toISOString()
+		})
+
+		expect(result.user).toEqual({
+			picture: 'avatar.jpg',
+			element: 'fire',
+			language: 'en',
+			gender: 1,
+			theme: 'dark',
+			granblueId: 'gbf-123',
+			showCrewGamertag: true
+		})
+
+		expect(result.refresh).toBe('ref-1')
+		expect(result.accessTokenExpiresAt).toBeInstanceOf(Date)
+	})
+
+	it('defaults null avatar/language/gender/theme values', () => {
+		const sparseInfo: UserInfoResponse = {
+			id: 'u2',
+			username: 'cave',
+			role: 1,
+			avatar: { picture: null, element: null },
+			language: null,
+			gender: null,
+			theme: null
+		}
+
+		const result = buildCookies(mockOAuth, sparseInfo)
+
+		expect(result.user.picture).toBe('')
+		expect(result.user.element).toBe('')
+		expect(result.user.language).toBe('en')
+		expect(result.user.gender).toBe(0)
+		expect(result.user.theme).toBe('system')
+	})
+})

--- a/src/lib/auth/__tests__/oauth.test.ts
+++ b/src/lib/auth/__tests__/oauth.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('$env/static/public', () => ({ PUBLIC_SIERO_API_URL: 'http://localhost:3000' }))
+
+const { passwordGrantLogin } = await import('../oauth')
+
+const loginBody = { email: 'grug@cave.dev', password: 'rock123', grant_type: 'password' as const }
+
+describe('passwordGrantLogin', () => {
+	it('returns parsed response on success', async () => {
+		const mockResponse = {
+			access_token: 'tok-1',
+			token_type: 'Bearer',
+			expires_in: 3600,
+			refresh_token: 'ref-1',
+			created_at: 1700000000,
+			user: { id: 'u1', username: 'grug', role: 0 }
+		}
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => mockResponse
+		})
+
+		const result = await passwordGrantLogin(mockFetch, loginBody)
+
+		expect(result).toEqual(mockResponse)
+		expect(mockFetch).toHaveBeenCalledWith(
+			'http://localhost:3000/oauth/token',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(loginBody)
+			}
+		)
+	})
+
+	it('throws "unauthorized" on 401', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 401
+		})
+
+		await expect(passwordGrantLogin(mockFetch, loginBody)).rejects.toThrow('unauthorized')
+	})
+
+	it('throws formatted error on other failures', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 500
+		})
+
+		await expect(passwordGrantLogin(mockFetch, loginBody)).rejects.toThrow('oauth_error_500')
+	})
+})

--- a/src/lib/query/__tests__/cacheHelpers.test.ts
+++ b/src/lib/query/__tests__/cacheHelpers.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Cache helper tests
+ *
+ * Tests resolvePartyShortcode and invalidateParty utilities.
+ * Uses real QueryClient instances seeded with cache data.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { resolvePartyShortcode, invalidateParty } from '../cacheHelpers'
+import { createTestQueryClient, seedPartyCache } from '$lib/api/mutations/__tests__/helpers'
+import { MOCK_PARTY, MOCK_SHORTCODE } from '$lib/api/mutations/__tests__/fixtures'
+import type { QueryClient } from '@tanstack/svelte-query'
+
+let queryClient: QueryClient
+
+beforeEach(() => {
+	queryClient = createTestQueryClient()
+	seedPartyCache(queryClient, MOCK_PARTY)
+})
+
+// ============================================================================
+// resolvePartyShortcode
+// ============================================================================
+
+describe('resolvePartyShortcode', () => {
+	it('returns short alphanumeric strings as-is', () => {
+		expect(resolvePartyShortcode(queryClient, 'ABC123')).toBe('ABC123')
+	})
+
+	it('returns short strings with hyphens/underscores as-is', () => {
+		expect(resolvePartyShortcode(queryClient, 'my-party_1')).toBe('my-party_1')
+	})
+
+	it('returns numeric input as string', () => {
+		expect(resolvePartyShortcode(queryClient, 42)).toBe('42')
+	})
+
+	it('resolves UUID to shortcode from cache', () => {
+		const result = resolvePartyShortcode(queryClient, MOCK_PARTY.id)
+		expect(result).toBe(MOCK_SHORTCODE)
+	})
+
+	it('falls back to input when UUID not found in cache', () => {
+		const unknownUuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+		expect(resolvePartyShortcode(queryClient, unknownUuid)).toBe(unknownUuid)
+	})
+
+	it('handles empty cache gracefully', () => {
+		const emptyClient = createTestQueryClient()
+		const uuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+		expect(resolvePartyShortcode(emptyClient, uuid)).toBe(uuid)
+	})
+})
+
+// ============================================================================
+// invalidateParty
+// ============================================================================
+
+describe('invalidateParty', () => {
+	it('invalidates by shortcode', async () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+		await invalidateParty(queryClient, MOCK_SHORTCODE)
+
+		expect(spy).toHaveBeenCalledWith({
+			queryKey: ['party', MOCK_SHORTCODE]
+		})
+	})
+
+	it('resolves UUID then invalidates correct key', async () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+		await invalidateParty(queryClient, MOCK_PARTY.id)
+
+		expect(spy).toHaveBeenCalledWith({
+			queryKey: ['party', MOCK_SHORTCODE]
+		})
+	})
+})

--- a/src/lib/stores/__tests__/auth.store.test.ts
+++ b/src/lib/stores/__tests__/auth.store.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Auth store tests
+ *
+ * Tests the Svelte writable-based auth store.
+ * Mocks $app/environment (browser flag), $env/static/public,
+ * and global fetch for refresh flow testing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { get } from 'svelte/store'
+
+// Mock SvelteKit modules before importing the store
+vi.mock('$app/environment', () => ({ browser: true }))
+vi.mock('$env/static/public', () => ({ PUBLIC_SIERO_API_URL: 'http://localhost:3000' }))
+
+// Dynamic import so mocks are in place first
+const { authStore } = await import('../auth.store')
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+beforeEach(() => {
+	authStore.clearAuth()
+	vi.restoreAllMocks()
+})
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+// ============================================================================
+// setAuth
+// ============================================================================
+
+describe('setAuth', () => {
+	it('sets token, user, and computes expiresAt', () => {
+		const user = { id: 'u1', username: 'grug' }
+		const before = Date.now()
+
+		authStore.setAuth('tok-123', user, 3600)
+
+		const state = get(authStore)
+		expect(state.accessToken).toBe('tok-123')
+		expect(state.user).toEqual(user)
+		expect(state.isAuthenticated).toBe(true)
+		expect(state.isRefreshing).toBe(false)
+
+		// expiresAt should be ~1 hour from now
+		const expiresMs = state.expiresAt!.getTime()
+		expect(expiresMs).toBeGreaterThanOrEqual(before + 3600 * 1000 - 100)
+		expect(expiresMs).toBeLessThanOrEqual(Date.now() + 3600 * 1000 + 100)
+	})
+
+	it('sets refreshToken to null (managed via httpOnly cookie)', () => {
+		authStore.setAuth('tok', { id: 'u1', username: 'grug' }, 60)
+
+		expect(get(authStore).refreshToken).toBeNull()
+	})
+})
+
+// ============================================================================
+// clearAuth
+// ============================================================================
+
+describe('clearAuth', () => {
+	it('resets all state', () => {
+		authStore.setAuth('tok', { id: 'u1', username: 'grug' }, 3600)
+		authStore.clearAuth()
+
+		const state = get(authStore)
+		expect(state.accessToken).toBeNull()
+		expect(state.user).toBeNull()
+		expect(state.expiresAt).toBeNull()
+		expect(state.isAuthenticated).toBe(false)
+		expect(state.isRefreshing).toBe(false)
+	})
+})
+
+// ============================================================================
+// getToken
+// ============================================================================
+
+describe('getToken', () => {
+	it('returns token when not expired', () => {
+		authStore.setAuth('valid-tok', { id: 'u1', username: 'grug' }, 3600)
+
+		expect(authStore.getToken()).toBe('valid-tok')
+	})
+
+	it('returns null when no token set', () => {
+		expect(authStore.getToken()).toBeNull()
+	})
+
+	it('returns null when token is expired', async () => {
+		authStore.setAuth('old-tok', { id: 'u1', username: 'grug' }, -1)
+
+		// Stub window + fetch so the async refresh side effect doesn't explode
+		;(globalThis as any).window = { location: { href: '' } }
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(
+				JSON.stringify({ access_token: 'x', user: { id: 'u1', username: 'grug' }, expires_in: 60 }),
+				{ status: 200 }
+			)
+		)
+
+		expect(authStore.getToken()).toBeNull()
+
+		// Let the fire-and-forget refresh() settle
+		await vi.waitFor(() => expect(get(authStore).isRefreshing).toBe(false))
+
+		delete (globalThis as any).window
+	})
+})
+
+// ============================================================================
+// initFromServer
+// ============================================================================
+
+describe('initFromServer', () => {
+	it('hydrates from SSR data', () => {
+		const user = { id: 'u1', username: 'grug' }
+		const expiresAt = new Date(Date.now() + 3600 * 1000).toISOString()
+
+		authStore.initFromServer('ssr-tok', user, expiresAt)
+
+		const state = get(authStore)
+		expect(state.accessToken).toBe('ssr-tok')
+		expect(state.user).toEqual(user)
+		expect(state.isAuthenticated).toBe(true)
+		expect(state.expiresAt).toBeInstanceOf(Date)
+	})
+
+	it('resets when params are null', () => {
+		authStore.setAuth('tok', { id: 'u1', username: 'grug' }, 3600)
+		authStore.initFromServer(null, null, null)
+
+		const state = get(authStore)
+		expect(state.accessToken).toBeNull()
+		expect(state.isAuthenticated).toBe(false)
+	})
+
+	it('resets when only some params are null', () => {
+		authStore.initFromServer('tok', null, null)
+
+		expect(get(authStore).isAuthenticated).toBe(false)
+	})
+})
+
+// ============================================================================
+// refresh
+// ============================================================================
+
+describe('refresh', () => {
+	it('calls /auth/refresh with credentials', async () => {
+		const mockFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					access_token: 'new-tok',
+					user: { id: 'u1', username: 'grug' },
+					expires_in: 3600
+				}),
+				{ status: 200 }
+			)
+		)
+
+		authStore.setAuth('old-tok', { id: 'u1', username: 'grug' }, 3600)
+		await authStore.refresh()
+
+		expect(mockFetch).toHaveBeenCalledWith('/auth/refresh', {
+			method: 'POST',
+			credentials: 'include',
+			headers: { 'Content-Type': 'application/json' }
+		})
+	})
+
+	it('updates state on successful refresh', async () => {
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					access_token: 'refreshed-tok',
+					user: { id: 'u1', username: 'refreshed-grug' },
+					expires_in: 7200
+				}),
+				{ status: 200 }
+			)
+		)
+
+		const result = await authStore.refresh()
+
+		expect(result).toBe(true)
+		expect(get(authStore).accessToken).toBe('refreshed-tok')
+	})
+
+	it('clears auth and redirects on failure', async () => {
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response('', { status: 401 })
+		)
+
+		// Stub window for Node environment
+		const fakeLocation = { href: '' }
+		;(globalThis as any).window = { location: fakeLocation }
+
+		const result = await authStore.refresh()
+
+		expect(result).toBe(false)
+		expect(get(authStore).isAuthenticated).toBe(false)
+		expect(fakeLocation.href).toBe('/auth/login')
+
+		delete (globalThis as any).window
+	})
+
+	it('deduplicates concurrent refresh calls', async () => {
+		let fetchCount = 0
+		vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+			fetchCount++
+			// Small delay to simulate network
+			await new Promise(r => setTimeout(r, 10))
+			return new Response(
+				JSON.stringify({
+					access_token: 'deduped-tok',
+					user: { id: 'u1', username: 'grug' },
+					expires_in: 3600
+				}),
+				{ status: 200 }
+			)
+		})
+
+		// Fire three concurrent refreshes
+		const [r1, r2, r3] = await Promise.all([
+			authStore.refresh(),
+			authStore.refresh(),
+			authStore.refresh()
+		])
+
+		// All should succeed
+		expect(r1).toBe(true)
+		expect(r2).toBe(true)
+		expect(r3).toBe(true)
+
+		// But only one fetch call should have been made
+		expect(fetchCount).toBe(1)
+	})
+})
+
+// ============================================================================
+// checkAndRefresh
+// ============================================================================
+
+describe('checkAndRefresh', () => {
+	it('returns null when no token is set', async () => {
+		const result = await authStore.checkAndRefresh()
+		expect(result).toBeNull()
+	})
+
+	it('returns token when not near expiry', async () => {
+		authStore.setAuth('fresh-tok', { id: 'u1', username: 'grug' }, 3600)
+
+		const result = await authStore.checkAndRefresh()
+		expect(result).toBe('fresh-tok')
+	})
+
+	it('triggers refresh when within 5 minutes of expiry', async () => {
+		// Set token that expires in 2 minutes (within the 5-minute window)
+		authStore.setAuth('expiring-tok', { id: 'u1', username: 'grug' }, 120)
+
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					access_token: 'renewed-tok',
+					user: { id: 'u1', username: 'grug' },
+					expires_in: 3600
+				}),
+				{ status: 200 }
+			)
+		)
+
+		const result = await authStore.checkAndRefresh()
+
+		expect(result).toBe('renewed-tok')
+		expect(get(authStore).accessToken).toBe('renewed-tok')
+	})
+
+	it('returns null when refresh fails', async () => {
+		// Token expiring in 1 minute (within the 5-minute refresh window)
+		authStore.setAuth('dying-tok', { id: 'u1', username: 'grug' }, 60)
+
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response('', { status: 401 })
+		)
+
+		const fakeLocation = { href: '' }
+		;(globalThis as any).window = { location: fakeLocation }
+
+		const result = await authStore.checkAndRefresh()
+
+		expect(result).toBeNull()
+		expect(get(authStore).isAuthenticated).toBe(false)
+
+		delete (globalThis as any).window
+	})
+})
+
+// ============================================================================
+// getToken recovery
+// ============================================================================
+
+describe('getToken recovery', () => {
+	it('returns new token after refresh triggered by expired getToken', async () => {
+		// Set an expired token
+		authStore.setAuth('expired-tok', { id: 'u1', username: 'grug' }, -1)
+
+		;(globalThis as any).window = { location: { href: '' } }
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					access_token: 'recovered-tok',
+					user: { id: 'u1', username: 'grug' },
+					expires_in: 3600
+				}),
+				{ status: 200 }
+			)
+		)
+
+		// First call returns null (expired)
+		expect(authStore.getToken()).toBeNull()
+
+		// Wait for the fire-and-forget refresh to complete
+		await vi.waitFor(() => expect(get(authStore).isRefreshing).toBe(false))
+
+		// Now getToken should return the refreshed token
+		expect(authStore.getToken()).toBe('recovered-tok')
+
+		delete (globalThis as any).window
+	})
+})

--- a/src/lib/stores/auth.store.ts
+++ b/src/lib/stores/auth.store.ts
@@ -133,6 +133,8 @@ function createAuthStore() {
           if (refreshed) {
             return get(authStore).accessToken
           }
+          // Refresh failed — auth was cleared, return null
+          return null
         }
       }
 


### PR DESCRIPTION
## Summary
- Fix double-transform bugs in crew, job, raid adapters
- Fix stale token return in auth store
- Add test fixtures grounded in Rails API blueprints
- 171 adapter tests, 18 auth tests, 21 cache/cookie/oauth tests

## Test plan
- [x] `pnpm vitest run` passes