### PR TITLE
Extract mutation options factories and add tests

### DIFF
--- a/src/lib/api/mutations/__tests__/artifact.mutations.test.ts
+++ b/src/lib/api/mutations/__tests__/artifact.mutations.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+	createCollectionArtifactOptions,
+	createCollectionArtifactsBatchOptions,
+	updateCollectionArtifactOptions,
+	deleteCollectionArtifactOptions,
+	bulkDeleteCollectionArtifactsOptions,
+	createGridArtifactOptions,
+	updateGridArtifactOptions,
+	deleteGridArtifactOptions,
+	equipCollectionArtifactOptions,
+	gradeArtifactOptions,
+	syncGridArtifactOptions
+} from '../artifact.mutations'
+import { createTestQueryClient } from './helpers'
+import type { QueryClient } from '@tanstack/svelte-query'
+
+vi.mock('$lib/api/adapters/artifact.adapter', () => ({
+	artifactAdapter: {
+		createCollectionArtifact: vi.fn(),
+		createCollectionArtifactsBatch: vi.fn(),
+		updateCollectionArtifact: vi.fn(),
+		deleteCollectionArtifact: vi.fn(),
+		deleteCollectionArtifactsBatch: vi.fn(),
+		createGridArtifact: vi.fn(),
+		updateGridArtifact: vi.fn(),
+		deleteGridArtifact: vi.fn(),
+		equipCollectionArtifact: vi.fn(),
+		gradeArtifact: vi.fn(),
+		syncGridArtifact: vi.fn()
+	}
+}))
+
+let queryClient: QueryClient
+
+beforeEach(() => {
+	queryClient = createTestQueryClient()
+})
+
+// ============================================================================
+// Collection Artifact Mutations
+// ============================================================================
+
+describe('createCollectionArtifactOptions', () => {
+	it('invalidates collection base on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = createCollectionArtifactOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['collection', 'artifacts'])
+	})
+})
+
+describe('createCollectionArtifactsBatchOptions', () => {
+	it('invalidates collection base on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = createCollectionArtifactsBatchOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['collection', 'artifacts'])
+	})
+})
+
+describe('updateCollectionArtifactOptions', () => {
+	it('invalidates collection base on settled', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updateCollectionArtifactOptions(queryClient)
+
+		opts.onSettled()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['collection', 'artifacts'])
+	})
+})
+
+describe('deleteCollectionArtifactOptions', () => {
+	it('invalidates collection base on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = deleteCollectionArtifactOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['collection', 'artifacts'])
+	})
+})
+
+describe('bulkDeleteCollectionArtifactsOptions', () => {
+	it('invalidates collection base on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = bulkDeleteCollectionArtifactsOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['collection', 'artifacts'])
+	})
+})
+
+// ============================================================================
+// Grid Artifact Mutations
+// ============================================================================
+
+describe('createGridArtifactOptions', () => {
+	it('invalidates specific party on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = createGridArtifactOptions(queryClient)
+
+		opts.onSuccess(undefined, { partyId: 'party-1', gridCharacterId: 'gc-1', artifactId: 'a-1' } as any)
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['parties', 'party-1'])
+	})
+})
+
+describe('updateGridArtifactOptions', () => {
+	it('invalidates all parties on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updateGridArtifactOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['parties'])
+	})
+})
+
+describe('deleteGridArtifactOptions', () => {
+	it('invalidates all parties on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = deleteGridArtifactOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['parties'])
+	})
+})
+
+describe('equipCollectionArtifactOptions', () => {
+	it('invalidates specific party on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = equipCollectionArtifactOptions(queryClient)
+
+		opts.onSuccess(undefined, { partyId: 'party-1', gridCharacterId: 'gc-1', collectionArtifactId: 'ca-1' })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['parties', 'party-1'])
+	})
+})
+
+// ============================================================================
+// Grading & Sync
+// ============================================================================
+
+describe('gradeArtifactOptions', () => {
+	it('has no cache side effects', () => {
+		const opts = gradeArtifactOptions()
+
+		expect(opts.mutationFn).toBeDefined()
+		expect((opts as any).onSuccess).toBeUndefined()
+		expect((opts as any).onSettled).toBeUndefined()
+		expect((opts as any).onMutate).toBeUndefined()
+	})
+})
+
+describe('syncGridArtifactOptions', () => {
+	it('invalidates party detail by shortcode on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = syncGridArtifactOptions(queryClient)
+
+		opts.onSuccess(undefined, { id: 'ga-1', partyShortcode: 'ABC123' })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['parties', 'detail', 'ABC123'])
+	})
+})

--- a/src/lib/api/mutations/__tests__/collection.mutations.test.ts
+++ b/src/lib/api/mutations/__tests__/collection.mutations.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+	addCharactersToCollectionOptions,
+	addCharacterToCollectionOptions,
+	updateCollectionCharacterOptions,
+	removeCharacterFromCollectionOptions,
+	bulkRemoveCharactersFromCollectionOptions,
+	addWeaponToCollectionOptions,
+	addWeaponsToCollectionOptions,
+	updateCollectionWeaponOptions,
+	removeWeaponFromCollectionOptions,
+	bulkRemoveWeaponsFromCollectionOptions,
+	addSummonToCollectionOptions,
+	addSummonsToCollectionOptions,
+	updateCollectionSummonOptions,
+	removeSummonFromCollectionOptions,
+	bulkRemoveSummonsFromCollectionOptions,
+	addJobAccessoryToCollectionOptions,
+	removeJobAccessoryFromCollectionOptions
+} from '../collection.mutations'
+import { createTestQueryClient } from './helpers'
+import { collectionKeys } from '$lib/api/queries/collection.queries'
+import type { QueryClient } from '@tanstack/svelte-query'
+
+vi.mock('$lib/api/adapters/collection.adapter', () => ({
+	collectionAdapter: {
+		addCharacters: vi.fn(),
+		addCharacter: vi.fn(),
+		updateCharacter: vi.fn(),
+		removeCharacter: vi.fn(),
+		removeCharactersBatch: vi.fn(),
+		addWeapon: vi.fn(),
+		addWeapons: vi.fn(),
+		updateWeapon: vi.fn(),
+		removeWeapon: vi.fn(),
+		removeWeaponsBatch: vi.fn(),
+		addSummon: vi.fn(),
+		addSummons: vi.fn(),
+		updateSummon: vi.fn(),
+		removeSummon: vi.fn(),
+		removeSummonsBatch: vi.fn(),
+		addJobAccessory: vi.fn(),
+		removeJobAccessory: vi.fn()
+	}
+}))
+
+let queryClient: QueryClient
+
+beforeEach(() => {
+	queryClient = createTestQueryClient()
+})
+
+// ============================================================================
+// Character Mutations
+// ============================================================================
+
+describe('addCharactersToCollectionOptions', () => {
+	it('invalidates characters and characterIds on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = addCharactersToCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.characters())
+		expect(keys).toContainEqual(collectionKeys.characterIds())
+	})
+})
+
+describe('addCharacterToCollectionOptions', () => {
+	it('invalidates characters and characterIds on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = addCharacterToCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.characters())
+		expect(keys).toContainEqual(collectionKeys.characterIds())
+	})
+})
+
+describe('updateCollectionCharacterOptions', () => {
+	const MOCK_COLLECTION_CHAR = { id: 'cc-1', uncapLevel: 4, name: 'Test' }
+
+	it('optimistically merges updates into cached character', async () => {
+		queryClient.setQueryData(collectionKeys.character('cc-1'), MOCK_COLLECTION_CHAR)
+		const opts = updateCollectionCharacterOptions(queryClient)
+
+		await opts.onMutate({ id: 'cc-1', input: { uncapLevel: 5 } as any })
+
+		const cached = queryClient.getQueryData(collectionKeys.character('cc-1')) as any
+		expect(cached.uncapLevel).toBe(5)
+		expect(cached.name).toBe('Test')
+	})
+
+	it('returns snapshot for rollback', async () => {
+		queryClient.setQueryData(collectionKeys.character('cc-1'), MOCK_COLLECTION_CHAR)
+		const opts = updateCollectionCharacterOptions(queryClient)
+
+		const context = await opts.onMutate({ id: 'cc-1', input: { uncapLevel: 5 } as any })
+
+		expect(context.previousCharacter).toEqual(MOCK_COLLECTION_CHAR)
+	})
+
+	it('rolls back on error', async () => {
+		queryClient.setQueryData(collectionKeys.character('cc-1'), MOCK_COLLECTION_CHAR)
+		const opts = updateCollectionCharacterOptions(queryClient)
+		const params = { id: 'cc-1', input: { uncapLevel: 5 } as any }
+
+		const context = await opts.onMutate(params)
+		opts.onError(new Error('fail'), params, context)
+
+		const cached = queryClient.getQueryData(collectionKeys.character('cc-1')) as any
+		expect(cached.uncapLevel).toBe(4)
+	})
+
+	it('does nothing on error without context', () => {
+		queryClient.setQueryData(collectionKeys.character('cc-1'), MOCK_COLLECTION_CHAR)
+		const opts = updateCollectionCharacterOptions(queryClient)
+
+		opts.onError(new Error('fail'), { id: 'cc-1', input: {} as any }, undefined)
+
+		const cached = queryClient.getQueryData(collectionKeys.character('cc-1'))
+		expect(cached).toEqual(MOCK_COLLECTION_CHAR)
+	})
+
+	it('invalidates character and characters on settled', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updateCollectionCharacterOptions(queryClient)
+
+		opts.onSettled(undefined, undefined, { id: 'cc-1', input: {} as any })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.character('cc-1'))
+		expect(keys).toContainEqual(collectionKeys.characters())
+	})
+})
+
+describe('removeCharacterFromCollectionOptions', () => {
+	it('invalidates characters and characterIds on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = removeCharacterFromCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.characters())
+		expect(keys).toContainEqual(collectionKeys.characterIds())
+	})
+})
+
+describe('bulkRemoveCharactersFromCollectionOptions', () => {
+	it('invalidates characters and characterIds on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = bulkRemoveCharactersFromCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.characters())
+		expect(keys).toContainEqual(collectionKeys.characterIds())
+	})
+})
+
+// ============================================================================
+// Weapon Mutations
+// ============================================================================
+
+describe('addWeaponToCollectionOptions', () => {
+	it('invalidates weapons on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = addWeaponToCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.weapons())
+	})
+})
+
+describe('addWeaponsToCollectionOptions', () => {
+	it('invalidates weapons on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = addWeaponsToCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.weapons())
+	})
+})
+
+describe('updateCollectionWeaponOptions', () => {
+	it('resets weapons queries on success', () => {
+		const spy = vi.spyOn(queryClient, 'resetQueries')
+		const opts = updateCollectionWeaponOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.weapons())
+	})
+})
+
+describe('removeWeaponFromCollectionOptions', () => {
+	it('resets weapons queries on success', () => {
+		const spy = vi.spyOn(queryClient, 'resetQueries')
+		const opts = removeWeaponFromCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.weapons())
+	})
+})
+
+describe('bulkRemoveWeaponsFromCollectionOptions', () => {
+	it('resets weapons queries on success', () => {
+		const spy = vi.spyOn(queryClient, 'resetQueries')
+		const opts = bulkRemoveWeaponsFromCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.weapons())
+	})
+})
+
+// ============================================================================
+// Summon Mutations
+// ============================================================================
+
+describe('addSummonToCollectionOptions', () => {
+	it('invalidates summons on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = addSummonToCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.summons())
+	})
+})
+
+describe('addSummonsToCollectionOptions', () => {
+	it('invalidates summons on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = addSummonsToCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.summons())
+	})
+})
+
+describe('updateCollectionSummonOptions', () => {
+	it('invalidates summons on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updateCollectionSummonOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.summons())
+	})
+})
+
+describe('removeSummonFromCollectionOptions', () => {
+	it('invalidates summons on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = removeSummonFromCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.summons())
+	})
+})
+
+describe('bulkRemoveSummonsFromCollectionOptions', () => {
+	it('invalidates summons on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = bulkRemoveSummonsFromCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.summons())
+	})
+})
+
+// ============================================================================
+// Job Accessory Mutations
+// ============================================================================
+
+describe('addJobAccessoryToCollectionOptions', () => {
+	it('invalidates all collection queries on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = addJobAccessoryToCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.all)
+	})
+})
+
+describe('removeJobAccessoryFromCollectionOptions', () => {
+	it('invalidates all collection queries on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = removeJobAccessoryFromCollectionOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(collectionKeys.all)
+	})
+})

--- a/src/lib/api/mutations/__tests__/crew.mutations.test.ts
+++ b/src/lib/api/mutations/__tests__/crew.mutations.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+	createCrewOptions,
+	updateCrewOptions,
+	leaveCrewOptions,
+	transferCaptainOptions,
+	updateMembershipOptions,
+	removeMemberOptions,
+	sendInvitationOptions,
+	acceptInvitationOptions,
+	rejectInvitationOptions,
+	createPhantomOptions,
+	bulkCreatePhantomsOptions,
+	updatePhantomOptions,
+	deletePhantomOptions,
+	assignPhantomOptions,
+	confirmPhantomClaimOptions,
+	declinePhantomClaimOptions
+} from '../crew.mutations'
+import { createTestQueryClient } from './helpers'
+import { crewKeys } from '$lib/api/queries/crew.queries'
+import type { QueryClient } from '@tanstack/svelte-query'
+
+vi.mock('$lib/api/adapters/crew.adapter', () => ({
+	crewAdapter: {
+		create: vi.fn(),
+		update: vi.fn(),
+		leave: vi.fn(),
+		transferCaptain: vi.fn(),
+		updateMembership: vi.fn(),
+		removeMember: vi.fn(),
+		sendInvitation: vi.fn(),
+		acceptInvitation: vi.fn(),
+		rejectInvitation: vi.fn(),
+		createPhantom: vi.fn(),
+		bulkCreatePhantoms: vi.fn(),
+		updatePhantom: vi.fn(),
+		deletePhantom: vi.fn(),
+		assignPhantom: vi.fn(),
+		confirmPhantomClaim: vi.fn(),
+		declinePhantomClaim: vi.fn()
+	}
+}))
+
+let queryClient: QueryClient
+
+beforeEach(() => {
+	queryClient = createTestQueryClient()
+})
+
+// ============================================================================
+// Crew CRUD
+// ============================================================================
+
+describe('createCrewOptions', () => {
+	it('sets crew in cache on success', () => {
+		const opts = createCrewOptions(queryClient)
+		const crew = { id: 'crew-1', name: 'Test Crew' }
+
+		opts.onSuccess(crew)
+
+		expect(queryClient.getQueryData(crewKeys.myCrew())).toEqual(crew)
+	})
+
+	it('invalidates pending invitations on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = createCrewOptions(queryClient)
+
+		opts.onSuccess({ id: 'crew-1' })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.invitations.pending())
+	})
+})
+
+describe('updateCrewOptions', () => {
+	it('sets updated crew in cache on success', () => {
+		const opts = updateCrewOptions(queryClient)
+		const crew = { id: 'crew-1', name: 'Updated Crew' }
+
+		opts.onSuccess(crew)
+
+		expect(queryClient.getQueryData(crewKeys.myCrew())).toEqual(crew)
+	})
+})
+
+describe('leaveCrewOptions', () => {
+	it('removes crew and members from cache on success', () => {
+		queryClient.setQueryData(crewKeys.myCrew(), { id: 'crew-1' })
+		queryClient.setQueryData(crewKeys.membersAll(), [{ id: 'm-1' }])
+		const opts = leaveCrewOptions(queryClient)
+
+		opts.onSuccess()
+
+		expect(queryClient.getQueryData(crewKeys.myCrew())).toBeUndefined()
+		expect(queryClient.getQueryData(crewKeys.membersAll())).toBeUndefined()
+	})
+})
+
+describe('transferCaptainOptions', () => {
+	it('invalidates myCrew and membersAll on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = transferCaptainOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.myCrew())
+		expect(keys).toContainEqual(crewKeys.membersAll())
+	})
+})
+
+// ============================================================================
+// Membership
+// ============================================================================
+
+describe('updateMembershipOptions', () => {
+	it('invalidates membersAll on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updateMembershipOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.membersAll())
+	})
+})
+
+describe('removeMemberOptions', () => {
+	it('invalidates membersAll and myCrew on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = removeMemberOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.membersAll())
+		expect(keys).toContainEqual(crewKeys.myCrew())
+	})
+})
+
+// ============================================================================
+// Invitations
+// ============================================================================
+
+describe('sendInvitationOptions', () => {
+	it('invalidates crew-specific invitations on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = sendInvitationOptions(queryClient)
+
+		opts.onSuccess(undefined, { crewId: 'crew-1', userId: 'user-1' })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.crewInvitations('crew-1'))
+	})
+})
+
+describe('acceptInvitationOptions', () => {
+	it('invalidates myCrew and pending invitations on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = acceptInvitationOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.myCrew())
+		expect(keys).toContainEqual(crewKeys.invitations.pending())
+	})
+})
+
+describe('rejectInvitationOptions', () => {
+	it('invalidates pending invitations on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = rejectInvitationOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.invitations.pending())
+	})
+})
+
+// ============================================================================
+// Phantom Players
+// ============================================================================
+
+describe('createPhantomOptions', () => {
+	it('invalidates membersAll on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = createPhantomOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.membersAll())
+	})
+})
+
+describe('bulkCreatePhantomsOptions', () => {
+	it('invalidates membersAll on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = bulkCreatePhantomsOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.membersAll())
+	})
+})
+
+describe('updatePhantomOptions', () => {
+	it('invalidates membersAll on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updatePhantomOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.membersAll())
+	})
+})
+
+describe('deletePhantomOptions', () => {
+	it('invalidates membersAll on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = deletePhantomOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.membersAll())
+	})
+})
+
+describe('assignPhantomOptions', () => {
+	it('invalidates membersAll on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = assignPhantomOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.membersAll())
+	})
+})
+
+describe('confirmPhantomClaimOptions', () => {
+	it('invalidates membersAll and pending phantom claims on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = confirmPhantomClaimOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.membersAll())
+		expect(keys).toContainEqual(crewKeys.phantomClaims.pending())
+	})
+})
+
+describe('declinePhantomClaimOptions', () => {
+	it('invalidates membersAll and pending phantom claims on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = declinePhantomClaimOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(crewKeys.membersAll())
+		expect(keys).toContainEqual(crewKeys.phantomClaims.pending())
+	})
+})

--- a/src/lib/api/mutations/__tests__/fixtures.ts
+++ b/src/lib/api/mutations/__tests__/fixtures.ts
@@ -1,0 +1,196 @@
+/**
+ * Shared test fixtures for mutation tests
+ *
+ * Provides mock data objects matching the app's TypeScript types.
+ * Keep fixtures minimal — only include required fields and fields
+ * that mutations actually read or transform.
+ */
+
+import type { Party, GridWeapon, GridCharacter, GridSummon, JobSkillList } from '$lib/types/api/party'
+import type { Weapon, Character, Summon, Job, JobSkill } from '$lib/types/api/entities'
+
+// ============================================================================
+// Base Entities
+// ============================================================================
+
+export const MOCK_WEAPON: Weapon = {
+	id: 'weapon-1',
+	granblueId: '1040001',
+	name: { en: 'Test Weapon', ja: 'テスト武器' },
+	rarity: 5,
+	element: 1,
+	maxLevel: 150,
+	maxSkillLevel: 15,
+	maxAwakeningLevel: 5,
+	series: {
+		id: 'series-1',
+		slug: 'dark-opus',
+		name: { en: 'Dark Opus', ja: 'ダークオーパス' },
+		hasWeaponKeys: true,
+		hasAwakening: true,
+		augmentType: 'no_augment',
+		extra: false,
+		elementChangeable: false
+	},
+	proficiency: 1,
+	ax: true,
+	axType: 1,
+	uncap: { flb: true, ulb: true, transcendence: false },
+	hp: { minHp: 100, maxHp: 500, maxHpFlb: 600, maxHpUlb: 700 },
+	atk: { minAtk: 200, maxAtk: 1000, maxAtkFlb: 1200, maxAtkUlb: 1400 }
+}
+
+export const MOCK_CHARACTER: Character = {
+	id: 'char-1',
+	granblueId: '3040001',
+	name: { en: 'Test Character', ja: 'テストキャラ' },
+	rarity: 5,
+	element: 1,
+	maxLevel: 100,
+	uncap: { flb: true, ulb: true },
+	special: false,
+	recruits: null,
+	gender: 0,
+	race: { race1: 1, race2: 0 },
+	proficiency: [1],
+	hp: { minHp: 150, maxHp: 750, maxHpFlb: 900 },
+	atk: { minAtk: 250, maxAtk: 1250, maxAtkFlb: 1500 }
+}
+
+export const MOCK_SUMMON: Summon = {
+	id: 'summon-1',
+	granblueId: '2040001',
+	name: { en: 'Test Summon', ja: 'テスト召喚石' },
+	rarity: 5,
+	element: 1,
+	maxLevel: 150,
+	uncap: { flb: true, ulb: true, transcendence: false },
+	subaura: false,
+	hp: { minHp: 100, maxHp: 500, maxHpFlb: 600, maxHpUlb: 700 },
+	atk: { minAtk: 200, maxAtk: 1000, maxAtkFlb: 1200, maxAtkUlb: 1400 }
+}
+
+// ============================================================================
+// Grid Items
+// ============================================================================
+
+export const MOCK_GRID_WEAPON: GridWeapon = {
+	id: 'gw-1',
+	position: 1,
+	mainhand: true,
+	uncapLevel: 5,
+	transcendenceStep: 0,
+	weapon: MOCK_WEAPON
+}
+
+export const MOCK_GRID_WEAPON_2: GridWeapon = {
+	id: 'gw-2',
+	position: 2,
+	mainhand: false,
+	uncapLevel: 4,
+	transcendenceStep: 0,
+	weapon: { ...MOCK_WEAPON, id: 'weapon-2', granblueId: '1040002' }
+}
+
+export const MOCK_GRID_CHARACTER: GridCharacter = {
+	id: 'gc-1',
+	position: 1,
+	uncapLevel: 5,
+	transcendenceStep: 1,
+	character: MOCK_CHARACTER
+}
+
+export const MOCK_GRID_CHARACTER_2: GridCharacter = {
+	id: 'gc-2',
+	position: 2,
+	uncapLevel: 4,
+	transcendenceStep: 0,
+	character: { ...MOCK_CHARACTER, id: 'char-2', granblueId: '3040002' }
+}
+
+export const MOCK_GRID_SUMMON: GridSummon = {
+	id: 'gs-1',
+	position: 1,
+	quickSummon: true,
+	uncapLevel: 5,
+	transcendenceStep: 2,
+	summon: MOCK_SUMMON
+}
+
+export const MOCK_GRID_SUMMON_2: GridSummon = {
+	id: 'gs-2',
+	position: 2,
+	quickSummon: false,
+	uncapLevel: 3,
+	transcendenceStep: 0,
+	summon: { ...MOCK_SUMMON, id: 'summon-2', granblueId: '2040002' }
+}
+
+// ============================================================================
+// Job & Skills
+// ============================================================================
+
+export const MOCK_JOB: Job = {
+	id: 'job-1',
+	granblueId: '100001',
+	name: { en: 'Dark Fencer', ja: 'ダークフェンサー' },
+	row: 4,
+	order: 1,
+	proficiency: [1, 0],
+	masterLevel: true,
+	ultimateMastery: false,
+	accessory: false,
+	auxWeapon: false
+}
+
+export const MOCK_JOB_SKILL_1: JobSkill = {
+	id: 'skill-1',
+	name: { en: 'Gravity', ja: 'グラビティ' },
+	slug: 'gravity',
+	color: 0,
+	main: true,
+	sub: false,
+	emp: false,
+	base: false,
+	order: 1,
+	job: MOCK_JOB
+}
+
+export const MOCK_JOB_SKILL_2: JobSkill = {
+	id: 'skill-2',
+	name: { en: 'Delay', ja: 'ディレイ' },
+	slug: 'delay',
+	color: 1,
+	main: false,
+	sub: true,
+	emp: false,
+	base: false,
+	order: 2,
+	job: MOCK_JOB
+}
+
+export const MOCK_JOB_SKILLS: JobSkillList = {
+	0: MOCK_JOB_SKILL_1,
+	1: MOCK_JOB_SKILL_2
+}
+
+// ============================================================================
+// Party
+// ============================================================================
+
+export const MOCK_SHORTCODE = 'ABC123'
+
+export const MOCK_PARTY: Party = {
+	id: 'party-uuid-550e8400-e29b-41d4-a716-446655440000',
+	shortcode: MOCK_SHORTCODE,
+	name: 'Test Party',
+	weapons: [MOCK_GRID_WEAPON, MOCK_GRID_WEAPON_2],
+	characters: [MOCK_GRID_CHARACTER, MOCK_GRID_CHARACTER_2],
+	summons: [MOCK_GRID_SUMMON, MOCK_GRID_SUMMON_2],
+	job: MOCK_JOB,
+	jobSkills: MOCK_JOB_SKILLS,
+	favorited: false,
+	user: { id: 'user-1', username: 'testuser' },
+	createdAt: '2024-01-01T00:00:00Z',
+	updatedAt: '2024-01-01T00:00:00Z'
+}

--- a/src/lib/api/mutations/__tests__/grid.mutations.test.ts
+++ b/src/lib/api/mutations/__tests__/grid.mutations.test.ts
@@ -1,0 +1,628 @@
+/**
+ * Tests for grid mutation options factories
+ *
+ * Tests cache operations (optimistic updates, rollbacks, invalidation)
+ * by calling options callbacks directly against a real QueryClient.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { partyKeys } from '$lib/api/queries/party.queries'
+import {
+	createGridMutation,
+	createGridWeaponOptions,
+	updateGridWeaponOptions,
+	deleteGridWeaponOptions,
+	updateWeaponUncapOptions,
+	resolveWeaponConflictOptions,
+	swapWeaponsOptions,
+	createGridCharacterOptions,
+	updateGridCharacterOptions,
+	deleteGridCharacterOptions,
+	updateCharacterUncapOptions,
+	resolveCharacterConflictOptions,
+	swapCharactersOptions,
+	createGridSummonOptions,
+	updateGridSummonOptions,
+	deleteGridSummonOptions,
+	updateSummonUncapOptions,
+	updateQuickSummonOptions,
+	swapSummonsOptions,
+	syncGridCharacterOptions,
+	syncGridWeaponOptions,
+	syncGridSummonOptions,
+	syncAllPartyItemsOptions,
+	unlinkCollectionSourceOptions
+} from '../grid.mutations'
+import { createTestQueryClient, seedPartyCache, getCachedParty } from './helpers'
+import { MOCK_PARTY, MOCK_SHORTCODE } from './fixtures'
+import type { QueryClient } from '@tanstack/svelte-query'
+
+// Mock adapter modules — we only test cache behavior, not API calls
+vi.mock('$lib/api/adapters/grid.adapter', () => ({
+	gridAdapter: {
+		createWeapon: vi.fn().mockResolvedValue({}),
+		updateWeapon: vi.fn().mockResolvedValue({}),
+		deleteWeapon: vi.fn().mockResolvedValue({}),
+		updateWeaponUncap: vi.fn().mockResolvedValue({}),
+		resolveWeaponConflict: vi.fn().mockResolvedValue({}),
+		swapWeapons: vi.fn().mockResolvedValue({}),
+		createCharacter: vi.fn().mockResolvedValue({}),
+		updateCharacter: vi.fn().mockResolvedValue({}),
+		deleteCharacter: vi.fn().mockResolvedValue({}),
+		updateCharacterUncap: vi.fn().mockResolvedValue({}),
+		resolveCharacterConflict: vi.fn().mockResolvedValue({}),
+		swapCharacters: vi.fn().mockResolvedValue({}),
+		createSummon: vi.fn().mockResolvedValue({}),
+		updateSummon: vi.fn().mockResolvedValue({}),
+		deleteSummon: vi.fn().mockResolvedValue({}),
+		updateSummonUncap: vi.fn().mockResolvedValue({}),
+		updateQuickSummon: vi.fn().mockResolvedValue({}),
+		swapSummons: vi.fn().mockResolvedValue({}),
+		syncCharacter: vi.fn().mockResolvedValue({}),
+		syncWeapon: vi.fn().mockResolvedValue({}),
+		syncSummon: vi.fn().mockResolvedValue({}),
+		syncAllPartyItems: vi.fn().mockResolvedValue({}),
+		unlinkCollectionSource: vi.fn().mockResolvedValue({})
+	}
+}))
+
+vi.mock('$lib/utils/editKeys', () => ({
+	getEditKey: vi.fn()
+}))
+
+vi.mock('$lib/query/cacheHelpers', () => ({
+	invalidateParty: vi.fn()
+}))
+
+describe('grid mutations', () => {
+	let queryClient: QueryClient
+
+	beforeEach(() => {
+		queryClient = createTestQueryClient()
+		seedPartyCache(queryClient, MOCK_PARTY)
+		vi.clearAllMocks()
+	})
+
+	// ========================================================================
+	// createGridMutation wrapper
+	// ========================================================================
+
+	describe('createGridMutation', () => {
+		it('calls adapter without X-Edit-Key when no edit key exists', async () => {
+			const { getEditKey } = await import('$lib/utils/editKeys')
+			vi.mocked(getEditKey).mockReturnValue(null)
+
+			const mockAdapter = vi.fn().mockResolvedValue({ id: 'result' })
+			const wrapped = createGridMutation(mockAdapter)
+
+			await wrapped({ partyId: 'some-shortcode', weaponId: 'w1', position: 1 })
+
+			expect(mockAdapter).toHaveBeenCalledWith(
+				{ partyId: 'some-shortcode', weaponId: 'w1', position: 1 },
+				undefined
+			)
+		})
+
+		it('injects X-Edit-Key header when edit key exists', async () => {
+			const { getEditKey } = await import('$lib/utils/editKeys')
+			vi.mocked(getEditKey).mockReturnValue('secret-edit-key')
+
+			const mockAdapter = vi.fn().mockResolvedValue({ id: 'result' })
+			const wrapped = createGridMutation(mockAdapter)
+
+			await wrapped({ partyId: 'some-shortcode', weaponId: 'w1', position: 1 })
+
+			expect(mockAdapter).toHaveBeenCalledWith(
+				{ partyId: 'some-shortcode', weaponId: 'w1', position: 1 },
+				{ 'X-Edit-Key': 'secret-edit-key' }
+			)
+		})
+
+		it('skips edit key lookup for numeric partyId', async () => {
+			const { getEditKey } = await import('$lib/utils/editKeys')
+
+			const mockAdapter = vi.fn().mockResolvedValue({ id: 'result' })
+			const wrapped = createGridMutation(mockAdapter)
+
+			await wrapped({ partyId: 123, weaponId: 'w1', position: 1 })
+
+			expect(getEditKey).not.toHaveBeenCalled()
+			expect(mockAdapter).toHaveBeenCalledWith(
+				{ partyId: 123, weaponId: 'w1', position: 1 },
+				undefined
+			)
+		})
+	})
+
+	// ========================================================================
+	// Weapon Mutations
+	// ========================================================================
+
+	describe('createGridWeaponOptions', () => {
+		it('onSuccess calls invalidateParty', async () => {
+			const { invalidateParty } = await import('$lib/query/cacheHelpers')
+			const opts = createGridWeaponOptions(queryClient)
+
+			opts.onSuccess({}, { partyId: 'party-uuid', weaponId: 'w1', position: 1 })
+
+			expect(invalidateParty).toHaveBeenCalledWith(queryClient, 'party-uuid')
+		})
+	})
+
+	describe('updateGridWeaponOptions', () => {
+		it('onMutate optimistically updates the weapon in cache', async () => {
+			const opts = updateGridWeaponOptions(queryClient)
+
+			const context = await opts.onMutate({
+				id: 'gw-1',
+				partyShortcode: MOCK_SHORTCODE,
+				updates: { element: 3 }
+			})
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.weapons[0]).toMatchObject({ id: 'gw-1', element: 3 })
+			expect(cached?.weapons[1].id).toBe('gw-2') // other weapon untouched
+			expect(context?.previousParty).toEqual(MOCK_PARTY)
+		})
+
+		it('onMutate handles missing weapons array', async () => {
+			const partyWithoutWeapons = { ...MOCK_PARTY, weapons: undefined as any }
+			queryClient.setQueryData(partyKeys.detail(MOCK_SHORTCODE), partyWithoutWeapons)
+
+			const opts = updateGridWeaponOptions(queryClient)
+			const context = await opts.onMutate({
+				id: 'gw-1',
+				partyShortcode: MOCK_SHORTCODE,
+				updates: { element: 3 }
+			})
+
+			expect(context?.previousParty).toEqual(partyWithoutWeapons)
+		})
+
+		it('onError rolls back to previous party', () => {
+			const opts = updateGridWeaponOptions(queryClient)
+			const modifiedParty = { ...MOCK_PARTY, name: 'Modified' }
+			queryClient.setQueryData(partyKeys.detail(MOCK_SHORTCODE), modifiedParty)
+
+			opts.onError(new Error('fail'), { partyShortcode: MOCK_SHORTCODE } as any, {
+				previousParty: MOCK_PARTY
+			})
+
+			expect(getCachedParty(queryClient, MOCK_SHORTCODE)).toEqual(MOCK_PARTY)
+		})
+
+		it('onError does nothing without context', () => {
+			const opts = updateGridWeaponOptions(queryClient)
+
+			opts.onError(new Error('fail'), { partyShortcode: MOCK_SHORTCODE } as any, undefined)
+
+			expect(getCachedParty(queryClient, MOCK_SHORTCODE)).toEqual(MOCK_PARTY)
+		})
+
+		it('onSettled invalidates the party query', () => {
+			const opts = updateGridWeaponOptions(queryClient)
+			const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+			opts.onSettled(null, null, { partyShortcode: MOCK_SHORTCODE } as any)
+
+			expect(spy).toHaveBeenCalledWith({ queryKey: partyKeys.detail(MOCK_SHORTCODE) })
+		})
+	})
+
+	describe('deleteGridWeaponOptions', () => {
+		it('onMutate removes weapon by id', async () => {
+			const opts = deleteGridWeaponOptions(queryClient)
+
+			await opts.onMutate({ partyShortcode: MOCK_SHORTCODE, id: 'gw-1' })
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.weapons).toHaveLength(1)
+			expect(cached?.weapons[0].id).toBe('gw-2')
+		})
+
+		it('onMutate removes weapon by position when id is undefined', async () => {
+			const opts = deleteGridWeaponOptions(queryClient)
+
+			await opts.onMutate({ partyShortcode: MOCK_SHORTCODE, id: undefined, position: 2 })
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.weapons).toHaveLength(1)
+			expect(cached?.weapons[0].id).toBe('gw-1')
+		})
+
+		it('onError restores deleted weapon', async () => {
+			const opts = deleteGridWeaponOptions(queryClient)
+
+			await opts.onMutate({ partyShortcode: MOCK_SHORTCODE, id: 'gw-1' })
+			opts.onError(new Error('fail'), { partyShortcode: MOCK_SHORTCODE } as any, {
+				previousParty: MOCK_PARTY
+			})
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.weapons).toHaveLength(2)
+		})
+	})
+
+	describe('updateWeaponUncapOptions', () => {
+		it('onMutate updates uncapLevel on correct weapon', async () => {
+			const opts = updateWeaponUncapOptions(queryClient)
+
+			await opts.onMutate({
+				partyShortcode: MOCK_SHORTCODE,
+				id: 'gw-1',
+				partyId: 'party-uuid',
+				uncapLevel: 6
+			})
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.weapons[0].uncapLevel).toBe(6)
+			expect(cached?.weapons[1].uncapLevel).toBe(4) // untouched
+		})
+
+		it('onMutate updates transcendenceStep when provided', async () => {
+			const opts = updateWeaponUncapOptions(queryClient)
+
+			await opts.onMutate({
+				partyShortcode: MOCK_SHORTCODE,
+				id: 'gw-1',
+				partyId: 'party-uuid',
+				uncapLevel: 6,
+				transcendenceStep: 3
+			})
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.weapons[0].transcendenceStep).toBe(3)
+		})
+
+		it('onMutate does not set transcendenceStep when undefined', async () => {
+			const opts = updateWeaponUncapOptions(queryClient)
+
+			await opts.onMutate({
+				partyShortcode: MOCK_SHORTCODE,
+				id: 'gw-1',
+				partyId: 'party-uuid',
+				uncapLevel: 6,
+				transcendenceStep: undefined
+			})
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.weapons[0].transcendenceStep).toBe(0) // original value preserved
+		})
+	})
+
+	describe('resolveWeaponConflictOptions', () => {
+		it('onSuccess invalidates party detail', () => {
+			const opts = resolveWeaponConflictOptions(queryClient)
+			const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+			opts.onSuccess({}, { partyShortcode: MOCK_SHORTCODE } as any)
+
+			expect(spy).toHaveBeenCalledWith({ queryKey: partyKeys.detail(MOCK_SHORTCODE) })
+		})
+	})
+
+	describe('swapWeaponsOptions', () => {
+		it('onSuccess invalidates party detail', () => {
+			const opts = swapWeaponsOptions(queryClient)
+			const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+			opts.onSuccess({}, { partyShortcode: MOCK_SHORTCODE } as any)
+
+			expect(spy).toHaveBeenCalledWith({ queryKey: partyKeys.detail(MOCK_SHORTCODE) })
+		})
+	})
+
+	// ========================================================================
+	// Character Mutations
+	// ========================================================================
+
+	describe('createGridCharacterOptions', () => {
+		it('onSuccess calls invalidateParty', async () => {
+			const { invalidateParty } = await import('$lib/query/cacheHelpers')
+			const opts = createGridCharacterOptions(queryClient)
+
+			opts.onSuccess({}, { partyId: 'party-uuid', characterId: 'c1', position: 1 })
+
+			expect(invalidateParty).toHaveBeenCalledWith(queryClient, 'party-uuid')
+		})
+	})
+
+	describe('updateGridCharacterOptions', () => {
+		it('onMutate optimistically updates the character in cache', async () => {
+			const opts = updateGridCharacterOptions(queryClient)
+
+			const context = await opts.onMutate({
+				id: 'gc-1',
+				partyShortcode: MOCK_SHORTCODE,
+				updates: { perpetuity: true }
+			})
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.characters[0]).toMatchObject({ id: 'gc-1', perpetuity: true })
+			expect(cached?.characters[1].id).toBe('gc-2')
+			expect(context?.previousParty).toEqual(MOCK_PARTY)
+		})
+
+		it('onError rolls back to previous party', () => {
+			const opts = updateGridCharacterOptions(queryClient)
+
+			opts.onError(new Error('fail'), { partyShortcode: MOCK_SHORTCODE } as any, {
+				previousParty: MOCK_PARTY
+			})
+
+			expect(getCachedParty(queryClient, MOCK_SHORTCODE)).toEqual(MOCK_PARTY)
+		})
+	})
+
+	describe('deleteGridCharacterOptions', () => {
+		it('onMutate removes character by id', async () => {
+			const opts = deleteGridCharacterOptions(queryClient)
+
+			await opts.onMutate({ partyShortcode: MOCK_SHORTCODE, id: 'gc-1' })
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.characters).toHaveLength(1)
+			expect(cached?.characters[0].id).toBe('gc-2')
+		})
+
+		it('onMutate removes character by position', async () => {
+			const opts = deleteGridCharacterOptions(queryClient)
+
+			await opts.onMutate({ partyShortcode: MOCK_SHORTCODE, id: undefined, position: 2 })
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.characters).toHaveLength(1)
+			expect(cached?.characters[0].id).toBe('gc-1')
+		})
+	})
+
+	describe('updateCharacterUncapOptions', () => {
+		it('onMutate updates uncapLevel and transcendenceStep', async () => {
+			const opts = updateCharacterUncapOptions(queryClient)
+
+			await opts.onMutate({
+				partyShortcode: MOCK_SHORTCODE,
+				id: 'gc-1',
+				partyId: 'party-uuid',
+				uncapLevel: 6,
+				transcendenceStep: 2
+			})
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.characters[0].uncapLevel).toBe(6)
+			expect(cached?.characters[0].transcendenceStep).toBe(2)
+		})
+	})
+
+	describe('resolveCharacterConflictOptions', () => {
+		it('onSuccess invalidates party detail', () => {
+			const opts = resolveCharacterConflictOptions(queryClient)
+			const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+			opts.onSuccess({}, { partyShortcode: MOCK_SHORTCODE } as any)
+
+			expect(spy).toHaveBeenCalledWith({ queryKey: partyKeys.detail(MOCK_SHORTCODE) })
+		})
+	})
+
+	describe('swapCharactersOptions', () => {
+		it('onSuccess invalidates party detail', () => {
+			const opts = swapCharactersOptions(queryClient)
+			const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+			opts.onSuccess({}, { partyShortcode: MOCK_SHORTCODE } as any)
+
+			expect(spy).toHaveBeenCalledWith({ queryKey: partyKeys.detail(MOCK_SHORTCODE) })
+		})
+	})
+
+	// ========================================================================
+	// Summon Mutations
+	// ========================================================================
+
+	describe('createGridSummonOptions', () => {
+		it('onSuccess calls invalidateParty', async () => {
+			const { invalidateParty } = await import('$lib/query/cacheHelpers')
+			const opts = createGridSummonOptions(queryClient)
+
+			opts.onSuccess({}, { partyId: 'party-uuid', summonId: 's1', position: 1 })
+
+			expect(invalidateParty).toHaveBeenCalledWith(queryClient, 'party-uuid')
+		})
+	})
+
+	describe('updateGridSummonOptions', () => {
+		it('onMutate optimistically updates the summon in cache', async () => {
+			const opts = updateGridSummonOptions(queryClient)
+
+			const context = await opts.onMutate({
+				id: 'gs-1',
+				partyShortcode: MOCK_SHORTCODE,
+				updates: { quickSummon: false }
+			})
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.summons[0]).toMatchObject({ id: 'gs-1', quickSummon: false })
+			expect(cached?.summons[1].id).toBe('gs-2')
+			expect(context?.previousParty).toEqual(MOCK_PARTY)
+		})
+
+		it('onError rolls back to previous party', () => {
+			const opts = updateGridSummonOptions(queryClient)
+
+			opts.onError(new Error('fail'), { partyShortcode: MOCK_SHORTCODE } as any, {
+				previousParty: MOCK_PARTY
+			})
+
+			expect(getCachedParty(queryClient, MOCK_SHORTCODE)).toEqual(MOCK_PARTY)
+		})
+	})
+
+	describe('deleteGridSummonOptions', () => {
+		it('onMutate removes summon by id', async () => {
+			const opts = deleteGridSummonOptions(queryClient)
+
+			await opts.onMutate({ partyShortcode: MOCK_SHORTCODE, id: 'gs-1' })
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.summons).toHaveLength(1)
+			expect(cached?.summons[0].id).toBe('gs-2')
+		})
+
+		it('onMutate removes summon by position', async () => {
+			const opts = deleteGridSummonOptions(queryClient)
+
+			await opts.onMutate({ partyShortcode: MOCK_SHORTCODE, id: undefined, position: 2 })
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.summons).toHaveLength(1)
+			expect(cached?.summons[0].id).toBe('gs-1')
+		})
+	})
+
+	describe('updateSummonUncapOptions', () => {
+		it('onMutate updates uncapLevel and transcendenceStep', async () => {
+			const opts = updateSummonUncapOptions(queryClient)
+
+			await opts.onMutate({
+				partyShortcode: MOCK_SHORTCODE,
+				id: 'gs-1',
+				partyId: 'party-uuid',
+				uncapLevel: 6,
+				transcendenceStep: 4
+			})
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.summons[0].uncapLevel).toBe(6)
+			expect(cached?.summons[0].transcendenceStep).toBe(4)
+		})
+
+		it('onMutate preserves original transcendenceStep when undefined', async () => {
+			const opts = updateSummonUncapOptions(queryClient)
+
+			await opts.onMutate({
+				partyShortcode: MOCK_SHORTCODE,
+				id: 'gs-1',
+				partyId: 'party-uuid',
+				uncapLevel: 6,
+				transcendenceStep: undefined
+			})
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.summons[0].transcendenceStep).toBe(2) // original value
+		})
+	})
+
+	describe('updateQuickSummonOptions', () => {
+		it('onMutate toggles quickSummon to false', async () => {
+			const opts = updateQuickSummonOptions(queryClient)
+
+			await opts.onMutate({
+				partyShortcode: MOCK_SHORTCODE,
+				id: 'gs-1',
+				quickSummon: false
+			})
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.summons[0].quickSummon).toBe(false)
+		})
+
+		it('onMutate toggles quickSummon to true', async () => {
+			const opts = updateQuickSummonOptions(queryClient)
+
+			await opts.onMutate({
+				partyShortcode: MOCK_SHORTCODE,
+				id: 'gs-2',
+				quickSummon: true
+			})
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.summons[1].quickSummon).toBe(true)
+		})
+
+		it('onError rolls back quickSummon change', async () => {
+			const opts = updateQuickSummonOptions(queryClient)
+
+			const context = await opts.onMutate({
+				partyShortcode: MOCK_SHORTCODE,
+				id: 'gs-1',
+				quickSummon: false
+			})
+
+			opts.onError(new Error('fail'), { partyShortcode: MOCK_SHORTCODE } as any, context)
+
+			const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+			expect(cached?.summons[0].quickSummon).toBe(true) // restored
+		})
+	})
+
+	describe('swapSummonsOptions', () => {
+		it('onSuccess invalidates party detail', () => {
+			const opts = swapSummonsOptions(queryClient)
+			const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+			opts.onSuccess({}, { partyShortcode: MOCK_SHORTCODE } as any)
+
+			expect(spy).toHaveBeenCalledWith({ queryKey: partyKeys.detail(MOCK_SHORTCODE) })
+		})
+	})
+
+	// ========================================================================
+	// Sync Mutations
+	// ========================================================================
+
+	describe('syncGridCharacterOptions', () => {
+		it('onSuccess invalidates party detail', () => {
+			const opts = syncGridCharacterOptions(queryClient)
+			const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+			opts.onSuccess({}, { partyShortcode: MOCK_SHORTCODE } as any)
+
+			expect(spy).toHaveBeenCalledWith({ queryKey: partyKeys.detail(MOCK_SHORTCODE) })
+		})
+	})
+
+	describe('syncGridWeaponOptions', () => {
+		it('onSuccess invalidates party detail', () => {
+			const opts = syncGridWeaponOptions(queryClient)
+			const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+			opts.onSuccess({}, { partyShortcode: MOCK_SHORTCODE } as any)
+
+			expect(spy).toHaveBeenCalledWith({ queryKey: partyKeys.detail(MOCK_SHORTCODE) })
+		})
+	})
+
+	describe('syncGridSummonOptions', () => {
+		it('onSuccess invalidates party detail', () => {
+			const opts = syncGridSummonOptions(queryClient)
+			const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+			opts.onSuccess({}, { partyShortcode: MOCK_SHORTCODE } as any)
+
+			expect(spy).toHaveBeenCalledWith({ queryKey: partyKeys.detail(MOCK_SHORTCODE) })
+		})
+	})
+
+	describe('syncAllPartyItemsOptions', () => {
+		it('onSuccess invalidates party detail', () => {
+			const opts = syncAllPartyItemsOptions(queryClient)
+			const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+			opts.onSuccess({}, { partyShortcode: MOCK_SHORTCODE } as any)
+
+			expect(spy).toHaveBeenCalledWith({ queryKey: partyKeys.detail(MOCK_SHORTCODE) })
+		})
+	})
+
+	describe('unlinkCollectionSourceOptions', () => {
+		it('onSuccess invalidates party detail', () => {
+			const opts = unlinkCollectionSourceOptions(queryClient)
+			const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+			opts.onSuccess({}, { partyShortcode: MOCK_SHORTCODE } as any)
+
+			expect(spy).toHaveBeenCalledWith({ queryKey: partyKeys.detail(MOCK_SHORTCODE) })
+		})
+	})
+})

--- a/src/lib/api/mutations/__tests__/gw.mutations.test.ts
+++ b/src/lib/api/mutations/__tests__/gw.mutations.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+	createGwEventOptions,
+	updateGwEventOptions,
+	joinGwEventOptions,
+	updateParticipationRankingOptions,
+	addCrewScoreOptions,
+	updateCrewScoreOptions,
+	addIndividualScoreOptions,
+	batchAddIndividualScoresOptions,
+	updateIndividualScoreOptions,
+	deleteIndividualScoreOptions
+} from '../gw.mutations'
+import { createTestQueryClient } from './helpers'
+import { gwKeys } from '$lib/api/queries/gw.queries'
+import type { QueryClient } from '@tanstack/svelte-query'
+
+vi.mock('$lib/api/adapters/gw.adapter', () => ({
+	gwAdapter: {
+		createEvent: vi.fn(),
+		updateEvent: vi.fn(),
+		joinEvent: vi.fn(),
+		updateParticipationRanking: vi.fn(),
+		addCrewScore: vi.fn(),
+		updateCrewScore: vi.fn(),
+		addIndividualScore: vi.fn(),
+		batchAddIndividualScores: vi.fn(),
+		updateIndividualScore: vi.fn(),
+		deleteIndividualScore: vi.fn()
+	}
+}))
+
+let queryClient: QueryClient
+
+beforeEach(() => {
+	queryClient = createTestQueryClient()
+})
+
+// ============================================================================
+// Event Mutations
+// ============================================================================
+
+describe('createGwEventOptions', () => {
+	it('invalidates events list on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = createGwEventOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(gwKeys.events())
+	})
+})
+
+describe('updateGwEventOptions', () => {
+	it('invalidates events list and specific event on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updateGwEventOptions(queryClient)
+
+		opts.onSuccess(undefined, { eventId: 'gw-1', input: {} as any })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(gwKeys.events())
+		expect(keys).toContainEqual(gwKeys.event('gw-1'))
+	})
+})
+
+// ============================================================================
+// Participation Mutations
+// ============================================================================
+
+describe('joinGwEventOptions', () => {
+	it('invalidates all participations on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = joinGwEventOptions(queryClient)
+
+		opts.onSuccess()
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(gwKeys.participationsAll())
+	})
+})
+
+describe('updateParticipationRankingOptions', () => {
+	it('invalidates all participations and specific participation on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updateParticipationRankingOptions(queryClient)
+
+		opts.onSuccess(undefined, { participationId: 'part-1', input: {} as any })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(gwKeys.participationsAll())
+		expect(keys).toContainEqual(gwKeys.participation('part-1'))
+	})
+})
+
+// ============================================================================
+// Crew Score Mutations
+// ============================================================================
+
+describe('addCrewScoreOptions', () => {
+	it('invalidates specific participation on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = addCrewScoreOptions(queryClient)
+
+		opts.onSuccess(undefined, { participationId: 'part-1', input: {} as any })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(gwKeys.participation('part-1'))
+	})
+})
+
+describe('updateCrewScoreOptions', () => {
+	it('invalidates specific participation on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updateCrewScoreOptions(queryClient)
+
+		opts.onSuccess(undefined, { participationId: 'part-1', scoreId: 's-1', input: {} as any })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(gwKeys.participation('part-1'))
+	})
+})
+
+// ============================================================================
+// Individual Score Mutations
+// ============================================================================
+
+describe('addIndividualScoreOptions', () => {
+	it('invalidates specific participation on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = addIndividualScoreOptions(queryClient)
+
+		opts.onSuccess(undefined, { participationId: 'part-1', input: {} as any })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(gwKeys.participation('part-1'))
+	})
+})
+
+describe('batchAddIndividualScoresOptions', () => {
+	it('invalidates specific participation on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = batchAddIndividualScoresOptions(queryClient)
+
+		opts.onSuccess(undefined, { participationId: 'part-1', input: {} as any })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(gwKeys.participation('part-1'))
+	})
+})
+
+describe('updateIndividualScoreOptions', () => {
+	it('invalidates specific participation on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updateIndividualScoreOptions(queryClient)
+
+		opts.onSuccess(undefined, { participationId: 'part-1', scoreId: 's-1', input: {} as any })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(gwKeys.participation('part-1'))
+	})
+})
+
+describe('deleteIndividualScoreOptions', () => {
+	it('invalidates specific participation on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = deleteIndividualScoreOptions(queryClient)
+
+		opts.onSuccess(undefined, { participationId: 'part-1', scoreId: 's-1' })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(gwKeys.participation('part-1'))
+	})
+})

--- a/src/lib/api/mutations/__tests__/helpers.ts
+++ b/src/lib/api/mutations/__tests__/helpers.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared test helpers for mutation tests
+ *
+ * Provides utilities for creating QueryClient instances,
+ * seeding cache data, and reading cache state for assertions.
+ */
+
+import { QueryClient } from '@tanstack/svelte-query'
+import { partyKeys } from '$lib/api/queries/party.queries'
+import type { Party } from '$lib/types/api/party'
+
+/**
+ * Creates a QueryClient configured for testing.
+ * Disables retries and garbage collection to keep tests deterministic.
+ */
+export function createTestQueryClient(): QueryClient {
+	return new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: Infinity },
+			mutations: { retry: false }
+		}
+	})
+}
+
+/**
+ * Seeds a party into the query cache under its shortcode key.
+ */
+export function seedPartyCache(queryClient: QueryClient, party: Party): void {
+	queryClient.setQueryData(partyKeys.detail(party.shortcode), party)
+}
+
+/**
+ * Reads the cached party for assertions.
+ */
+export function getCachedParty(queryClient: QueryClient, shortcode: string): Party | undefined {
+	return queryClient.getQueryData<Party>(partyKeys.detail(shortcode))
+}

--- a/src/lib/api/mutations/__tests__/job.mutations.test.ts
+++ b/src/lib/api/mutations/__tests__/job.mutations.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+	updatePartyJobOptions,
+	updatePartyJobSkillsOptions,
+	removePartyJobSkillOptions,
+	updatePartyAccessoryOptions
+} from '../job.mutations'
+import { createTestQueryClient, seedPartyCache, getCachedParty } from './helpers'
+import { MOCK_PARTY, MOCK_SHORTCODE } from './fixtures'
+import type { QueryClient } from '@tanstack/svelte-query'
+
+vi.mock('$lib/api/adapters/party.adapter', () => ({
+	partyAdapter: {
+		updateJob: vi.fn(),
+		updateJobSkills: vi.fn(),
+		removeJobSkill: vi.fn(),
+		updateAccessory: vi.fn()
+	}
+}))
+
+let queryClient: QueryClient
+
+beforeEach(() => {
+	queryClient = createTestQueryClient()
+	seedPartyCache(queryClient, MOCK_PARTY)
+})
+
+// ============================================================================
+// updatePartyJob
+// ============================================================================
+
+describe('updatePartyJobOptions', () => {
+	it('optimistically updates job ID in cached party', async () => {
+		const opts = updatePartyJobOptions(queryClient)
+
+		await opts.onMutate({ shortcode: MOCK_SHORTCODE, jobId: 'new-job-id' })
+
+		const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+		expect(cached?.job?.id).toBe('new-job-id')
+	})
+
+	it('preserves other job fields during optimistic update', async () => {
+		const opts = updatePartyJobOptions(queryClient)
+
+		await opts.onMutate({ shortcode: MOCK_SHORTCODE, jobId: 'new-job-id' })
+
+		const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+		expect(cached?.job?.name).toEqual(MOCK_PARTY.job?.name)
+	})
+
+	it('returns snapshot for rollback', async () => {
+		const opts = updatePartyJobOptions(queryClient)
+
+		const context = await opts.onMutate({ shortcode: MOCK_SHORTCODE, jobId: 'new-job-id' })
+
+		expect(context.previousParty).toEqual(MOCK_PARTY)
+	})
+
+	it('rolls back on error', async () => {
+		const opts = updatePartyJobOptions(queryClient)
+		const params = { shortcode: MOCK_SHORTCODE, jobId: 'new-job-id' }
+
+		const context = await opts.onMutate(params)
+		opts.onError(new Error('fail'), params, context)
+
+		const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+		expect(cached?.job?.id).toBe(MOCK_PARTY.job?.id)
+	})
+
+	it('does nothing on error without context', () => {
+		const opts = updatePartyJobOptions(queryClient)
+
+		opts.onError(new Error('fail'), { shortcode: MOCK_SHORTCODE, jobId: 'x' }, undefined)
+
+		expect(getCachedParty(queryClient, MOCK_SHORTCODE)).toEqual(MOCK_PARTY)
+	})
+
+	it('invalidates party on settled', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updatePartyJobOptions(queryClient)
+
+		opts.onSettled(undefined, undefined, { shortcode: MOCK_SHORTCODE, jobId: 'x' })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['party', MOCK_SHORTCODE])
+	})
+})
+
+// ============================================================================
+// updatePartyJobSkills
+// ============================================================================
+
+describe('updatePartyJobSkillsOptions', () => {
+	it('invalidates party detail on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updatePartyJobSkillsOptions(queryClient)
+
+		opts.onSuccess(undefined, { shortcode: MOCK_SHORTCODE, skills: [] })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['party', MOCK_SHORTCODE])
+	})
+})
+
+// ============================================================================
+// removePartyJobSkill
+// ============================================================================
+
+describe('removePartyJobSkillOptions', () => {
+	it('optimistically removes skill from slot', async () => {
+		const opts = removePartyJobSkillOptions(queryClient)
+
+		await opts.onMutate({ shortcode: MOCK_SHORTCODE, slot: 0 })
+
+		const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+		expect(cached?.jobSkills?.[0]).toBeUndefined()
+		expect(cached?.jobSkills?.[1]).toBeDefined()
+	})
+
+	it('returns snapshot for rollback', async () => {
+		const opts = removePartyJobSkillOptions(queryClient)
+
+		const context = await opts.onMutate({ shortcode: MOCK_SHORTCODE, slot: 0 })
+
+		expect(context.previousParty?.jobSkills?.[0]).toBeDefined()
+	})
+
+	it('rolls back on error', async () => {
+		const opts = removePartyJobSkillOptions(queryClient)
+		const params = { shortcode: MOCK_SHORTCODE, slot: 0 }
+
+		const context = await opts.onMutate(params)
+		opts.onError(new Error('fail'), params, context)
+
+		const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+		expect(cached?.jobSkills?.[0]).toBeDefined()
+	})
+
+	it('does nothing on error without context', () => {
+		const opts = removePartyJobSkillOptions(queryClient)
+
+		opts.onError(new Error('fail'), { shortcode: MOCK_SHORTCODE, slot: 0 }, undefined)
+
+		expect(getCachedParty(queryClient, MOCK_SHORTCODE)).toEqual(MOCK_PARTY)
+	})
+
+	it('invalidates party on settled', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = removePartyJobSkillOptions(queryClient)
+
+		opts.onSettled(undefined, undefined, { shortcode: MOCK_SHORTCODE, slot: 0 })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['party', MOCK_SHORTCODE])
+	})
+})
+
+// ============================================================================
+// updatePartyAccessory
+// ============================================================================
+
+describe('updatePartyAccessoryOptions', () => {
+	it('invalidates party detail on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updatePartyAccessoryOptions(queryClient)
+
+		opts.onSuccess(undefined, { shortcode: MOCK_SHORTCODE, accessoryId: 'acc-1' })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['party', MOCK_SHORTCODE])
+	})
+})

--- a/src/lib/api/mutations/__tests__/party.mutations.test.ts
+++ b/src/lib/api/mutations/__tests__/party.mutations.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Party mutation tests
+ *
+ * Tests the options factories exported from party.mutations.ts.
+ * Each factory is exercised with a real QueryClient so we can
+ * assert on cache state after optimistic updates, rollbacks,
+ * and invalidations.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+	createPartyOptions,
+	updatePartyOptions,
+	deletePartyOptions,
+	remixPartyOptions,
+	favoritePartyOptions,
+	unfavoritePartyOptions,
+	regeneratePreviewOptions,
+	sharePartyWithCrewOptions,
+	removePartyShareOptions
+} from '../party.mutations'
+import { createTestQueryClient, seedPartyCache, getCachedParty } from './helpers'
+import { MOCK_PARTY, MOCK_SHORTCODE } from './fixtures'
+import type { QueryClient } from '@tanstack/svelte-query'
+import type { Party } from '$lib/types/api/party'
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+vi.mock('$lib/api/adapters/party.adapter', () => ({
+	partyAdapter: {
+		create: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+		remix: vi.fn(),
+		favorite: vi.fn(),
+		unfavorite: vi.fn(),
+		regeneratePreview: vi.fn(),
+		shareWithCrew: vi.fn(),
+		removeShare: vi.fn()
+	}
+}))
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+let queryClient: QueryClient
+
+beforeEach(() => {
+	queryClient = createTestQueryClient()
+	seedPartyCache(queryClient, MOCK_PARTY)
+})
+
+// ============================================================================
+// createParty
+// ============================================================================
+
+describe('createPartyOptions', () => {
+	it('sets the new party in cache on success', () => {
+		const opts = createPartyOptions(queryClient)
+		const newParty: Party = { ...MOCK_PARTY, shortcode: 'NEW123', id: 'new-id' }
+
+		opts.onSuccess(newParty)
+
+		expect(getCachedParty(queryClient, 'NEW123')).toEqual(newParty)
+	})
+
+	it('invalidates party lists on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = createPartyOptions(queryClient)
+		const newParty: Party = { ...MOCK_PARTY, shortcode: 'NEW123' }
+
+		opts.onSuccess(newParty)
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['parties', 'list'])
+	})
+
+	it('invalidates user queries on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = createPartyOptions(queryClient)
+		const newParty: Party = { ...MOCK_PARTY, shortcode: 'NEW123' }
+
+		opts.onSuccess(newParty)
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['user'])
+	})
+})
+
+// ============================================================================
+// updateParty
+// ============================================================================
+
+describe('updatePartyOptions', () => {
+	it('optimistically merges updates into cached party', async () => {
+		const opts = updatePartyOptions(queryClient)
+		const params = { id: MOCK_PARTY.id, shortcode: MOCK_SHORTCODE, name: 'Updated Name' }
+
+		await opts.onMutate(params)
+
+		const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+		expect(cached?.name).toBe('Updated Name')
+	})
+
+	it('returns snapshot for rollback', async () => {
+		const opts = updatePartyOptions(queryClient)
+		const params = { id: MOCK_PARTY.id, shortcode: MOCK_SHORTCODE, name: 'Updated' }
+
+		const context = await opts.onMutate(params)
+
+		expect(context.previousParty).toEqual(MOCK_PARTY)
+	})
+
+	it('rolls back on error', async () => {
+		const opts = updatePartyOptions(queryClient)
+		const params = { id: MOCK_PARTY.id, shortcode: MOCK_SHORTCODE, name: 'Updated' }
+
+		const context = await opts.onMutate(params)
+		opts.onError(new Error('fail'), params, context)
+
+		const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+		expect(cached?.name).toBe('Test Party')
+	})
+
+	it('does nothing on error without context', () => {
+		const opts = updatePartyOptions(queryClient)
+		const params = { id: MOCK_PARTY.id, shortcode: MOCK_SHORTCODE, name: 'Updated' }
+
+		// should not throw
+		opts.onError(new Error('fail'), params, undefined)
+
+		const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+		expect(cached).toEqual(MOCK_PARTY)
+	})
+
+	it('invalidates party on settled', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = updatePartyOptions(queryClient)
+		const params = { id: MOCK_PARTY.id, shortcode: MOCK_SHORTCODE }
+
+		opts.onSettled(undefined, undefined, params)
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['party', MOCK_SHORTCODE])
+	})
+})
+
+// ============================================================================
+// deleteParty
+// ============================================================================
+
+describe('deletePartyOptions', () => {
+	it('removes party from cache on success', () => {
+		const opts = deletePartyOptions(queryClient)
+		const params = { id: MOCK_PARTY.id, shortcode: MOCK_SHORTCODE }
+
+		opts.onSuccess(undefined, params)
+
+		expect(getCachedParty(queryClient, MOCK_SHORTCODE)).toBeUndefined()
+	})
+
+	it('invalidates party lists on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = deletePartyOptions(queryClient)
+
+		opts.onSuccess(undefined, { id: MOCK_PARTY.id, shortcode: MOCK_SHORTCODE })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['parties', 'list'])
+	})
+
+	it('invalidates user queries on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = deletePartyOptions(queryClient)
+
+		opts.onSuccess(undefined, { id: MOCK_PARTY.id, shortcode: MOCK_SHORTCODE })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['user'])
+	})
+})
+
+// ============================================================================
+// remixParty
+// ============================================================================
+
+describe('remixPartyOptions', () => {
+	it('sets remixed party in cache on success', () => {
+		const opts = remixPartyOptions(queryClient)
+		const remixed: Party = { ...MOCK_PARTY, shortcode: 'REMIX1', id: 'remixed-id' }
+
+		opts.onSuccess(remixed)
+
+		expect(getCachedParty(queryClient, 'REMIX1')).toEqual(remixed)
+	})
+
+	it('invalidates party lists and user queries on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = remixPartyOptions(queryClient)
+		const remixed: Party = { ...MOCK_PARTY, shortcode: 'REMIX1' }
+
+		opts.onSuccess(remixed)
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['parties', 'list'])
+		expect(keys).toContainEqual(['user'])
+	})
+})
+
+// ============================================================================
+// favoriteParty
+// ============================================================================
+
+describe('favoritePartyOptions', () => {
+	it('optimistically sets favorited to true', async () => {
+		const opts = favoritePartyOptions(queryClient)
+
+		await opts.onMutate(MOCK_SHORTCODE)
+
+		const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+		expect(cached?.favorited).toBe(true)
+	})
+
+	it('returns snapshot for rollback', async () => {
+		const opts = favoritePartyOptions(queryClient)
+
+		const context = await opts.onMutate(MOCK_SHORTCODE)
+
+		expect(context.previousParty?.favorited).toBe(false)
+	})
+
+	it('rolls back on error', async () => {
+		const opts = favoritePartyOptions(queryClient)
+
+		const context = await opts.onMutate(MOCK_SHORTCODE)
+		expect(getCachedParty(queryClient, MOCK_SHORTCODE)?.favorited).toBe(true)
+
+		opts.onError(new Error('fail'), MOCK_SHORTCODE, context)
+
+		expect(getCachedParty(queryClient, MOCK_SHORTCODE)?.favorited).toBe(false)
+	})
+
+	it('invalidates favorites and party on settled', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = favoritePartyOptions(queryClient)
+
+		opts.onSettled(undefined, undefined, MOCK_SHORTCODE)
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['user', 'favorites'])
+		expect(keys).toContainEqual(['party', MOCK_SHORTCODE])
+	})
+})
+
+// ============================================================================
+// unfavoriteParty
+// ============================================================================
+
+describe('unfavoritePartyOptions', () => {
+	it('optimistically sets favorited to false', async () => {
+		// seed a favorited party
+		const favParty = { ...MOCK_PARTY, favorited: true }
+		seedPartyCache(queryClient, favParty)
+
+		const opts = unfavoritePartyOptions(queryClient)
+		await opts.onMutate(MOCK_SHORTCODE)
+
+		const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
+		expect(cached?.favorited).toBe(false)
+	})
+
+	it('returns snapshot for rollback', async () => {
+		const favParty = { ...MOCK_PARTY, favorited: true }
+		seedPartyCache(queryClient, favParty)
+
+		const opts = unfavoritePartyOptions(queryClient)
+		const context = await opts.onMutate(MOCK_SHORTCODE)
+
+		expect(context.previousParty?.favorited).toBe(true)
+	})
+
+	it('rolls back on error', async () => {
+		const favParty = { ...MOCK_PARTY, favorited: true }
+		seedPartyCache(queryClient, favParty)
+
+		const opts = unfavoritePartyOptions(queryClient)
+		const context = await opts.onMutate(MOCK_SHORTCODE)
+		expect(getCachedParty(queryClient, MOCK_SHORTCODE)?.favorited).toBe(false)
+
+		opts.onError(new Error('fail'), MOCK_SHORTCODE, context)
+
+		expect(getCachedParty(queryClient, MOCK_SHORTCODE)?.favorited).toBe(true)
+	})
+
+	it('invalidates favorites and party on settled', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = unfavoritePartyOptions(queryClient)
+
+		opts.onSettled(undefined, undefined, MOCK_SHORTCODE)
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['user', 'favorites'])
+		expect(keys).toContainEqual(['party', MOCK_SHORTCODE])
+	})
+})
+
+// ============================================================================
+// regeneratePreview
+// ============================================================================
+
+describe('regeneratePreviewOptions', () => {
+	it('invalidates preview key on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = regeneratePreviewOptions(queryClient)
+
+		opts.onSuccess(undefined, MOCK_SHORTCODE)
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['party', MOCK_SHORTCODE, 'preview'])
+	})
+})
+
+// ============================================================================
+// sharePartyWithCrew
+// ============================================================================
+
+describe('sharePartyWithCrewOptions', () => {
+	it('invalidates party detail on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = sharePartyWithCrewOptions(queryClient)
+
+		opts.onSuccess(undefined, { partyId: MOCK_PARTY.id, shortcode: MOCK_SHORTCODE })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['party', MOCK_SHORTCODE])
+	})
+
+	it('invalidates crew shared parties on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = sharePartyWithCrewOptions(queryClient)
+
+		opts.onSuccess(undefined, { partyId: MOCK_PARTY.id, shortcode: MOCK_SHORTCODE })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['crew', 'shared_parties'])
+	})
+})
+
+// ============================================================================
+// removePartyShare
+// ============================================================================
+
+describe('removePartyShareOptions', () => {
+	it('invalidates party detail on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = removePartyShareOptions(queryClient)
+
+		opts.onSuccess(undefined, { partyId: MOCK_PARTY.id, shareId: 'share-1', shortcode: MOCK_SHORTCODE })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['party', MOCK_SHORTCODE])
+	})
+
+	it('invalidates crew shared parties on success', () => {
+		const spy = vi.spyOn(queryClient, 'invalidateQueries')
+		const opts = removePartyShareOptions(queryClient)
+
+		opts.onSuccess(undefined, { partyId: MOCK_PARTY.id, shareId: 'share-1', shortcode: MOCK_SHORTCODE })
+
+		const keys = spy.mock.calls.map((c) => c[0].queryKey)
+		expect(keys).toContainEqual(['crew', 'shared_parties'])
+	})
+})

--- a/src/lib/api/mutations/artifact.mutations.ts
+++ b/src/lib/api/mutations/artifact.mutations.ts
@@ -4,184 +4,107 @@
  * Provides mutation configurations for artifact operations
  * with cache invalidation using TanStack Query v6.
  *
+ * Each mutation exports both an options factory (for testing) and a hook (for components).
+ *
  * @module api/mutations/artifact
  */
 
-import { useQueryClient, createMutation } from '@tanstack/svelte-query'
+import { useQueryClient, createMutation, type QueryClient } from '@tanstack/svelte-query'
 import { artifactAdapter } from '$lib/api/adapters/artifact.adapter'
 import { artifactKeys } from '$lib/api/queries/artifact.queries'
 import type {
-	CollectionArtifact,
 	CollectionArtifactInput,
-	GridArtifact,
 	GridArtifactInput,
 	GridArtifactUpdateInput,
-	ArtifactGrade,
 	ArtifactGradeInput
 } from '$lib/types/api/artifact'
 
 // ============================================================================
-// Collection Artifact Mutations
+// Options Factories — Collection Artifacts
 // ============================================================================
 
-/**
- * Create a collection artifact mutation
- *
- * Adds a single artifact to the user's collection.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useCreateCollectionArtifact } from '$lib/api/mutations/artifact.mutations'
- *
- *   const createArtifact = useCreateCollectionArtifact()
- *
- *   function handleCreate(input: CollectionArtifactInput) {
- *     createArtifact.mutate(input)
- *   }
- * </script>
- * ```
- */
-export function useCreateCollectionArtifact() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function createCollectionArtifactOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (input: CollectionArtifactInput) =>
 			artifactAdapter.createCollectionArtifact(input),
 		onSuccess: () => {
-			// Invalidate all collection artifact queries
 			queryClient.invalidateQueries({ queryKey: artifactKeys.collectionBase })
 		}
-	}))
+	}
 }
 
-/**
- * Create multiple collection artifacts in a batch
- */
-export function useCreateCollectionArtifactsBatch() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function createCollectionArtifactsBatchOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (inputs: CollectionArtifactInput[]) =>
 			artifactAdapter.createCollectionArtifactsBatch(inputs),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: artifactKeys.collectionBase })
 		}
-	}))
+	}
 }
 
-/**
- * Update a collection artifact mutation
- *
- * Updates an artifact's properties (skills, level, nickname, etc.)
- * Includes optimistic updates for better UX.
- */
-export function useUpdateCollectionArtifact() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updateCollectionArtifactOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({ id, input }: { id: string; input: Partial<CollectionArtifactInput> }) =>
 			artifactAdapter.updateCollectionArtifact(id, input),
 		onSettled: () => {
-			// Invalidate collection list to reflect changes
 			queryClient.invalidateQueries({ queryKey: artifactKeys.collectionBase })
 		}
-	}))
+	}
 }
 
-/**
- * Delete a collection artifact mutation
- */
-export function useDeleteCollectionArtifact() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function deleteCollectionArtifactOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (id: string) => artifactAdapter.deleteCollectionArtifact(id),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: artifactKeys.collectionBase })
 		}
-	}))
+	}
 }
 
-/**
- * Delete multiple collection artifacts in a single batch
- */
-export function useBulkDeleteCollectionArtifacts() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function bulkDeleteCollectionArtifactsOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (ids: string[]) => artifactAdapter.deleteCollectionArtifactsBatch(ids),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: artifactKeys.collectionBase })
 		}
-	}))
+	}
 }
 
 // ============================================================================
-// Grid Artifact Mutations (Equipped on Characters)
+// Options Factories — Grid Artifacts
 // ============================================================================
 
-/**
- * Create a grid artifact mutation
- *
- * Creates a new artifact and equips it on a character in a party.
- */
-export function useCreateGridArtifact() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function createGridArtifactOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (input: GridArtifactInput) => artifactAdapter.createGridArtifact(input),
-		onSuccess: (_data, input) => {
-			// Invalidate party queries to reflect the new artifact
+		onSuccess: (_data: unknown, input: GridArtifactInput) => {
 			queryClient.invalidateQueries({ queryKey: ['parties', input.partyId] })
 		}
-	}))
+	}
 }
 
-/**
- * Update a grid artifact mutation
- *
- * Updates an artifact equipped on a character.
- */
-export function useUpdateGridArtifact() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updateGridArtifactOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({ id, input }: { id: string; input: GridArtifactUpdateInput }) =>
 			artifactAdapter.updateGridArtifact(id, input),
 		onSuccess: () => {
-			// Invalidate party queries to reflect the updated artifact
 			queryClient.invalidateQueries({ queryKey: ['parties'] })
 		}
-	}))
+	}
 }
 
-/**
- * Delete a grid artifact mutation
- *
- * Removes an artifact from a character.
- */
-export function useDeleteGridArtifact() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function deleteGridArtifactOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (id: string) => artifactAdapter.deleteGridArtifact(id),
 		onSuccess: () => {
-			// Invalidate party queries to reflect the removal
 			queryClient.invalidateQueries({ queryKey: ['parties'] })
 		}
-	}))
+	}
 }
 
-/**
- * Equip a collection artifact onto a character
- *
- * Links an existing collection artifact to a character in a party.
- */
-export function useEquipCollectionArtifact() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function equipCollectionArtifactOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({
 			partyId,
 			gridCharacterId,
@@ -191,47 +114,86 @@ export function useEquipCollectionArtifact() {
 			gridCharacterId: string
 			collectionArtifactId: string
 		}) => artifactAdapter.equipCollectionArtifact(partyId, gridCharacterId, collectionArtifactId),
-		onSuccess: (_data, { partyId }) => {
-			// Invalidate party queries to reflect the equipped artifact
+		onSuccess: (_data: unknown, { partyId }: { partyId: string; gridCharacterId: string; collectionArtifactId: string }) => {
 			queryClient.invalidateQueries({ queryKey: ['parties', partyId] })
 		}
-	}))
+	}
 }
 
 // ============================================================================
-// Artifact Grading (Stateless)
+// Options Factories — Grading & Sync
 // ============================================================================
 
-/**
- * Grade artifact skills mutation
- *
- * Calculates a grade for artifact skills without persisting.
- * Useful for preview/what-if scenarios.
- */
-export function useGradeArtifact() {
-	return createMutation(() => ({
+export function gradeArtifactOptions() {
+	return {
 		mutationFn: (input: ArtifactGradeInput) => artifactAdapter.gradeArtifact(input)
-	}))
+	}
 }
 
-// ============================================================================
-// Sync Mutations (Collection -> Grid)
-// ============================================================================
-
-/**
- * Sync grid artifact from collection mutation
- *
- * Syncs a grid artifact's properties from its linked collection source.
- */
-export function useSyncGridArtifact() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function syncGridArtifactOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: { id: string; partyShortcode: string }) =>
 			artifactAdapter.syncGridArtifact(params.id),
-		onSuccess: (_data, { partyShortcode }) => {
-			// Invalidate party queries to reflect the synced artifact
+		onSuccess: (_data: unknown, { partyShortcode }: { id: string; partyShortcode: string }) => {
 			queryClient.invalidateQueries({ queryKey: ['parties', 'detail', partyShortcode] })
 		}
-	}))
+	}
+}
+
+// ============================================================================
+// Hooks (thin wrappers for component use)
+// ============================================================================
+
+export function useCreateCollectionArtifact() {
+	const queryClient = useQueryClient()
+	return createMutation(() => createCollectionArtifactOptions(queryClient))
+}
+
+export function useCreateCollectionArtifactsBatch() {
+	const queryClient = useQueryClient()
+	return createMutation(() => createCollectionArtifactsBatchOptions(queryClient))
+}
+
+export function useUpdateCollectionArtifact() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updateCollectionArtifactOptions(queryClient))
+}
+
+export function useDeleteCollectionArtifact() {
+	const queryClient = useQueryClient()
+	return createMutation(() => deleteCollectionArtifactOptions(queryClient))
+}
+
+export function useBulkDeleteCollectionArtifacts() {
+	const queryClient = useQueryClient()
+	return createMutation(() => bulkDeleteCollectionArtifactsOptions(queryClient))
+}
+
+export function useCreateGridArtifact() {
+	const queryClient = useQueryClient()
+	return createMutation(() => createGridArtifactOptions(queryClient))
+}
+
+export function useUpdateGridArtifact() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updateGridArtifactOptions(queryClient))
+}
+
+export function useDeleteGridArtifact() {
+	const queryClient = useQueryClient()
+	return createMutation(() => deleteGridArtifactOptions(queryClient))
+}
+
+export function useEquipCollectionArtifact() {
+	const queryClient = useQueryClient()
+	return createMutation(() => equipCollectionArtifactOptions(queryClient))
+}
+
+export function useGradeArtifact() {
+	return createMutation(() => gradeArtifactOptions())
+}
+
+export function useSyncGridArtifact() {
+	const queryClient = useQueryClient()
+	return createMutation(() => syncGridArtifactOptions(queryClient))
 }

--- a/src/lib/api/mutations/collection.mutations.ts
+++ b/src/lib/api/mutations/collection.mutations.ts
@@ -4,10 +4,12 @@
  * Provides mutation configurations for collection operations
  * with cache invalidation using TanStack Query v6.
  *
+ * Each mutation exports both an options factory (for testing) and a hook (for components).
+ *
  * @module api/mutations/collection
  */
 
-import { useQueryClient, createMutation } from '@tanstack/svelte-query'
+import { useQueryClient, createMutation, type QueryClient } from '@tanstack/svelte-query'
 import { collectionAdapter } from '$lib/api/adapters/collection.adapter'
 import { collectionKeys } from '$lib/api/queries/collection.queries'
 import type {
@@ -19,78 +21,40 @@ import type {
 } from '$lib/types/api/collection'
 
 // ============================================================================
-// Character Mutations
+// Options Factories — Characters
 // ============================================================================
 
-/**
- * Add characters to collection mutation
- *
- * Adds one or more characters to the user's collection.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useAddToCollection } from '$lib/api/mutations/collection.mutations'
- *
- *   const addToCollection = useAddToCollection()
- *
- *   function handleAdd(characterIds: string[]) {
- *     addToCollection.mutate(
- *       characterIds.map(id => ({ characterId: id }))
- *     )
- *   }
- * </script>
- * ```
- */
-export function useAddCharactersToCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function addCharactersToCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (inputs: CollectionCharacterInput[]) => collectionAdapter.addCharacters(inputs),
 		onSuccess: () => {
-			// Invalidate all character-related collection queries
 			queryClient.invalidateQueries({ queryKey: collectionKeys.characters() })
 			queryClient.invalidateQueries({ queryKey: collectionKeys.characterIds() })
 		}
-	}))
+	}
 }
 
-/**
- * Add single character to collection mutation
- */
-export function useAddCharacterToCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function addCharacterToCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (input: CollectionCharacterInput) => collectionAdapter.addCharacter(input),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: collectionKeys.characters() })
 			queryClient.invalidateQueries({ queryKey: collectionKeys.characterIds() })
 		}
-	}))
+	}
 }
 
-/**
- * Update collection character mutation
- *
- * Updates a character's customizations (uncap, rings, etc.) in the collection.
- */
-export function useUpdateCollectionCharacter() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updateCollectionCharacterOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({ id, input }: { id: string; input: Partial<CollectionCharacterInput> }) =>
 			collectionAdapter.updateCharacter(id, input),
-		onMutate: async ({ id, input }) => {
-			// Cancel any outgoing refetches
+		onMutate: async ({ id, input }: { id: string; input: Partial<CollectionCharacterInput> }) => {
 			await queryClient.cancelQueries({ queryKey: collectionKeys.character(id) })
 
-			// Snapshot the previous value
 			const previousCharacter = queryClient.getQueryData<CollectionCharacter>(
 				collectionKeys.character(id)
 			)
 
-			// Optimistically update the cache
 			if (previousCharacter) {
 				queryClient.setQueryData(collectionKeys.character(id), {
 					...previousCharacter,
@@ -100,232 +64,255 @@ export function useUpdateCollectionCharacter() {
 
 			return { previousCharacter }
 		},
-		onError: (_err, { id }, context) => {
-			// Rollback on error
+		onError: (
+			_err: unknown,
+			{ id }: { id: string; input: Partial<CollectionCharacterInput> },
+			context: { previousCharacter?: CollectionCharacter } | undefined
+		) => {
 			if (context?.previousCharacter) {
 				queryClient.setQueryData(collectionKeys.character(id), context.previousCharacter)
 			}
 		},
-		onSettled: (_data, _err, { id }) => {
-			// Always refetch after mutation
+		onSettled: (
+			_data: unknown,
+			_err: unknown,
+			{ id }: { id: string; input: Partial<CollectionCharacterInput> }
+		) => {
 			queryClient.invalidateQueries({ queryKey: collectionKeys.character(id) })
 			queryClient.invalidateQueries({ queryKey: collectionKeys.characters() })
 		}
-	}))
+	}
 }
 
-/**
- * Remove character from collection mutation
- */
-export function useRemoveCharacterFromCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function removeCharacterFromCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (id: string) => collectionAdapter.removeCharacter(id),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: collectionKeys.characters() })
 			queryClient.invalidateQueries({ queryKey: collectionKeys.characterIds() })
 		}
-	}))
+	}
 }
 
-/**
- * Remove multiple characters from collection in a single batch
- */
-export function useBulkRemoveCharactersFromCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function bulkRemoveCharactersFromCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (ids: string[]) => collectionAdapter.removeCharactersBatch(ids),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: collectionKeys.characters() })
 			queryClient.invalidateQueries({ queryKey: collectionKeys.characterIds() })
 		}
-	}))
+	}
 }
 
 // ============================================================================
-// Weapon Mutations
+// Options Factories — Weapons
 // ============================================================================
 
-/**
- * Add weapon to collection mutation
- */
-export function useAddWeaponToCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function addWeaponToCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (input: CollectionWeaponInput) => collectionAdapter.addWeapon(input),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: collectionKeys.weapons() })
 		}
-	}))
+	}
 }
 
-/**
- * Add multiple weapons to collection mutation with quantity support
- */
-export function useAddWeaponsToCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function addWeaponsToCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (inputs: Array<CollectionWeaponInput & { quantity?: number }>) =>
 			collectionAdapter.addWeapons(inputs),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: collectionKeys.weapons() })
 		}
-	}))
+	}
 }
 
-/**
- * Update collection weapon mutation
- * Uses resetQueries to clear cache and start fresh, avoiding issues where
- * items shift between pages after sort-affecting updates (like element changes)
- */
-export function useUpdateCollectionWeapon() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updateCollectionWeaponOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({ id, input }: { id: string; input: Partial<CollectionWeaponInput> }) =>
 			collectionAdapter.updateWeapon(id, input),
 		onSuccess: () => {
 			queryClient.resetQueries({ queryKey: collectionKeys.weapons() })
 		}
-	}))
+	}
 }
 
-/**
- * Remove weapon from collection mutation
- */
-export function useRemoveWeaponFromCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function removeWeaponFromCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (id: string) => collectionAdapter.removeWeapon(id),
 		onSuccess: () => {
 			queryClient.resetQueries({ queryKey: collectionKeys.weapons() })
 		}
-	}))
+	}
 }
 
-/**
- * Remove multiple weapons from collection in a single batch
- */
-export function useBulkRemoveWeaponsFromCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function bulkRemoveWeaponsFromCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (ids: string[]) => collectionAdapter.removeWeaponsBatch(ids),
 		onSuccess: () => {
 			queryClient.resetQueries({ queryKey: collectionKeys.weapons() })
 		}
-	}))
+	}
 }
 
 // ============================================================================
-// Summon Mutations
+// Options Factories — Summons
 // ============================================================================
 
-/**
- * Add summon to collection mutation
- */
-export function useAddSummonToCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function addSummonToCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (input: CollectionSummonInput) => collectionAdapter.addSummon(input),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: collectionKeys.summons() })
 		}
-	}))
+	}
 }
 
-/**
- * Add multiple summons to collection mutation with quantity support
- */
-export function useAddSummonsToCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function addSummonsToCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (inputs: Array<CollectionSummonInput & { quantity?: number }>) =>
 			collectionAdapter.addSummons(inputs),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: collectionKeys.summons() })
 		}
-	}))
+	}
 }
 
-/**
- * Update collection summon mutation
- */
-export function useUpdateCollectionSummon() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updateCollectionSummonOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({ id, input }: { id: string; input: Partial<CollectionSummonInput> }) =>
 			collectionAdapter.updateSummon(id, input),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: collectionKeys.summons() })
 		}
-	}))
+	}
 }
 
-/**
- * Remove summon from collection mutation
- */
-export function useRemoveSummonFromCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function removeSummonFromCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (id: string) => collectionAdapter.removeSummon(id),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: collectionKeys.summons() })
 		}
-	}))
+	}
 }
 
-/**
- * Remove multiple summons from collection in a single batch
- */
-export function useBulkRemoveSummonsFromCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function bulkRemoveSummonsFromCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (ids: string[]) => collectionAdapter.removeSummonsBatch(ids),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: collectionKeys.summons() })
 		}
-	}))
+	}
 }
 
 // ============================================================================
-// Job Accessory Mutations
+// Options Factories — Job Accessories
 // ============================================================================
 
-/**
- * Add job accessory to collection mutation
- */
-export function useAddJobAccessoryToCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function addJobAccessoryToCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (input: CollectionJobAccessoryInput) => collectionAdapter.addJobAccessory(input),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: collectionKeys.all })
 		}
-	}))
+	}
 }
 
-/**
- * Remove job accessory from collection mutation
- */
-export function useRemoveJobAccessoryFromCollection() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function removeJobAccessoryFromCollectionOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (id: string) => collectionAdapter.removeJobAccessory(id),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: collectionKeys.all })
 		}
-	}))
+	}
+}
+
+// ============================================================================
+// Hooks (thin wrappers for component use)
+// ============================================================================
+
+export function useAddCharactersToCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => addCharactersToCollectionOptions(queryClient))
+}
+
+export function useAddCharacterToCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => addCharacterToCollectionOptions(queryClient))
+}
+
+export function useUpdateCollectionCharacter() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updateCollectionCharacterOptions(queryClient))
+}
+
+export function useRemoveCharacterFromCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => removeCharacterFromCollectionOptions(queryClient))
+}
+
+export function useBulkRemoveCharactersFromCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => bulkRemoveCharactersFromCollectionOptions(queryClient))
+}
+
+export function useAddWeaponToCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => addWeaponToCollectionOptions(queryClient))
+}
+
+export function useAddWeaponsToCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => addWeaponsToCollectionOptions(queryClient))
+}
+
+export function useUpdateCollectionWeapon() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updateCollectionWeaponOptions(queryClient))
+}
+
+export function useRemoveWeaponFromCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => removeWeaponFromCollectionOptions(queryClient))
+}
+
+export function useBulkRemoveWeaponsFromCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => bulkRemoveWeaponsFromCollectionOptions(queryClient))
+}
+
+export function useAddSummonToCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => addSummonToCollectionOptions(queryClient))
+}
+
+export function useAddSummonsToCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => addSummonsToCollectionOptions(queryClient))
+}
+
+export function useUpdateCollectionSummon() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updateCollectionSummonOptions(queryClient))
+}
+
+export function useRemoveSummonFromCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => removeSummonFromCollectionOptions(queryClient))
+}
+
+export function useBulkRemoveSummonsFromCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => bulkRemoveSummonsFromCollectionOptions(queryClient))
+}
+
+export function useAddJobAccessoryToCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => addJobAccessoryToCollectionOptions(queryClient))
+}
+
+export function useRemoveJobAccessoryFromCollection() {
+	const queryClient = useQueryClient()
+	return createMutation(() => removeJobAccessoryFromCollectionOptions(queryClient))
 }

--- a/src/lib/api/mutations/crew.mutations.ts
+++ b/src/lib/api/mutations/crew.mutations.ts
@@ -4,287 +4,301 @@
  * Provides mutation configurations for crew CRUD operations
  * with cache invalidation using TanStack Query v6.
  *
+ * Each mutation exports both an options factory (for testing) and a hook (for components).
+ *
  * @module api/mutations/crew
  */
 
-import { useQueryClient, createMutation } from '@tanstack/svelte-query'
+import { useQueryClient, createMutation, type QueryClient } from '@tanstack/svelte-query'
 import { crewAdapter } from '$lib/api/adapters/crew.adapter'
 import { crewKeys } from '$lib/api/queries/crew.queries'
 import type {
-  CreateCrewInput,
-  UpdateCrewInput,
-  CreatePhantomPlayerInput,
-  UpdatePhantomPlayerInput,
-  UpdateMembershipInput
+	CreateCrewInput,
+	UpdateCrewInput,
+	CreatePhantomPlayerInput,
+	UpdatePhantomPlayerInput,
+	UpdateMembershipInput
 } from '$lib/types/api/crew'
 
-// ==================== Crew Mutations ====================
+// ============================================================================
+// Options Factories — Crew CRUD
+// ============================================================================
 
-/**
- * Create crew mutation
- */
+export function createCrewOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: (input: CreateCrewInput) => crewAdapter.create(input),
+		onSuccess: (crew: any) => {
+			queryClient.setQueryData(crewKeys.myCrew(), crew)
+			queryClient.invalidateQueries({ queryKey: crewKeys.invitations.pending() })
+		}
+	}
+}
+
+export function updateCrewOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: (input: UpdateCrewInput) => crewAdapter.update(input),
+		onSuccess: (crew: any) => {
+			queryClient.setQueryData(crewKeys.myCrew(), crew)
+		}
+	}
+}
+
+export function leaveCrewOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: () => crewAdapter.leave(),
+		onSuccess: () => {
+			queryClient.removeQueries({ queryKey: crewKeys.myCrew() })
+			queryClient.removeQueries({ queryKey: crewKeys.membersAll() })
+		}
+	}
+}
+
+export function transferCaptainOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({ crewId, userId }: { crewId: string; userId: string }) =>
+			crewAdapter.transferCaptain(crewId, userId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: crewKeys.myCrew() })
+			queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
+		}
+	}
+}
+
+// ============================================================================
+// Options Factories — Membership
+// ============================================================================
+
+export function updateMembershipOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({
+			crewId,
+			membershipId,
+			input
+		}: {
+			crewId: string
+			membershipId: string
+			input: UpdateMembershipInput
+		}) => crewAdapter.updateMembership(crewId, membershipId, input),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
+		}
+	}
+}
+
+export function removeMemberOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({ crewId, membershipId }: { crewId: string; membershipId: string }) =>
+			crewAdapter.removeMember(crewId, membershipId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
+			queryClient.invalidateQueries({ queryKey: crewKeys.myCrew() })
+		}
+	}
+}
+
+// ============================================================================
+// Options Factories — Invitations
+// ============================================================================
+
+export function sendInvitationOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({ crewId, userId }: { crewId: string; userId: string }) =>
+			crewAdapter.sendInvitation(crewId, userId),
+		onSuccess: (_invitation: unknown, { crewId }: { crewId: string; userId: string }) => {
+			queryClient.invalidateQueries({ queryKey: crewKeys.crewInvitations(crewId) })
+		}
+	}
+}
+
+export function acceptInvitationOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: (invitationId: string) => crewAdapter.acceptInvitation(invitationId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: crewKeys.myCrew() })
+			queryClient.invalidateQueries({ queryKey: crewKeys.invitations.pending() })
+		}
+	}
+}
+
+export function rejectInvitationOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: (invitationId: string) => crewAdapter.rejectInvitation(invitationId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: crewKeys.invitations.pending() })
+		}
+	}
+}
+
+// ============================================================================
+// Options Factories — Phantom Players
+// ============================================================================
+
+export function createPhantomOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({ crewId, input }: { crewId: string; input: CreatePhantomPlayerInput }) =>
+			crewAdapter.createPhantom(crewId, input),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
+		}
+	}
+}
+
+export function bulkCreatePhantomsOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({ crewId, phantoms }: { crewId: string; phantoms: CreatePhantomPlayerInput[] }) =>
+			crewAdapter.bulkCreatePhantoms(crewId, phantoms),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
+		}
+	}
+}
+
+export function updatePhantomOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({
+			crewId,
+			phantomId,
+			input
+		}: {
+			crewId: string
+			phantomId: string
+			input: UpdatePhantomPlayerInput
+		}) => crewAdapter.updatePhantom(crewId, phantomId, input),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
+		}
+	}
+}
+
+export function deletePhantomOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({ crewId, phantomId }: { crewId: string; phantomId: string }) =>
+			crewAdapter.deletePhantom(crewId, phantomId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
+		}
+	}
+}
+
+export function assignPhantomOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({
+			crewId,
+			phantomId,
+			userId
+		}: {
+			crewId: string
+			phantomId: string
+			userId: string
+		}) => crewAdapter.assignPhantom(crewId, phantomId, userId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
+		}
+	}
+}
+
+export function confirmPhantomClaimOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({ crewId, phantomId }: { crewId: string; phantomId: string }) =>
+			crewAdapter.confirmPhantomClaim(crewId, phantomId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
+			queryClient.invalidateQueries({ queryKey: crewKeys.phantomClaims.pending() })
+		}
+	}
+}
+
+export function declinePhantomClaimOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({ crewId, phantomId }: { crewId: string; phantomId: string }) =>
+			crewAdapter.declinePhantomClaim(crewId, phantomId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
+			queryClient.invalidateQueries({ queryKey: crewKeys.phantomClaims.pending() })
+		}
+	}
+}
+
+// ============================================================================
+// Hooks (thin wrappers for component use)
+// ============================================================================
+
 export function useCreateCrew() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: (input: CreateCrewInput) => crewAdapter.create(input),
-    onSuccess: (crew) => {
-      queryClient.setQueryData(crewKeys.myCrew(), crew)
-      queryClient.invalidateQueries({ queryKey: crewKeys.invitations.pending() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => createCrewOptions(queryClient))
 }
 
-/**
- * Update crew mutation
- */
 export function useUpdateCrew() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: (input: UpdateCrewInput) => crewAdapter.update(input),
-    onSuccess: (crew) => {
-      queryClient.setQueryData(crewKeys.myCrew(), crew)
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => updateCrewOptions(queryClient))
 }
 
-/**
- * Leave crew mutation
- */
 export function useLeaveCrew() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: () => crewAdapter.leave(),
-    onSuccess: () => {
-      queryClient.removeQueries({ queryKey: crewKeys.myCrew() })
-      queryClient.removeQueries({ queryKey: crewKeys.membersAll() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => leaveCrewOptions(queryClient))
 }
 
-/**
- * Transfer captain mutation
- */
 export function useTransferCaptain() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({ crewId, userId }: { crewId: string; userId: string }) =>
-      crewAdapter.transferCaptain(crewId, userId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: crewKeys.myCrew() })
-      queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => transferCaptainOptions(queryClient))
 }
 
-// ==================== Membership Mutations ====================
-
-/**
- * Update membership (promote/demote or update joined_at) mutation
- */
 export function useUpdateMembership() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({
-      crewId,
-      membershipId,
-      input
-    }: {
-      crewId: string
-      membershipId: string
-      input: UpdateMembershipInput
-    }) => crewAdapter.updateMembership(crewId, membershipId, input),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => updateMembershipOptions(queryClient))
 }
 
-/**
- * Remove member mutation
- */
 export function useRemoveMember() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({ crewId, membershipId }: { crewId: string; membershipId: string }) =>
-      crewAdapter.removeMember(crewId, membershipId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
-      queryClient.invalidateQueries({ queryKey: crewKeys.myCrew() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => removeMemberOptions(queryClient))
 }
 
-// ==================== Invitation Mutations ====================
-
-/**
- * Send invitation mutation
- */
 export function useSendInvitation() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({ crewId, userId }: { crewId: string; userId: string }) =>
-      crewAdapter.sendInvitation(crewId, userId),
-    onSuccess: (_invitation, { crewId }) => {
-      queryClient.invalidateQueries({ queryKey: crewKeys.crewInvitations(crewId) })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => sendInvitationOptions(queryClient))
 }
 
-/**
- * Accept invitation mutation
- */
 export function useAcceptInvitation() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: (invitationId: string) => crewAdapter.acceptInvitation(invitationId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: crewKeys.myCrew() })
-      queryClient.invalidateQueries({ queryKey: crewKeys.invitations.pending() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => acceptInvitationOptions(queryClient))
 }
 
-/**
- * Reject invitation mutation
- */
 export function useRejectInvitation() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: (invitationId: string) => crewAdapter.rejectInvitation(invitationId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: crewKeys.invitations.pending() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => rejectInvitationOptions(queryClient))
 }
 
-// ==================== Phantom Player Mutations ====================
-
-/**
- * Create phantom player mutation
- */
 export function useCreatePhantom() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({ crewId, input }: { crewId: string; input: CreatePhantomPlayerInput }) =>
-      crewAdapter.createPhantom(crewId, input),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => createPhantomOptions(queryClient))
 }
 
-/**
- * Bulk create phantom players mutation
- */
 export function useBulkCreatePhantoms() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({ crewId, phantoms }: { crewId: string; phantoms: CreatePhantomPlayerInput[] }) =>
-      crewAdapter.bulkCreatePhantoms(crewId, phantoms),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => bulkCreatePhantomsOptions(queryClient))
 }
 
-/**
- * Update phantom player mutation
- */
 export function useUpdatePhantom() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({
-      crewId,
-      phantomId,
-      input
-    }: {
-      crewId: string
-      phantomId: string
-      input: UpdatePhantomPlayerInput
-    }) => crewAdapter.updatePhantom(crewId, phantomId, input),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => updatePhantomOptions(queryClient))
 }
 
-/**
- * Delete phantom player mutation
- */
 export function useDeletePhantom() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({ crewId, phantomId }: { crewId: string; phantomId: string }) =>
-      crewAdapter.deletePhantom(crewId, phantomId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => deletePhantomOptions(queryClient))
 }
 
-/**
- * Assign phantom player mutation
- */
 export function useAssignPhantom() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({
-      crewId,
-      phantomId,
-      userId
-    }: {
-      crewId: string
-      phantomId: string
-      userId: string
-    }) => crewAdapter.assignPhantom(crewId, phantomId, userId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => assignPhantomOptions(queryClient))
 }
 
-/**
- * Confirm phantom claim mutation
- */
 export function useConfirmPhantomClaim() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({ crewId, phantomId }: { crewId: string; phantomId: string }) =>
-      crewAdapter.confirmPhantomClaim(crewId, phantomId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
-      queryClient.invalidateQueries({ queryKey: crewKeys.phantomClaims.pending() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => confirmPhantomClaimOptions(queryClient))
 }
 
-/**
- * Decline phantom claim mutation
- */
 export function useDeclinePhantomClaim() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({ crewId, phantomId }: { crewId: string; phantomId: string }) =>
-      crewAdapter.declinePhantomClaim(crewId, phantomId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: crewKeys.membersAll() })
-      queryClient.invalidateQueries({ queryKey: crewKeys.phantomClaims.pending() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => declinePhantomClaimOptions(queryClient))
 }

--- a/src/lib/api/mutations/grid.mutations.ts
+++ b/src/lib/api/mutations/grid.mutations.ts
@@ -4,10 +4,12 @@
  * Provides mutation configurations for grid item operations (weapons, characters, summons)
  * with cache invalidation and optimistic updates using TanStack Query v6.
  *
+ * Each mutation exports both an options factory (for testing) and a hook (for components).
+ *
  * @module api/mutations/grid
  */
 
-import { useQueryClient, createMutation } from '@tanstack/svelte-query'
+import { useQueryClient, createMutation, type QueryClient } from '@tanstack/svelte-query'
 import {
 	gridAdapter,
 	type CreateGridWeaponParams,
@@ -41,7 +43,7 @@ import { invalidateParty } from '$lib/query/cacheHelpers'
  * @param adapterMethod - The grid adapter method to wrap
  * @returns Wrapped method that automatically handles edit key injection
  */
-function createGridMutation<TParams extends { partyId: number | string }>(
+export function createGridMutation<TParams extends { partyId: number | string }>(
 	adapterMethod: (params: TParams, headers?: Record<string, string>) => Promise<any>
 ) {
 	return (params: TParams) => {
@@ -52,73 +54,43 @@ function createGridMutation<TParams extends { partyId: number | string }>(
 }
 
 // ============================================================================
-// Weapon Mutations
+// Shared optimistic update helpers
 // ============================================================================
 
-/**
- * Create grid weapon mutation
- *
- * Adds a weapon to a party's grid.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useCreateGridWeapon } from '$lib/api/mutations/grid.mutations'
- *
- *   const createWeapon = useCreateGridWeapon()
- *
- *   function handleAddWeapon() {
- *     createWeapon.mutate({
- *       partyId: 'party-uuid',
- *       weaponId: 'weapon-id',
- *       position: 1
- *     })
- *   }
- * </script>
- * ```
- */
-export function useCreateGridWeapon() {
-	const queryClient = useQueryClient()
+function optimisticRollback(
+	queryClient: QueryClient,
+	partyShortcode: string,
+	context: { previousParty?: Party } | undefined
+) {
+	if (context?.previousParty) {
+		queryClient.setQueryData(partyKeys.detail(partyShortcode), context.previousParty)
+	}
+}
 
-	return createMutation(() => ({
+function invalidateOnSettled(queryClient: QueryClient, partyShortcode: string) {
+	queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+}
+
+// ============================================================================
+// Weapon Mutation Options
+// ============================================================================
+
+export function createGridWeaponOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: createGridMutation((params: CreateGridWeaponParams, headers?: Record<string, string>) =>
 			gridAdapter.createWeapon(params, headers)
 		),
-		onSuccess: (_data, params) => {
+		onSuccess: (_data: any, params: CreateGridWeaponParams) => {
 			invalidateParty(queryClient, params.partyId)
 		}
-	}))
+	}
 }
 
-/**
- * Update grid weapon mutation
- *
- * Updates a weapon in a party's grid with optimistic updates.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useUpdateGridWeapon } from '$lib/api/mutations/grid.mutations'
- *
- *   const updateWeapon = useUpdateGridWeapon()
- *
- *   function handleUpdateWeapon(id: string, partyShortcode: string) {
- *     updateWeapon.mutate({
- *       id,
- *       partyShortcode,
- *       updates: { element: 2 }
- *     })
- *   }
- * </script>
- * ```
- */
-export function useUpdateGridWeapon() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updateGridWeaponOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({ id, updates }: { id: string; partyShortcode: string; updates: Partial<GridWeapon> }) =>
 			gridAdapter.updateWeapon(id, updates),
-		onMutate: async ({ id, partyShortcode, updates }) => {
+		onMutate: async ({ id, partyShortcode, updates }: { id: string; partyShortcode: string; updates: Partial<GridWeapon> }) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(partyShortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(partyShortcode))
@@ -135,29 +107,20 @@ export function useUpdateGridWeapon() {
 
 			return { previousParty }
 		},
-		onError: (_err, { partyShortcode }, context) => {
-			if (context?.previousParty) {
-				queryClient.setQueryData(partyKeys.detail(partyShortcode), context.previousParty)
-			}
+		onError: (_err: any, { partyShortcode }: { partyShortcode: string }, context: { previousParty?: Party } | undefined) => {
+			optimisticRollback(queryClient, partyShortcode, context)
 		},
-		onSettled: (_data, _err, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSettled: (_data: any, _err: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Delete grid weapon mutation
- *
- * Removes a weapon from a party's grid.
- */
-export function useDeleteGridWeapon() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function deleteGridWeaponOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: { id?: string; partyId: string; partyShortcode: string; position?: number }) =>
 			gridAdapter.deleteWeapon({ id: params.id, partyId: params.partyId, position: params.position }),
-		onMutate: async ({ partyShortcode, id, position }) => {
+		onMutate: async ({ partyShortcode, id, position }: { partyShortcode: string; id?: string; position?: number }) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(partyShortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(partyShortcode))
@@ -174,29 +137,20 @@ export function useDeleteGridWeapon() {
 
 			return { previousParty }
 		},
-		onError: (_err, { partyShortcode }, context) => {
-			if (context?.previousParty) {
-				queryClient.setQueryData(partyKeys.detail(partyShortcode), context.previousParty)
-			}
+		onError: (_err: any, { partyShortcode }: { partyShortcode: string }, context: { previousParty?: Party } | undefined) => {
+			optimisticRollback(queryClient, partyShortcode, context)
 		},
-		onSettled: (_data, _err, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSettled: (_data: any, _err: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Update weapon uncap mutation
- *
- * Updates a weapon's uncap level with optimistic updates.
- */
-export function useUpdateWeaponUncap() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updateWeaponUncapOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: UpdateUncapParams & { partyShortcode: string }) =>
 			gridAdapter.updateWeaponUncap(params),
-		onMutate: async ({ partyShortcode, id, uncapLevel, transcendenceStep }) => {
+		onMutate: async ({ partyShortcode, id, uncapLevel, transcendenceStep }: UpdateUncapParams & { partyShortcode: string }) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(partyShortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(partyShortcode))
@@ -219,85 +173,55 @@ export function useUpdateWeaponUncap() {
 
 			return { previousParty }
 		},
-		onError: (_err, { partyShortcode }, context) => {
-			if (context?.previousParty) {
-				queryClient.setQueryData(partyKeys.detail(partyShortcode), context.previousParty)
-			}
+		onError: (_err: any, { partyShortcode }: { partyShortcode: string }, context: { previousParty?: Party } | undefined) => {
+			optimisticRollback(queryClient, partyShortcode, context)
 		},
-		onSettled: (_data, _err, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSettled: (_data: any, _err: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Resolve weapon conflict mutation
- *
- * Resolves conflicts when adding a weapon that conflicts with existing weapons.
- */
-export function useResolveWeaponConflict() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function resolveWeaponConflictOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: ResolveConflictParams & { partyShortcode: string }) =>
 			gridAdapter.resolveWeaponConflict(params),
-		onSuccess: (_data, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSuccess: (_data: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Swap weapon positions mutation
- *
- * Swaps the positions of two weapons in the grid.
- */
-export function useSwapWeapons() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function swapWeaponsOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: SwapPositionsParams & { partyShortcode: string }) =>
 			gridAdapter.swapWeapons(params),
-		onSuccess: (_data, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSuccess: (_data: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
 // ============================================================================
-// Character Mutations
+// Character Mutation Options
 // ============================================================================
 
-/**
- * Create grid character mutation
- *
- * Adds a character to a party's grid.
- */
-export function useCreateGridCharacter() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function createGridCharacterOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: createGridMutation((params: CreateGridCharacterParams, headers?: Record<string, string>) =>
 			gridAdapter.createCharacter(params, headers)
 		),
-		onSuccess: (_data, params) => {
+		onSuccess: (_data: any, params: CreateGridCharacterParams) => {
 			invalidateParty(queryClient, params.partyId)
 		}
-	}))
+	}
 }
 
-/**
- * Update grid character mutation
- *
- * Updates a character in a party's grid with optimistic updates.
- */
-export function useUpdateGridCharacter() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updateGridCharacterOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({ id, updates }: { id: string; partyShortcode: string; updates: Partial<GridCharacter> }) =>
 			gridAdapter.updateCharacter(id, updates),
-		onMutate: async ({ id, partyShortcode, updates }) => {
+		onMutate: async ({ id, partyShortcode, updates }: { id: string; partyShortcode: string; updates: Partial<GridCharacter> }) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(partyShortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(partyShortcode))
@@ -314,29 +238,20 @@ export function useUpdateGridCharacter() {
 
 			return { previousParty }
 		},
-		onError: (_err, { partyShortcode }, context) => {
-			if (context?.previousParty) {
-				queryClient.setQueryData(partyKeys.detail(partyShortcode), context.previousParty)
-			}
+		onError: (_err: any, { partyShortcode }: { partyShortcode: string }, context: { previousParty?: Party } | undefined) => {
+			optimisticRollback(queryClient, partyShortcode, context)
 		},
-		onSettled: (_data, _err, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSettled: (_data: any, _err: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Delete grid character mutation
- *
- * Removes a character from a party's grid.
- */
-export function useDeleteGridCharacter() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function deleteGridCharacterOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: { id?: string; partyId: string; partyShortcode: string; position?: number }) =>
 			gridAdapter.deleteCharacter({ id: params.id, partyId: params.partyId, position: params.position }),
-		onMutate: async ({ partyShortcode, id, position }) => {
+		onMutate: async ({ partyShortcode, id, position }: { partyShortcode: string; id?: string; position?: number }) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(partyShortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(partyShortcode))
@@ -353,29 +268,20 @@ export function useDeleteGridCharacter() {
 
 			return { previousParty }
 		},
-		onError: (_err, { partyShortcode }, context) => {
-			if (context?.previousParty) {
-				queryClient.setQueryData(partyKeys.detail(partyShortcode), context.previousParty)
-			}
+		onError: (_err: any, { partyShortcode }: { partyShortcode: string }, context: { previousParty?: Party } | undefined) => {
+			optimisticRollback(queryClient, partyShortcode, context)
 		},
-		onSettled: (_data, _err, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSettled: (_data: any, _err: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Update character uncap mutation
- *
- * Updates a character's uncap level with optimistic updates.
- */
-export function useUpdateCharacterUncap() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updateCharacterUncapOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: UpdateUncapParams & { partyShortcode: string }) =>
 			gridAdapter.updateCharacterUncap(params),
-		onMutate: async ({ partyShortcode, id, uncapLevel, transcendenceStep }) => {
+		onMutate: async ({ partyShortcode, id, uncapLevel, transcendenceStep }: UpdateUncapParams & { partyShortcode: string }) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(partyShortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(partyShortcode))
@@ -398,85 +304,55 @@ export function useUpdateCharacterUncap() {
 
 			return { previousParty }
 		},
-		onError: (_err, { partyShortcode }, context) => {
-			if (context?.previousParty) {
-				queryClient.setQueryData(partyKeys.detail(partyShortcode), context.previousParty)
-			}
+		onError: (_err: any, { partyShortcode }: { partyShortcode: string }, context: { previousParty?: Party } | undefined) => {
+			optimisticRollback(queryClient, partyShortcode, context)
 		},
-		onSettled: (_data, _err, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSettled: (_data: any, _err: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Resolve character conflict mutation
- *
- * Resolves conflicts when adding a character that conflicts with existing characters.
- */
-export function useResolveCharacterConflict() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function resolveCharacterConflictOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: ResolveConflictParams & { partyShortcode: string }) =>
 			gridAdapter.resolveCharacterConflict(params),
-		onSuccess: (_data, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSuccess: (_data: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Swap character positions mutation
- *
- * Swaps the positions of two characters in the grid.
- */
-export function useSwapCharacters() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function swapCharactersOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: SwapPositionsParams & { partyShortcode: string }) =>
 			gridAdapter.swapCharacters(params),
-		onSuccess: (_data, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSuccess: (_data: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
 // ============================================================================
-// Summon Mutations
+// Summon Mutation Options
 // ============================================================================
 
-/**
- * Create grid summon mutation
- *
- * Adds a summon to a party's grid.
- */
-export function useCreateGridSummon() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function createGridSummonOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: createGridMutation((params: CreateGridSummonParams, headers?: Record<string, string>) =>
 			gridAdapter.createSummon(params, headers)
 		),
-		onSuccess: (_data, params) => {
+		onSuccess: (_data: any, params: CreateGridSummonParams) => {
 			invalidateParty(queryClient, params.partyId)
 		}
-	}))
+	}
 }
 
-/**
- * Update grid summon mutation
- *
- * Updates a summon in a party's grid with optimistic updates.
- */
-export function useUpdateGridSummon() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updateGridSummonOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({ id, updates }: { id: string; partyShortcode: string; updates: Partial<GridSummon> }) =>
 			gridAdapter.updateSummon(id, updates),
-		onMutate: async ({ id, partyShortcode, updates }) => {
+		onMutate: async ({ id, partyShortcode, updates }: { id: string; partyShortcode: string; updates: Partial<GridSummon> }) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(partyShortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(partyShortcode))
@@ -493,29 +369,20 @@ export function useUpdateGridSummon() {
 
 			return { previousParty }
 		},
-		onError: (_err, { partyShortcode }, context) => {
-			if (context?.previousParty) {
-				queryClient.setQueryData(partyKeys.detail(partyShortcode), context.previousParty)
-			}
+		onError: (_err: any, { partyShortcode }: { partyShortcode: string }, context: { previousParty?: Party } | undefined) => {
+			optimisticRollback(queryClient, partyShortcode, context)
 		},
-		onSettled: (_data, _err, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSettled: (_data: any, _err: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Delete grid summon mutation
- *
- * Removes a summon from a party's grid.
- */
-export function useDeleteGridSummon() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function deleteGridSummonOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: { id?: string; partyId: string; partyShortcode: string; position?: number }) =>
 			gridAdapter.deleteSummon({ id: params.id, partyId: params.partyId, position: params.position }),
-		onMutate: async ({ partyShortcode, id, position }) => {
+		onMutate: async ({ partyShortcode, id, position }: { partyShortcode: string; id?: string; position?: number }) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(partyShortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(partyShortcode))
@@ -532,29 +399,20 @@ export function useDeleteGridSummon() {
 
 			return { previousParty }
 		},
-		onError: (_err, { partyShortcode }, context) => {
-			if (context?.previousParty) {
-				queryClient.setQueryData(partyKeys.detail(partyShortcode), context.previousParty)
-			}
+		onError: (_err: any, { partyShortcode }: { partyShortcode: string }, context: { previousParty?: Party } | undefined) => {
+			optimisticRollback(queryClient, partyShortcode, context)
 		},
-		onSettled: (_data, _err, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSettled: (_data: any, _err: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Update summon uncap mutation
- *
- * Updates a summon's uncap level with optimistic updates.
- */
-export function useUpdateSummonUncap() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updateSummonUncapOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: UpdateUncapParams & { partyShortcode: string }) =>
 			gridAdapter.updateSummonUncap(params),
-		onMutate: async ({ partyShortcode, id, uncapLevel, transcendenceStep }) => {
+		onMutate: async ({ partyShortcode, id, uncapLevel, transcendenceStep }: UpdateUncapParams & { partyShortcode: string }) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(partyShortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(partyShortcode))
@@ -577,26 +435,17 @@ export function useUpdateSummonUncap() {
 
 			return { previousParty }
 		},
-		onError: (_err, { partyShortcode }, context) => {
-			if (context?.previousParty) {
-				queryClient.setQueryData(partyKeys.detail(partyShortcode), context.previousParty)
-			}
+		onError: (_err: any, { partyShortcode }: { partyShortcode: string }, context: { previousParty?: Party } | undefined) => {
+			optimisticRollback(queryClient, partyShortcode, context)
 		},
-		onSettled: (_data, _err, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSettled: (_data: any, _err: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Update quick summon mutation
- *
- * Updates a summon's quick summon setting with optimistic updates.
- */
-export function useUpdateQuickSummon() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updateQuickSummonOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: {
 			id?: string
 			partyId: string
@@ -610,7 +459,7 @@ export function useUpdateQuickSummon() {
 				position: params.position,
 				quickSummon: params.quickSummon
 			}),
-		onMutate: async ({ partyShortcode, id, quickSummon }) => {
+		onMutate: async ({ partyShortcode, id, quickSummon }: { partyShortcode: string; id?: string; quickSummon: boolean }) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(partyShortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(partyShortcode))
@@ -627,119 +476,194 @@ export function useUpdateQuickSummon() {
 
 			return { previousParty }
 		},
-		onError: (_err, { partyShortcode }, context) => {
-			if (context?.previousParty) {
-				queryClient.setQueryData(partyKeys.detail(partyShortcode), context.previousParty)
-			}
+		onError: (_err: any, { partyShortcode }: { partyShortcode: string }, context: { previousParty?: Party } | undefined) => {
+			optimisticRollback(queryClient, partyShortcode, context)
 		},
-		onSettled: (_data, _err, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSettled: (_data: any, _err: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Swap summon positions mutation
- *
- * Swaps the positions of two summons in the grid.
- */
-export function useSwapSummons() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function swapSummonsOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: SwapPositionsParams & { partyShortcode: string }) =>
 			gridAdapter.swapSummons(params),
-		onSuccess: (_data, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSuccess: (_data: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
 // ============================================================================
-// Sync Mutations (Collection -> Grid)
+// Sync Mutation Options
 // ============================================================================
 
-/**
- * Sync grid character from collection mutation
- *
- * Syncs a grid character's customizations from its linked collection source.
- */
-export function useSyncGridCharacter() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function syncGridCharacterOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: { id: string; partyShortcode: string }) =>
 			gridAdapter.syncCharacter(params.id),
-		onSuccess: (_data, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSuccess: (_data: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Sync grid weapon from collection mutation
- *
- * Syncs a grid weapon's customizations from its linked collection source.
- */
-export function useSyncGridWeapon() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function syncGridWeaponOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: { id: string; partyShortcode: string }) =>
 			gridAdapter.syncWeapon(params.id),
-		onSuccess: (_data, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSuccess: (_data: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Sync grid summon from collection mutation
- *
- * Syncs a grid summon's customizations from its linked collection source.
- */
-export function useSyncGridSummon() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function syncGridSummonOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: { id: string; partyShortcode: string }) =>
 			gridAdapter.syncSummon(params.id),
-		onSuccess: (_data, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSuccess: (_data: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Sync all party items from collection mutation
- *
- * Syncs all linked grid items in a party from their collection sources.
- */
-export function useSyncAllPartyItems() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function syncAllPartyItemsOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: { partyId: string; partyShortcode: string }) =>
 			gridAdapter.syncAllPartyItems(params.partyId),
-		onSuccess: (_data, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSuccess: (_data: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
 }
 
-/**
- * Unlink all collection sources from a party's grid items.
- *
- * Keeps the grid items but removes their collection references and clears the collection source user.
- */
-export function useUnlinkCollectionSource() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function unlinkCollectionSourceOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: { partyId: string; partyShortcode: string }) =>
 			gridAdapter.unlinkCollectionSource(params.partyId),
-		onSuccess: (_data, { partyShortcode }) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.detail(partyShortcode) })
+		onSuccess: (_data: any, { partyShortcode }: { partyShortcode: string }) => {
+			invalidateOnSettled(queryClient, partyShortcode)
 		}
-	}))
+	}
+}
+
+// ============================================================================
+// Svelte Hooks (thin wrappers for component use)
+// ============================================================================
+
+export function useCreateGridWeapon() {
+	const queryClient = useQueryClient()
+	return createMutation(() => createGridWeaponOptions(queryClient))
+}
+
+export function useUpdateGridWeapon() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updateGridWeaponOptions(queryClient))
+}
+
+export function useDeleteGridWeapon() {
+	const queryClient = useQueryClient()
+	return createMutation(() => deleteGridWeaponOptions(queryClient))
+}
+
+export function useUpdateWeaponUncap() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updateWeaponUncapOptions(queryClient))
+}
+
+export function useResolveWeaponConflict() {
+	const queryClient = useQueryClient()
+	return createMutation(() => resolveWeaponConflictOptions(queryClient))
+}
+
+export function useSwapWeapons() {
+	const queryClient = useQueryClient()
+	return createMutation(() => swapWeaponsOptions(queryClient))
+}
+
+export function useCreateGridCharacter() {
+	const queryClient = useQueryClient()
+	return createMutation(() => createGridCharacterOptions(queryClient))
+}
+
+export function useUpdateGridCharacter() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updateGridCharacterOptions(queryClient))
+}
+
+export function useDeleteGridCharacter() {
+	const queryClient = useQueryClient()
+	return createMutation(() => deleteGridCharacterOptions(queryClient))
+}
+
+export function useUpdateCharacterUncap() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updateCharacterUncapOptions(queryClient))
+}
+
+export function useResolveCharacterConflict() {
+	const queryClient = useQueryClient()
+	return createMutation(() => resolveCharacterConflictOptions(queryClient))
+}
+
+export function useSwapCharacters() {
+	const queryClient = useQueryClient()
+	return createMutation(() => swapCharactersOptions(queryClient))
+}
+
+export function useCreateGridSummon() {
+	const queryClient = useQueryClient()
+	return createMutation(() => createGridSummonOptions(queryClient))
+}
+
+export function useUpdateGridSummon() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updateGridSummonOptions(queryClient))
+}
+
+export function useDeleteGridSummon() {
+	const queryClient = useQueryClient()
+	return createMutation(() => deleteGridSummonOptions(queryClient))
+}
+
+export function useUpdateSummonUncap() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updateSummonUncapOptions(queryClient))
+}
+
+export function useUpdateQuickSummon() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updateQuickSummonOptions(queryClient))
+}
+
+export function useSwapSummons() {
+	const queryClient = useQueryClient()
+	return createMutation(() => swapSummonsOptions(queryClient))
+}
+
+export function useSyncGridCharacter() {
+	const queryClient = useQueryClient()
+	return createMutation(() => syncGridCharacterOptions(queryClient))
+}
+
+export function useSyncGridWeapon() {
+	const queryClient = useQueryClient()
+	return createMutation(() => syncGridWeaponOptions(queryClient))
+}
+
+export function useSyncGridSummon() {
+	const queryClient = useQueryClient()
+	return createMutation(() => syncGridSummonOptions(queryClient))
+}
+
+export function useSyncAllPartyItems() {
+	const queryClient = useQueryClient()
+	return createMutation(() => syncAllPartyItemsOptions(queryClient))
+}
+
+export function useUnlinkCollectionSource() {
+	const queryClient = useQueryClient()
+	return createMutation(() => unlinkCollectionSourceOptions(queryClient))
 }

--- a/src/lib/api/mutations/gw.mutations.ts
+++ b/src/lib/api/mutations/gw.mutations.ts
@@ -4,210 +4,245 @@
  * Provides mutation configurations for GW operations
  * with cache invalidation using TanStack Query v6.
  *
+ * Each mutation exports both an options factory (for testing) and a hook (for components).
+ *
  * @module api/mutations/gw
  */
 
-import { useQueryClient, createMutation } from '@tanstack/svelte-query'
+import { useQueryClient, createMutation, type QueryClient } from '@tanstack/svelte-query'
 import { gwAdapter } from '$lib/api/adapters/gw.adapter'
 import { gwKeys } from '$lib/api/queries/gw.queries'
 import type {
-  CreateGwEventInput,
-  UpdateGwEventInput,
-  UpdateParticipationRankingInput,
-  CreateCrewScoreInput,
-  UpdateCrewScoreInput,
-  CreateIndividualScoreInput,
-  BatchIndividualScoresInput
+	CreateGwEventInput,
+	UpdateGwEventInput,
+	UpdateParticipationRankingInput,
+	CreateCrewScoreInput,
+	UpdateCrewScoreInput,
+	CreateIndividualScoreInput,
+	BatchIndividualScoresInput
 } from '$lib/types/api/gw'
 
-// ==================== Event Mutations (Admin) ====================
+// ============================================================================
+// Options Factories — Events (Admin)
+// ============================================================================
 
-/**
- * Create GW event mutation (admin only)
- */
+export function createGwEventOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: (input: CreateGwEventInput) => gwAdapter.createEvent(input),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: gwKeys.events() })
+		}
+	}
+}
+
+export function updateGwEventOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({ eventId, input }: { eventId: string; input: UpdateGwEventInput }) =>
+			gwAdapter.updateEvent(eventId, input),
+		onSuccess: (_data: unknown, { eventId }: { eventId: string; input: UpdateGwEventInput }) => {
+			queryClient.invalidateQueries({ queryKey: gwKeys.events() })
+			queryClient.invalidateQueries({ queryKey: gwKeys.event(eventId) })
+		}
+	}
+}
+
+// ============================================================================
+// Options Factories — Participation
+// ============================================================================
+
+export function joinGwEventOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: (eventId: string) => gwAdapter.joinEvent(eventId),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: gwKeys.participationsAll() })
+		}
+	}
+}
+
+export function updateParticipationRankingOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({
+			participationId,
+			input
+		}: {
+			participationId: string
+			input: UpdateParticipationRankingInput
+		}) => gwAdapter.updateParticipationRanking(participationId, input),
+		onSuccess: (
+			_data: unknown,
+			{ participationId }: { participationId: string; input: UpdateParticipationRankingInput }
+		) => {
+			queryClient.invalidateQueries({ queryKey: gwKeys.participationsAll() })
+			queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
+		}
+	}
+}
+
+// ============================================================================
+// Options Factories — Crew Scores
+// ============================================================================
+
+export function addCrewScoreOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({
+			participationId,
+			input
+		}: {
+			participationId: string
+			input: CreateCrewScoreInput
+		}) => gwAdapter.addCrewScore(participationId, input),
+		onSuccess: (
+			_data: unknown,
+			{ participationId }: { participationId: string; input: CreateCrewScoreInput }
+		) => {
+			queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
+		}
+	}
+}
+
+export function updateCrewScoreOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({
+			participationId,
+			scoreId,
+			input
+		}: {
+			participationId: string
+			scoreId: string
+			input: UpdateCrewScoreInput
+		}) => gwAdapter.updateCrewScore(participationId, scoreId, input),
+		onSuccess: (
+			_data: unknown,
+			{ participationId }: { participationId: string; scoreId: string; input: UpdateCrewScoreInput }
+		) => {
+			queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
+		}
+	}
+}
+
+// ============================================================================
+// Options Factories — Individual Scores
+// ============================================================================
+
+export function addIndividualScoreOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({
+			participationId,
+			input
+		}: {
+			participationId: string
+			input: CreateIndividualScoreInput
+		}) => gwAdapter.addIndividualScore(participationId, input),
+		onSuccess: (
+			_data: unknown,
+			{ participationId }: { participationId: string; input: CreateIndividualScoreInput }
+		) => {
+			queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
+		}
+	}
+}
+
+export function batchAddIndividualScoresOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({
+			participationId,
+			input
+		}: {
+			participationId: string
+			input: BatchIndividualScoresInput
+		}) => gwAdapter.batchAddIndividualScores(participationId, input),
+		onSuccess: (
+			_data: unknown,
+			{ participationId }: { participationId: string; input: BatchIndividualScoresInput }
+		) => {
+			queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
+		}
+	}
+}
+
+export function updateIndividualScoreOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({
+			participationId,
+			scoreId,
+			input
+		}: {
+			participationId: string
+			scoreId: string
+			input: Partial<CreateIndividualScoreInput>
+		}) => gwAdapter.updateIndividualScore(participationId, scoreId, input),
+		onSuccess: (
+			_data: unknown,
+			{ participationId }: { participationId: string; scoreId: string; input: Partial<CreateIndividualScoreInput> }
+		) => {
+			queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
+		}
+	}
+}
+
+export function deleteIndividualScoreOptions(queryClient: QueryClient) {
+	return {
+		mutationFn: ({ participationId, scoreId }: { participationId: string; scoreId: string }) =>
+			gwAdapter.deleteIndividualScore(participationId, scoreId),
+		onSuccess: (
+			_data: unknown,
+			{ participationId }: { participationId: string; scoreId: string }
+		) => {
+			queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
+		}
+	}
+}
+
+// ============================================================================
+// Hooks (thin wrappers for component use)
+// ============================================================================
+
 export function useCreateGwEvent() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: (input: CreateGwEventInput) => gwAdapter.createEvent(input),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: gwKeys.events() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => createGwEventOptions(queryClient))
 }
 
-/**
- * Update GW event mutation (admin only)
- */
 export function useUpdateGwEvent() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({ eventId, input }: { eventId: string; input: UpdateGwEventInput }) =>
-      gwAdapter.updateEvent(eventId, input),
-    onSuccess: (_data, { eventId }) => {
-      queryClient.invalidateQueries({ queryKey: gwKeys.events() })
-      queryClient.invalidateQueries({ queryKey: gwKeys.event(eventId) })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => updateGwEventOptions(queryClient))
 }
 
-// ==================== Participation Mutations ====================
-
-/**
- * Join GW event mutation
- */
 export function useJoinGwEvent() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: (eventId: string) => gwAdapter.joinEvent(eventId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: gwKeys.participationsAll() })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => joinGwEventOptions(queryClient))
 }
 
-/**
- * Update participation ranking mutation
- */
 export function useUpdateParticipationRanking() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({
-      participationId,
-      input
-    }: {
-      participationId: string
-      input: UpdateParticipationRankingInput
-    }) => gwAdapter.updateParticipationRanking(participationId, input),
-    onSuccess: (_data, { participationId }) => {
-      queryClient.invalidateQueries({ queryKey: gwKeys.participationsAll() })
-      queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => updateParticipationRankingOptions(queryClient))
 }
 
-// ==================== Crew Score Mutations ====================
-
-/**
- * Add crew score mutation
- */
 export function useAddCrewScore() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({
-      participationId,
-      input
-    }: {
-      participationId: string
-      input: CreateCrewScoreInput
-    }) => gwAdapter.addCrewScore(participationId, input),
-    onSuccess: (_data, { participationId }) => {
-      queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => addCrewScoreOptions(queryClient))
 }
 
-/**
- * Update crew score mutation
- */
 export function useUpdateCrewScore() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({
-      participationId,
-      scoreId,
-      input
-    }: {
-      participationId: string
-      scoreId: string
-      input: UpdateCrewScoreInput
-    }) => gwAdapter.updateCrewScore(participationId, scoreId, input),
-    onSuccess: (_data, { participationId }) => {
-      queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => updateCrewScoreOptions(queryClient))
 }
 
-// ==================== Individual Score Mutations ====================
-
-/**
- * Add individual score mutation
- */
 export function useAddIndividualScore() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({
-      participationId,
-      input
-    }: {
-      participationId: string
-      input: CreateIndividualScoreInput
-    }) => gwAdapter.addIndividualScore(participationId, input),
-    onSuccess: (_data, { participationId }) => {
-      queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => addIndividualScoreOptions(queryClient))
 }
 
-/**
- * Batch add individual scores mutation
- */
 export function useBatchAddIndividualScores() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({
-      participationId,
-      input
-    }: {
-      participationId: string
-      input: BatchIndividualScoresInput
-    }) => gwAdapter.batchAddIndividualScores(participationId, input),
-    onSuccess: (_data, { participationId }) => {
-      queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => batchAddIndividualScoresOptions(queryClient))
 }
 
-/**
- * Update individual score mutation
- */
 export function useUpdateIndividualScore() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({
-      participationId,
-      scoreId,
-      input
-    }: {
-      participationId: string
-      scoreId: string
-      input: Partial<CreateIndividualScoreInput>
-    }) => gwAdapter.updateIndividualScore(participationId, scoreId, input),
-    onSuccess: (_data, { participationId }) => {
-      queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => updateIndividualScoreOptions(queryClient))
 }
 
-/**
- * Delete individual score mutation
- */
 export function useDeleteIndividualScore() {
-  const queryClient = useQueryClient()
-
-  return createMutation(() => ({
-    mutationFn: ({ participationId, scoreId }: { participationId: string; scoreId: string }) =>
-      gwAdapter.deleteIndividualScore(participationId, scoreId),
-    onSuccess: (_data, { participationId }) => {
-      queryClient.invalidateQueries({ queryKey: gwKeys.participation(participationId) })
-    }
-  }))
+	const queryClient = useQueryClient()
+	return createMutation(() => deleteIndividualScoreOptions(queryClient))
 }

--- a/src/lib/api/mutations/job.mutations.ts
+++ b/src/lib/api/mutations/job.mutations.ts
@@ -4,39 +4,25 @@
  * Provides mutation configurations for job-related operations
  * with cache invalidation using TanStack Query v6.
  *
+ * Each mutation exports both an options factory (for testing) and a hook (for components).
+ *
  * @module api/mutations/job
  */
 
-import { useQueryClient, createMutation } from '@tanstack/svelte-query'
+import { useQueryClient, createMutation, type QueryClient } from '@tanstack/svelte-query'
 import { partyAdapter } from '$lib/api/adapters/party.adapter'
 import { partyKeys } from '$lib/api/queries/party.queries'
 import type { Party } from '$lib/types/api/party'
 
-/**
- * Update party job mutation
- *
- * Updates the job for a party with optimistic updates.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useUpdatePartyJob } from '$lib/api/mutations/job.mutations'
- *
- *   const updateJob = useUpdatePartyJob()
- *
- *   function handleJobSelect(jobId: string) {
- *     updateJob.mutate({ shortcode: 'abc123', jobId })
- *   }
- * </script>
- * ```
- */
-export function useUpdatePartyJob() {
-	const queryClient = useQueryClient()
+// ============================================================================
+// Options Factories
+// ============================================================================
 
-	return createMutation(() => ({
+export function updatePartyJobOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({ shortcode, jobId }: { shortcode: string; jobId: string }) =>
 			partyAdapter.updateJob(shortcode, jobId),
-		onMutate: async ({ shortcode, jobId }) => {
+		onMutate: async ({ shortcode, jobId }: { shortcode: string; jobId: string }) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(shortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(shortcode))
@@ -53,39 +39,27 @@ export function useUpdatePartyJob() {
 
 			return { previousParty }
 		},
-		onError: (_err, { shortcode }, context) => {
+		onError: (
+			_err: unknown,
+			{ shortcode }: { shortcode: string; jobId: string },
+			context: { previousParty?: Party } | undefined
+		) => {
 			if (context?.previousParty) {
 				queryClient.setQueryData(partyKeys.detail(shortcode), context.previousParty)
 			}
 		},
-		onSettled: (_data, _err, { shortcode }) => {
+		onSettled: (
+			_data: unknown,
+			_err: unknown,
+			{ shortcode }: { shortcode: string; jobId: string }
+		) => {
 			queryClient.invalidateQueries({ queryKey: partyKeys.detail(shortcode) })
 		}
-	}))
+	}
 }
 
-/**
- * Update party job skills mutation
- *
- * Updates the job skills for a party.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useUpdatePartyJobSkills } from '$lib/api/mutations/job.mutations'
- *
- *   const updateSkills = useUpdatePartyJobSkills()
- *
- *   function handleSkillsUpdate(skills: Array<{ id: string; slot: number }>) {
- *     updateSkills.mutate({ shortcode: 'abc123', skills })
- *   }
- * </script>
- * ```
- */
-export function useUpdatePartyJobSkills() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updatePartyJobSkillsOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({
 			shortcode,
 			skills
@@ -93,37 +67,17 @@ export function useUpdatePartyJobSkills() {
 			shortcode: string
 			skills: Array<{ id: string; slot: number }>
 		}) => partyAdapter.updateJobSkills(shortcode, skills),
-		onSuccess: (_data, { shortcode }) => {
+		onSuccess: (_data: unknown, { shortcode }: { shortcode: string; skills: Array<{ id: string; slot: number }> }) => {
 			queryClient.invalidateQueries({ queryKey: partyKeys.detail(shortcode) })
 		}
-	}))
+	}
 }
 
-/**
- * Remove party job skill mutation
- *
- * Removes a job skill from a party.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useRemovePartyJobSkill } from '$lib/api/mutations/job.mutations'
- *
- *   const removeSkill = useRemovePartyJobSkill()
- *
- *   function handleRemoveSkill(slot: number) {
- *     removeSkill.mutate({ shortcode: 'abc123', slot })
- *   }
- * </script>
- * ```
- */
-export function useRemovePartyJobSkill() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function removePartyJobSkillOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({ shortcode, slot }: { shortcode: string; slot: number }) =>
 			partyAdapter.removeJobSkill(shortcode, slot),
-		onMutate: async ({ shortcode, slot }) => {
+		onMutate: async ({ shortcode, slot }: { shortcode: string; slot: number }) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(shortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(shortcode))
@@ -142,43 +96,55 @@ export function useRemovePartyJobSkill() {
 
 			return { previousParty }
 		},
-		onError: (_err, { shortcode }, context) => {
+		onError: (
+			_err: unknown,
+			{ shortcode }: { shortcode: string; slot: number },
+			context: { previousParty?: Party } | undefined
+		) => {
 			if (context?.previousParty) {
 				queryClient.setQueryData(partyKeys.detail(shortcode), context.previousParty)
 			}
 		},
-		onSettled: (_data, _err, { shortcode }) => {
+		onSettled: (
+			_data: unknown,
+			_err: unknown,
+			{ shortcode }: { shortcode: string; slot: number }
+		) => {
 			queryClient.invalidateQueries({ queryKey: partyKeys.detail(shortcode) })
 		}
-	}))
+	}
 }
 
-/**
- * Update party accessory mutation
- *
- * Updates the accessory for a party.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useUpdatePartyAccessory } from '$lib/api/mutations/job.mutations'
- *
- *   const updateAccessory = useUpdatePartyAccessory()
- *
- *   function handleAccessorySelect(accessoryId: string) {
- *     updateAccessory.mutate({ shortcode: 'abc123', accessoryId })
- *   }
- * </script>
- * ```
- */
-export function useUpdatePartyAccessory() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updatePartyAccessoryOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({ shortcode, accessoryId }: { shortcode: string; accessoryId: string }) =>
 			partyAdapter.updateAccessory(shortcode, accessoryId),
-		onSuccess: (_data, { shortcode }) => {
+		onSuccess: (_data: unknown, { shortcode }: { shortcode: string; accessoryId: string }) => {
 			queryClient.invalidateQueries({ queryKey: partyKeys.detail(shortcode) })
 		}
-	}))
+	}
+}
+
+// ============================================================================
+// Hooks (thin wrappers for component use)
+// ============================================================================
+
+export function useUpdatePartyJob() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updatePartyJobOptions(queryClient))
+}
+
+export function useUpdatePartyJobSkills() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updatePartyJobSkillsOptions(queryClient))
+}
+
+export function useRemovePartyJobSkill() {
+	const queryClient = useQueryClient()
+	return createMutation(() => removePartyJobSkillOptions(queryClient))
+}
+
+export function useUpdatePartyAccessory() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updatePartyAccessoryOptions(queryClient))
 }

--- a/src/lib/api/mutations/party.mutations.ts
+++ b/src/lib/api/mutations/party.mutations.ts
@@ -4,10 +4,12 @@
  * Provides mutation configurations for party CRUD operations
  * with cache invalidation and optimistic updates using TanStack Query v6.
  *
+ * Each mutation exports both an options factory (for testing) and a hook (for components).
+ *
  * @module api/mutations/party
  */
 
-import { useQueryClient, createMutation } from '@tanstack/svelte-query'
+import { useQueryClient, createMutation, type QueryClient } from '@tanstack/svelte-query'
 import {
 	partyAdapter,
 	type CreatePartyParams,
@@ -18,71 +20,29 @@ import { userKeys } from '$lib/api/queries/user.queries'
 import { crewKeys } from '$lib/api/queries/crew.queries'
 import type { Party } from '$lib/types/api/party'
 
-/**
- * Create party mutation
- *
- * Creates a new party and invalidates relevant caches.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useCreateParty } from '$lib/api/mutations/party.mutations'
- *
- *   const createParty = useCreateParty()
- *
- *   function handleCreate() {
- *     createParty.mutate({ name: 'My Party', visibility: 'public' })
- *   }
- * </script>
- * ```
- */
-export function useCreateParty() {
-	const queryClient = useQueryClient()
+// ============================================================================
+// Options Factories
+// ============================================================================
 
-	return createMutation(() => ({
+export function createPartyOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: CreatePartyParams) => partyAdapter.create(params),
-		onSuccess: (party) => {
-			// Set the new party in cache
+		onSuccess: (party: Party) => {
 			queryClient.setQueryData(partyKeys.detail(party.shortcode), party)
-			// Invalidate party lists to include the new party
 			queryClient.invalidateQueries({ queryKey: partyKeys.lists() })
-			// Invalidate user's party lists
 			queryClient.invalidateQueries({ queryKey: userKeys.all })
 		}
-	}))
+	}
 }
 
-/**
- * Update party mutation
- *
- * Updates an existing party with optimistic updates.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useUpdateParty } from '$lib/api/mutations/party.mutations'
- *
- *   const updateParty = useUpdateParty()
- *
- *   function handleUpdate() {
- *     updateParty.mutate({ shortcode: 'abc123', name: 'Updated Name' })
- *   }
- * </script>
- * ```
- */
-export function useUpdateParty() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function updatePartyOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: UpdatePartyParams) => partyAdapter.update(params),
-		onMutate: async (params) => {
-			// Cancel any outgoing refetches
+		onMutate: async (params: UpdatePartyParams) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(params.shortcode) })
 
-			// Snapshot the previous value
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(params.shortcode))
 
-			// Optimistically update the cache
 			if (previousParty) {
 				queryClient.setQueryData(partyKeys.detail(params.shortcode), {
 					...previousParty,
@@ -92,119 +52,47 @@ export function useUpdateParty() {
 
 			return { previousParty }
 		},
-		onError: (_err, params, context) => {
-			// Rollback on error
+		onError: (_err: unknown, params: UpdatePartyParams, context: { previousParty?: Party } | undefined) => {
 			if (context?.previousParty) {
 				queryClient.setQueryData(partyKeys.detail(params.shortcode), context.previousParty)
 			}
 		},
-		onSettled: (_data, _err, params) => {
-			// Always refetch after error or success
+		onSettled: (_data: unknown, _err: unknown, params: UpdatePartyParams) => {
 			queryClient.invalidateQueries({ queryKey: partyKeys.detail(params.shortcode) })
 		}
-	}))
+	}
 }
 
-/**
- * Delete party mutation
- *
- * Deletes a party and removes it from all caches.
- * Note: The API expects the party UUID (id), not the shortcode.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useDeleteParty } from '$lib/api/mutations/party.mutations'
- *
- *   const deleteParty = useDeleteParty()
- *
- *   function handleDelete(id: string, shortcode: string) {
- *     deleteParty.mutate({ id, shortcode })
- *   }
- * </script>
- * ```
- */
-export function useDeleteParty() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function deletePartyOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (params: { id: string; shortcode: string }) => partyAdapter.delete(params.id),
-		onSuccess: (_data, params) => {
-			// Remove the party from cache (keyed by shortcode)
+		onSuccess: (_data: unknown, params: { id: string; shortcode: string }) => {
 			queryClient.removeQueries({ queryKey: partyKeys.detail(params.shortcode) })
-			// Invalidate party lists
 			queryClient.invalidateQueries({ queryKey: partyKeys.lists() })
-			// Invalidate user's party lists
 			queryClient.invalidateQueries({ queryKey: userKeys.all })
 		}
-	}))
+	}
 }
 
-/**
- * Remix party mutation
- *
- * Creates a copy of an existing party.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useRemixParty } from '$lib/api/mutations/party.mutations'
- *
- *   const remixParty = useRemixParty()
- *
- *   function handleRemix(shortcode: string) {
- *     remixParty.mutate(shortcode)
- *   }
- * </script>
- * ```
- */
-export function useRemixParty() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function remixPartyOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (shortcode: string) => partyAdapter.remix(shortcode),
-		onSuccess: (newParty) => {
-			// Set the new party in cache
+		onSuccess: (newParty: Party) => {
 			queryClient.setQueryData(partyKeys.detail(newParty.shortcode), newParty)
-			// Invalidate party lists to include the new party
 			queryClient.invalidateQueries({ queryKey: partyKeys.lists() })
-			// Invalidate user's party lists
 			queryClient.invalidateQueries({ queryKey: userKeys.all })
 		}
-	}))
+	}
 }
 
-/**
- * Favorite party mutation
- *
- * Adds a party to the user's favorites.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useFavoriteParty } from '$lib/api/mutations/party.mutations'
- *
- *   const favoriteParty = useFavoriteParty()
- *
- *   function handleFavorite(shortcode: string) {
- *     favoriteParty.mutate(shortcode)
- *   }
- * </script>
- * ```
- */
-export function useFavoriteParty() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function favoritePartyOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (shortcode: string) => partyAdapter.favorite(shortcode),
-		onMutate: async (shortcode) => {
-			// Cancel any outgoing refetches
+		onMutate: async (shortcode: string) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(shortcode) })
 
-			// Snapshot the previous value
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(shortcode))
 
-			// Optimistically update the cache
 			if (previousParty) {
 				queryClient.setQueryData(partyKeys.detail(shortcode), {
 					...previousParty,
@@ -214,52 +102,26 @@ export function useFavoriteParty() {
 
 			return { previousParty }
 		},
-		onError: (_err, shortcode, context) => {
-			// Rollback on error
+		onError: (_err: unknown, shortcode: string, context: { previousParty?: Party } | undefined) => {
 			if (context?.previousParty) {
 				queryClient.setQueryData(partyKeys.detail(shortcode), context.previousParty)
 			}
 		},
-		onSettled: (_data, _err, shortcode) => {
-			// Invalidate favorites list
+		onSettled: (_data: unknown, _err: unknown, shortcode: string) => {
 			queryClient.invalidateQueries({ queryKey: userKeys.favorites() })
-			// Refetch the party to get accurate state
 			queryClient.invalidateQueries({ queryKey: partyKeys.detail(shortcode) })
 		}
-	}))
+	}
 }
 
-/**
- * Unfavorite party mutation
- *
- * Removes a party from the user's favorites.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useUnfavoriteParty } from '$lib/api/mutations/party.mutations'
- *
- *   const unfavoriteParty = useUnfavoriteParty()
- *
- *   function handleUnfavorite(shortcode: string) {
- *     unfavoriteParty.mutate(shortcode)
- *   }
- * </script>
- * ```
- */
-export function useUnfavoriteParty() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function unfavoritePartyOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (shortcode: string) => partyAdapter.unfavorite(shortcode),
-		onMutate: async (shortcode) => {
-			// Cancel any outgoing refetches
+		onMutate: async (shortcode: string) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(shortcode) })
 
-			// Snapshot the previous value
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(shortcode))
 
-			// Optimistically update the cache
 			if (previousParty) {
 				queryClient.setQueryData(partyKeys.detail(shortcode), {
 					...previousParty,
@@ -269,113 +131,94 @@ export function useUnfavoriteParty() {
 
 			return { previousParty }
 		},
-		onError: (_err, shortcode, context) => {
-			// Rollback on error
+		onError: (_err: unknown, shortcode: string, context: { previousParty?: Party } | undefined) => {
 			if (context?.previousParty) {
 				queryClient.setQueryData(partyKeys.detail(shortcode), context.previousParty)
 			}
 		},
-		onSettled: (_data, _err, shortcode) => {
-			// Invalidate favorites list
+		onSettled: (_data: unknown, _err: unknown, shortcode: string) => {
 			queryClient.invalidateQueries({ queryKey: userKeys.favorites() })
-			// Refetch the party to get accurate state
 			queryClient.invalidateQueries({ queryKey: partyKeys.detail(shortcode) })
 		}
-	}))
+	}
 }
 
-/**
- * Regenerate preview mutation
- *
- * Triggers regeneration of a party's preview image.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useRegeneratePreview } from '$lib/api/mutations/party.mutations'
- *
- *   const regeneratePreview = useRegeneratePreview()
- *
- *   function handleRegenerate(shortcode: string) {
- *     regeneratePreview.mutate(shortcode)
- *   }
- * </script>
- * ```
- */
-export function useRegeneratePreview() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function regeneratePreviewOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: (shortcode: string) => partyAdapter.regeneratePreview(shortcode),
-		onSuccess: (_data, shortcode) => {
-			// Invalidate preview status to trigger refetch
+		onSuccess: (_data: unknown, shortcode: string) => {
 			queryClient.invalidateQueries({ queryKey: partyKeys.preview(shortcode) })
 		}
-	}))
+	}
 }
 
-/**
- * Share party with crew mutation
- *
- * Shares a party with the current user's crew.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useSharePartyWithCrew } from '$lib/api/mutations/party.mutations'
- *
- *   const shareParty = useSharePartyWithCrew()
- *
- *   function handleShare(partyId: string, shortcode: string) {
- *     shareParty.mutate({ partyId, shortcode })
- *   }
- * </script>
- * ```
- */
-export function useSharePartyWithCrew() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function sharePartyWithCrewOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({ partyId }: { partyId: string; shortcode: string }) =>
 			partyAdapter.shareWithCrew(partyId),
-		onSuccess: (_share, { shortcode }) => {
-			// Invalidate the party to refresh its shares
+		onSuccess: (_share: unknown, { shortcode }: { partyId: string; shortcode: string }) => {
 			queryClient.invalidateQueries({ queryKey: partyKeys.detail(shortcode) })
-			// Invalidate crew's shared parties list
 			queryClient.invalidateQueries({ queryKey: crewKeys.sharedParties() })
 		}
-	}))
+	}
 }
 
-/**
- * Remove party share mutation
- *
- * Removes a share from a party.
- *
- * @example
- * ```svelte
- * <script lang="ts">
- *   import { useRemovePartyShare } from '$lib/api/mutations/party.mutations'
- *
- *   const removeShare = useRemovePartyShare()
- *
- *   function handleRemoveShare(partyId: string, shareId: string, shortcode: string) {
- *     removeShare.mutate({ partyId, shareId, shortcode })
- *   }
- * </script>
- * ```
- */
-export function useRemovePartyShare() {
-	const queryClient = useQueryClient()
-
-	return createMutation(() => ({
+export function removePartyShareOptions(queryClient: QueryClient) {
+	return {
 		mutationFn: ({ partyId, shareId }: { partyId: string; shareId: string; shortcode: string }) =>
 			partyAdapter.removeShare(partyId, shareId),
-		onSuccess: (_data, { shortcode }) => {
-			// Invalidate the party to refresh its shares
+		onSuccess: (_data: unknown, { shortcode }: { partyId: string; shareId: string; shortcode: string }) => {
 			queryClient.invalidateQueries({ queryKey: partyKeys.detail(shortcode) })
-			// Invalidate crew's shared parties list
 			queryClient.invalidateQueries({ queryKey: crewKeys.sharedParties() })
 		}
-	}))
+	}
+}
+
+// ============================================================================
+// Hooks (thin wrappers for component use)
+// ============================================================================
+
+export function useCreateParty() {
+	const queryClient = useQueryClient()
+	return createMutation(() => createPartyOptions(queryClient))
+}
+
+export function useUpdateParty() {
+	const queryClient = useQueryClient()
+	return createMutation(() => updatePartyOptions(queryClient))
+}
+
+export function useDeleteParty() {
+	const queryClient = useQueryClient()
+	return createMutation(() => deletePartyOptions(queryClient))
+}
+
+export function useRemixParty() {
+	const queryClient = useQueryClient()
+	return createMutation(() => remixPartyOptions(queryClient))
+}
+
+export function useFavoriteParty() {
+	const queryClient = useQueryClient()
+	return createMutation(() => favoritePartyOptions(queryClient))
+}
+
+export function useUnfavoriteParty() {
+	const queryClient = useQueryClient()
+	return createMutation(() => unfavoritePartyOptions(queryClient))
+}
+
+export function useRegeneratePreview() {
+	const queryClient = useQueryClient()
+	return createMutation(() => regeneratePreviewOptions(queryClient))
+}
+
+export function useSharePartyWithCrew() {
+	const queryClient = useQueryClient()
+	return createMutation(() => sharePartyWithCrewOptions(queryClient))
+}
+
+export function useRemovePartyShare() {
+	const queryClient = useQueryClient()
+	return createMutation(() => removePartyShareOptions(queryClient))
 }


### PR DESCRIPTION
## Summary
- Extract options factories from all 7 mutation files for testability
- No runtime behavior changes
- 139 mutation tests across grid, party, crew, collection, artifact, gw, job

## Test plan
- [x] `pnpm vitest run` passes