### PR TITLE
Add query, utility, transform, and wiki tests

### DIFF
--- a/src/lib/api/__tests__/wiki.test.ts
+++ b/src/lib/api/__tests__/wiki.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchWikiPage, fetchWikiPages, buildWikiDataMap } from '../wiki'
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+	vi.stubGlobal('fetch', mockFetch)
+	mockFetch.mockReset()
+})
+
+function mockJsonResponse(data: any) {
+	return { json: () => Promise.resolve(data) }
+}
+
+// ============================================================================
+// fetchWikiPage
+// ============================================================================
+
+describe('fetchWikiPage', () => {
+	it('returns wikitext on success', async () => {
+		mockFetch.mockResolvedValue(
+			mockJsonResponse({
+				parse: { wikitext: { '*': '{{Some Template}}' } }
+			})
+		)
+
+		const result = await fetchWikiPage('Zeta_(SSR)')
+		expect(result.wikiPage).toBe('Zeta_(SSR)')
+		expect(result.wikiRaw).toBe('{{Some Template}}')
+		expect(result.error).toBeUndefined()
+	})
+
+	it('returns error from API', async () => {
+		mockFetch.mockResolvedValue(
+			mockJsonResponse({ error: { info: 'Page not found' } })
+		)
+
+		const result = await fetchWikiPage('NonExistent')
+		expect(result.error).toBe('Page not found')
+		expect(result.wikiRaw).toBeUndefined()
+	})
+
+	it('returns error when no wikitext in response', async () => {
+		mockFetch.mockResolvedValue(
+			mockJsonResponse({ parse: {} })
+		)
+
+		const result = await fetchWikiPage('EmptyPage')
+		expect(result.error).toBe('No wikitext in response')
+	})
+
+	it('follows redirects', async () => {
+		// First call returns redirect
+		mockFetch
+			.mockResolvedValueOnce(
+				mockJsonResponse({
+					parse: { wikitext: { '*': '#REDIRECT [[Actual Page]]' } }
+				})
+			)
+			// Second call returns actual content
+			.mockResolvedValueOnce(
+				mockJsonResponse({
+					parse: { wikitext: { '*': '{{Actual Content}}' } }
+				})
+			)
+
+		const result = await fetchWikiPage('Redirect Page')
+		expect(result.wikiPage).toBe('Actual Page')
+		expect(result.wikiRaw).toBe('{{Actual Content}}')
+		expect(result.redirectedFrom).toBe('Redirect Page')
+	})
+
+	it('handles fetch errors', async () => {
+		mockFetch.mockRejectedValue(new Error('Network error'))
+
+		const result = await fetchWikiPage('SomePage')
+		expect(result.error).toBe('Network error')
+	})
+
+	it('handles non-Error throw', async () => {
+		mockFetch.mockRejectedValue('string error')
+
+		const result = await fetchWikiPage('SomePage')
+		expect(result.error).toBe('string error')
+	})
+})
+
+// ============================================================================
+// fetchWikiPages
+// ============================================================================
+
+describe('fetchWikiPages', () => {
+	it('fetches multiple pages in parallel', async () => {
+		mockFetch.mockResolvedValue(
+			mockJsonResponse({ parse: { wikitext: { '*': 'content' } } })
+		)
+
+		const results = await fetchWikiPages(['Page1', 'Page2'])
+		expect(results).toHaveLength(2)
+		expect(mockFetch).toHaveBeenCalledTimes(2)
+	})
+})
+
+// ============================================================================
+// buildWikiDataMap
+// ============================================================================
+
+describe('buildWikiDataMap', () => {
+	it('builds map from successful results', () => {
+		const results = [
+			{ wikiPage: 'Page1', wikiRaw: 'content1' },
+			{ wikiPage: 'Page2', wikiRaw: 'content2' },
+			{ wikiPage: 'Page3', error: 'not found' }
+		]
+
+		const map = buildWikiDataMap(results)
+		expect(map).toEqual({
+			Page1: 'content1',
+			Page2: 'content2'
+		})
+	})
+
+	it('returns empty map for all errors', () => {
+		const results = [{ wikiPage: 'Page1', error: 'not found' }]
+		expect(buildWikiDataMap(results)).toEqual({})
+	})
+
+	it('returns empty map for empty input', () => {
+		expect(buildWikiDataMap([])).toEqual({})
+	})
+})

--- a/src/lib/api/queries/__tests__/party.queries.test.ts
+++ b/src/lib/api/queries/__tests__/party.queries.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { buildFilterQuery } from '../party.queries'
+import type { ExploreFilterParams } from '$lib/api/adapters/party.adapter'
+
+function emptyFilters(): ExploreFilterParams {
+	return {} as ExploreFilterParams
+}
+
+describe('buildFilterQuery', () => {
+	it('returns empty object for empty filters', () => {
+		expect(buildFilterQuery(emptyFilters())).toEqual({})
+	})
+
+	it('includes element when non-empty array', () => {
+		const result = buildFilterQuery({ ...emptyFilters(), element: [1, 2] })
+		expect(result.element).toEqual([1, 2])
+	})
+
+	it('omits element when empty array', () => {
+		const result = buildFilterQuery({ ...emptyFilters(), element: [] })
+		expect(result.element).toBeUndefined()
+	})
+
+	it('includes raid when truthy', () => {
+		const result = buildFilterQuery({ ...emptyFilters(), raid: 'raid-1' })
+		expect(result.raid).toBe('raid-1')
+	})
+
+	it('includes recency when > 0', () => {
+		const result = buildFilterQuery({ ...emptyFilters(), recency: 7 })
+		expect(result.recency).toBe(7)
+	})
+
+	it('omits recency when 0', () => {
+		const result = buildFilterQuery({ ...emptyFilters(), recency: 0 })
+		expect(result.recency).toBeUndefined()
+	})
+
+	it('includes job when truthy', () => {
+		const result = buildFilterQuery({ ...emptyFilters(), job: 'job-1' })
+		expect(result.job).toBe('job-1')
+	})
+
+	it('includes fullAuto when not -1', () => {
+		const result = buildFilterQuery({ ...emptyFilters(), fullAuto: 1 })
+		expect(result.fullAuto).toBe(1)
+	})
+
+	it('omits fullAuto when -1', () => {
+		const result = buildFilterQuery({ ...emptyFilters(), fullAuto: -1 })
+		expect(result.fullAuto).toBeUndefined()
+	})
+
+	it('includes autoGuard when not -1', () => {
+		const result = buildFilterQuery({ ...emptyFilters(), autoGuard: 0 })
+		expect(result.autoGuard).toBe(0)
+	})
+
+	it('omits autoGuard when -1', () => {
+		const result = buildFilterQuery({ ...emptyFilters(), autoGuard: -1 })
+		expect(result.autoGuard).toBeUndefined()
+	})
+
+	it('includes chargeAttack when not -1', () => {
+		const result = buildFilterQuery({ ...emptyFilters(), chargeAttack: 1 })
+		expect(result.chargeAttack).toBe(1)
+	})
+
+	it('omits chargeAttack when -1', () => {
+		const result = buildFilterQuery({ ...emptyFilters(), chargeAttack: -1 })
+		expect(result.chargeAttack).toBeUndefined()
+	})
+
+	it('includes hasVideo when truthy', () => {
+		const result = buildFilterQuery({ ...emptyFilters(), hasVideo: true })
+		expect(result.hasVideo).toBe(true)
+	})
+
+	it('includes count filters when > 0', () => {
+		const result = buildFilterQuery({
+			...emptyFilters(),
+			charactersCount: 5,
+			weaponsCount: 10,
+			summonsCount: 4
+		})
+		expect(result.charactersCount).toBe(5)
+		expect(result.weaponsCount).toBe(10)
+		expect(result.summonsCount).toBe(4)
+	})
+
+	it('omits count filters when 0', () => {
+		const result = buildFilterQuery({
+			...emptyFilters(),
+			charactersCount: 0,
+			weaponsCount: 0,
+			summonsCount: 0
+		})
+		expect(result.charactersCount).toBeUndefined()
+		expect(result.weaponsCount).toBeUndefined()
+		expect(result.summonsCount).toBeUndefined()
+	})
+
+	it('includes quality filters when truthy', () => {
+		const result = buildFilterQuery({
+			...emptyFilters(),
+			nameQuality: true,
+			userQuality: true
+		})
+		expect(result.nameQuality).toBe(true)
+		expect(result.userQuality).toBe(true)
+	})
+
+	it('passes through includes and excludes', () => {
+		const result = buildFilterQuery({
+			...emptyFilters(),
+			includes: 'char-1',
+			excludes: 'char-2'
+		})
+		expect(result.includes).toBe('char-1')
+		expect(result.excludes).toBe('char-2')
+	})
+
+	it('passes through original and collectionFilter', () => {
+		const result = buildFilterQuery({
+			...emptyFilters(),
+			original: true,
+			collectionFilter: true
+		})
+		expect(result.original).toBe(true)
+		expect(result.collectionFilter).toBe(true)
+	})
+})

--- a/src/lib/api/queries/__tests__/queryKeys.test.ts
+++ b/src/lib/api/queries/__tests__/queryKeys.test.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect } from 'vitest'
+
+import { partyKeys } from '../party.queries'
+import { crewKeys } from '../crew.queries'
+import { collectionKeys } from '../collection.queries'
+import { userKeys } from '../user.queries'
+import { artifactKeys } from '../artifact.queries'
+import { entityKeys } from '../entity.queries'
+import { jobKeys, jobAccessoryKeys } from '../job.queries'
+import { gwKeys } from '../gw.queries'
+import { raidKeys } from '../raid.queries'
+
+import { partyQueries } from '../party.queries'
+import { crewQueries } from '../crew.queries'
+import { collectionQueries } from '../collection.queries'
+import { userQueries } from '../user.queries'
+import { artifactQueries } from '../artifact.queries'
+import { entityQueries } from '../entity.queries'
+import { jobQueries } from '../job.queries'
+import { gwQueries } from '../gw.queries'
+import { raidQueries } from '../raid.queries'
+import { searchQueries } from '../search.queries'
+
+// ============================================================================
+// partyKeys
+// ============================================================================
+
+describe('partyKeys', () => {
+	it('produces correct key arrays', () => {
+		expect(partyKeys.all).toEqual(['parties'])
+		expect(partyKeys.lists()).toEqual(['parties', 'list'])
+		expect(partyKeys.list({ element: [1] } as any)).toEqual(['parties', 'list', { element: [1] }])
+		expect(partyKeys.userLists()).toEqual(['parties', 'user'])
+		expect(partyKeys.userList('alice')).toEqual(['parties', 'user', 'alice', undefined])
+		expect(partyKeys.raidLists()).toEqual(['parties', 'raid'])
+		expect(partyKeys.raidList('raid-1')).toEqual(['parties', 'raid', 'raid-1', undefined])
+		expect(partyKeys.details()).toEqual(['party'])
+		expect(partyKeys.detail('abc')).toEqual(['party', 'abc'])
+		expect(partyKeys.preview('abc')).toEqual(['party', 'abc', 'preview'])
+	})
+
+	it('detail key matches byShortcode queryKey', () => {
+		const opts = partyQueries.byShortcode('abc')
+		expect(partyKeys.detail('abc')).toEqual(opts.queryKey)
+	})
+
+	it('preview key matches previewStatus queryKey', () => {
+		const opts = partyQueries.previewStatus('abc')
+		expect(partyKeys.preview('abc')).toEqual(opts.queryKey)
+	})
+
+	it('list key matches list queryKey', () => {
+		const filters = { element: [1] } as any
+		const opts = partyQueries.list({ filters })
+		expect(partyKeys.list(filters)).toEqual(opts.queryKey)
+	})
+})
+
+// ============================================================================
+// crewKeys
+// ============================================================================
+
+describe('crewKeys', () => {
+	it('produces correct key arrays', () => {
+		expect(crewKeys.all).toEqual(['crew'])
+		expect(crewKeys.myCrew()).toEqual(['crew', 'my'])
+		expect(crewKeys.membersAll()).toEqual(['crew', 'members'])
+		expect(crewKeys.members('active')).toEqual(['crew', 'members', 'active'])
+		expect(crewKeys.crewInvitations('crew-1')).toEqual(['crew', 'crew-1', 'invitations'])
+		expect(crewKeys.sharedParties()).toEqual(['crew', 'shared_parties'])
+		expect(crewKeys.accessibleCollectionMembers()).toEqual([
+			'crew',
+			'members',
+			'accessible-collections'
+		])
+	})
+
+	it('nested invitations keys', () => {
+		expect(crewKeys.invitations.all).toEqual(['invitations'])
+		expect(crewKeys.invitations.pending()).toEqual(['invitations', 'pending'])
+	})
+
+	it('nested phantomClaims keys', () => {
+		expect(crewKeys.phantomClaims.all).toEqual(['phantom_claims'])
+		expect(crewKeys.phantomClaims.pending()).toEqual(['phantom_claims', 'pending'])
+	})
+
+	it('myCrew key matches query queryKey', () => {
+		expect(crewKeys.myCrew()).toEqual(crewQueries.myCrew().queryKey)
+	})
+
+	it('members key matches query queryKey', () => {
+		expect(crewKeys.members('active')).toEqual(crewQueries.members('active').queryKey)
+	})
+
+	it('crewInvitations key matches query queryKey', () => {
+		expect(crewKeys.crewInvitations('c-1')).toEqual(crewQueries.crewInvitations('c-1').queryKey)
+	})
+
+	it('pendingInvitations key matches query queryKey', () => {
+		expect(crewKeys.invitations.pending()).toEqual(crewQueries.pendingInvitations().queryKey)
+	})
+
+	it('sharedParties key matches query queryKey', () => {
+		expect(crewKeys.sharedParties()).toEqual(crewQueries.sharedParties().queryKey)
+	})
+})
+
+// ============================================================================
+// collectionKeys
+// ============================================================================
+
+describe('collectionKeys', () => {
+	it('produces correct key arrays', () => {
+		expect(collectionKeys.all).toEqual(['collection'])
+		expect(collectionKeys.counts('u-1')).toEqual(['collection', 'counts', 'u-1'])
+		expect(collectionKeys.granblueIds('u-1')).toEqual(['collection', 'granblue_ids', 'u-1'])
+		expect(collectionKeys.character('c-1')).toEqual(['collection', 'character', 'c-1'])
+	})
+
+	it('characters branches on userId', () => {
+		expect(collectionKeys.characters('u-1')).toEqual(['collection', 'characters', 'u-1'])
+		expect(collectionKeys.characters()).toEqual(['collection', 'characters'])
+	})
+
+	it('characterIds branches on userId', () => {
+		expect(collectionKeys.characterIds('u-1')).toEqual(['collection', 'characters', 'ids', 'u-1'])
+		expect(collectionKeys.characterIds()).toEqual(['collection', 'characters', 'ids'])
+	})
+
+	it('weapons branches on userId', () => {
+		expect(collectionKeys.weapons('u-1')).toEqual(['collection', 'weapons', 'u-1'])
+		expect(collectionKeys.weapons()).toEqual(['collection', 'weapons'])
+	})
+
+	it('summons branches on userId', () => {
+		expect(collectionKeys.summons('u-1')).toEqual(['collection', 'summons', 'u-1'])
+		expect(collectionKeys.summons()).toEqual(['collection', 'summons'])
+	})
+
+	it('counts key matches query queryKey', () => {
+		expect(collectionKeys.counts('u-1')).toEqual(collectionQueries.counts('u-1').queryKey)
+	})
+
+	it('granblueIds key matches query queryKey', () => {
+		expect(collectionKeys.granblueIds('u-1')).toEqual(
+			collectionQueries.granblueIds('u-1').queryKey
+		)
+	})
+
+	it('character key matches query queryKey', () => {
+		expect(collectionKeys.character('c-1')).toEqual(collectionQueries.character('c-1').queryKey)
+	})
+})
+
+// ============================================================================
+// userKeys
+// ============================================================================
+
+describe('userKeys', () => {
+	it('produces correct key arrays', () => {
+		expect(userKeys.all).toEqual(['user'])
+		expect(userKeys.me()).toEqual(['user', 'me'])
+		expect(userKeys.info('alice')).toEqual(['user', 'alice', 'info'])
+		expect(userKeys.profile('alice')).toEqual(['user', 'alice', 'profile'])
+		expect(userKeys.parties('alice')).toEqual(['user', 'alice', 'parties'])
+		expect(userKeys.favorites()).toEqual(['user', 'favorites'])
+		expect(userKeys.checkUsername('bob')).toEqual(['user', 'check', 'username', 'bob'])
+		expect(userKeys.checkEmail('a@b.com')).toEqual(['user', 'check', 'email', 'a@b.com'])
+	})
+
+	it('me key matches query queryKey', () => {
+		expect(userKeys.me()).toEqual(userQueries.me().queryKey)
+	})
+
+	it('info key matches query queryKey', () => {
+		expect(userKeys.info('alice')).toEqual(userQueries.info('alice').queryKey)
+	})
+
+	it('profile key matches query queryKey', () => {
+		expect(userKeys.profile('alice')).toEqual(userQueries.profile('alice').queryKey)
+	})
+
+	it('checkUsername key matches query queryKey', () => {
+		expect(userKeys.checkUsername('bob')).toEqual(userQueries.checkUsername('bob').queryKey)
+	})
+
+	it('checkEmail key matches query queryKey', () => {
+		expect(userKeys.checkEmail('a@b')).toEqual(userQueries.checkEmail('a@b').queryKey)
+	})
+})
+
+// ============================================================================
+// artifactKeys
+// ============================================================================
+
+describe('artifactKeys', () => {
+	it('produces correct key arrays', () => {
+		expect(artifactKeys.all).toEqual(['artifacts'])
+		expect(artifactKeys.reference).toEqual(['artifacts', 'all'])
+		expect(artifactKeys.list()).toEqual(['artifacts', 'all', undefined])
+		expect(artifactKeys.list({ rarity: 'standard' })).toEqual([
+			'artifacts',
+			'all',
+			{ rarity: 'standard' }
+		])
+		expect(artifactKeys.detail('a-1')).toEqual(['artifacts', 'detail', 'a-1'])
+		expect(artifactKeys.skills).toEqual(['artifacts', 'skills'])
+		expect(artifactKeys.skillsForSlot(2)).toEqual(['artifacts', 'skills', 'slot', 2])
+		expect(artifactKeys.skillDetail('s-1')).toEqual(['artifacts', 'skills', 'detail', 's-1'])
+		expect(artifactKeys.collectionBase).toEqual(['collection', 'artifacts'])
+		expect(artifactKeys.collection('u-1')).toEqual(['collection', 'artifacts', 'u-1'])
+		expect(artifactKeys.collection()).toEqual(['collection', 'artifacts'])
+		expect(artifactKeys.collectionArtifact('ca-1')).toEqual(['collection', 'artifact', 'ca-1'])
+	})
+
+	it('detail key matches byId queryKey', () => {
+		expect(artifactKeys.detail('a-1')).toEqual(artifactQueries.byId('a-1').queryKey)
+	})
+
+	it('skillsForSlot key matches query queryKey', () => {
+		expect(artifactKeys.skillsForSlot(3)).toEqual(artifactQueries.skillsForSlot(3).queryKey)
+	})
+
+	it('collectionArtifact key matches query queryKey', () => {
+		expect(artifactKeys.collectionArtifact('ca-1')).toEqual(
+			artifactQueries.collectionArtifact('ca-1').queryKey
+		)
+	})
+})
+
+// ============================================================================
+// entityKeys
+// ============================================================================
+
+describe('entityKeys', () => {
+	it('produces correct key arrays', () => {
+		expect(entityKeys.weapons()).toEqual(['weapon'])
+		expect(entityKeys.weapon('1040001000')).toEqual(['weapon', '1040001000'])
+		expect(entityKeys.characters()).toEqual(['character'])
+		expect(entityKeys.character('3040001000')).toEqual(['character', '3040001000'])
+		expect(entityKeys.summons()).toEqual(['summon'])
+		expect(entityKeys.summon('2040001000')).toEqual(['summon', '2040001000'])
+		expect(entityKeys.weaponSeriesList()).toEqual(['weaponSeries', 'list'])
+		expect(entityKeys.weaponSeries('dark-opus')).toEqual(['weaponSeries', 'dark-opus'])
+		expect(entityKeys.allWeaponSeries()).toEqual(['weaponSeries'])
+		expect(entityKeys.characterSeriesList()).toEqual(['characterSeries', 'list'])
+		expect(entityKeys.summonSeriesList()).toEqual(['summonSeries', 'list'])
+		expect(entityKeys.axSkills()).toEqual(['weaponStatModifiers', 'ax'])
+		expect(entityKeys.befoulments()).toEqual(['weaponStatModifiers', 'befoulment'])
+		expect(entityKeys.weaponStatModifiers('ax')).toEqual(['weaponStatModifiers', 'ax'])
+		expect(entityKeys.weaponStatModifiers()).toEqual(['weaponStatModifiers', 'all'])
+	})
+
+	it('weapon key matches query queryKey', () => {
+		expect(entityKeys.weapon('1040001000')).toEqual(
+			entityQueries.weapon('1040001000').queryKey
+		)
+	})
+
+	it('character key matches query queryKey', () => {
+		expect(entityKeys.character('3040001000')).toEqual(
+			entityQueries.character('3040001000').queryKey
+		)
+	})
+
+	it('summon key matches query queryKey', () => {
+		expect(entityKeys.summon('2040001000')).toEqual(
+			entityQueries.summon('2040001000').queryKey
+		)
+	})
+
+	it('weaponKeys matches query queryKey', () => {
+		const params = { seriesSlug: 'dark-opus', slot: 1, group: 'a' }
+		expect(entityKeys.weaponKeys(params)).toEqual(entityQueries.weaponKeys(params).queryKey)
+	})
+
+	it('series keys match query queryKeys', () => {
+		expect(entityKeys.weaponSeriesList()).toEqual(entityQueries.weaponSeriesList().queryKey)
+		expect(entityKeys.weaponSeries('dark-opus')).toEqual(
+			entityQueries.weaponSeries('dark-opus').queryKey
+		)
+		expect(entityKeys.characterSeriesList()).toEqual(
+			entityQueries.characterSeriesList().queryKey
+		)
+		expect(entityKeys.summonSeriesList()).toEqual(entityQueries.summonSeriesList().queryKey)
+	})
+
+	it('stat modifier keys match query queryKeys', () => {
+		expect(entityKeys.weaponStatModifiers('ax')).toEqual(
+			entityQueries.weaponStatModifiers('ax').queryKey
+		)
+		expect(entityKeys.axSkills()).toEqual(entityQueries.axSkills().queryKey)
+		expect(entityKeys.befoulments()).toEqual(entityQueries.befoulments().queryKey)
+	})
+})
+
+// ============================================================================
+// jobKeys + jobAccessoryKeys
+// ============================================================================
+
+describe('jobKeys', () => {
+	it('produces correct key arrays', () => {
+		expect(jobKeys.all).toEqual(['jobs'])
+		expect(jobKeys.lists()).toEqual(['jobs'])
+		expect(jobKeys.detail('j-1')).toEqual(['jobs', 'j-1'])
+		expect(jobKeys.skills('j-1')).toEqual(['jobs', 'j-1', 'skills'])
+		expect(jobKeys.empSkills('j-1')).toEqual(['jobs', 'j-1', 'emp_skills'])
+		expect(jobKeys.skillsSearch('j-1')).toEqual([
+			'jobs',
+			'j-1',
+			'skills',
+			'search',
+			undefined
+		])
+		expect(jobKeys.accessoriesForJob('j-1')).toEqual(['jobs', 'j-1', 'accessories'])
+		expect(jobKeys.allSkills()).toEqual(['jobs', 'skills', 'all'])
+	})
+
+	it('detail key matches byId queryKey', () => {
+		expect(jobKeys.detail('j-1')).toEqual(jobQueries.byId('j-1').queryKey)
+	})
+
+	it('skills key matches skillsByJob queryKey', () => {
+		expect(jobKeys.skills('j-1')).toEqual(jobQueries.skillsByJob('j-1').queryKey)
+	})
+
+	it('empSkills key matches query queryKey', () => {
+		expect(jobKeys.empSkills('j-1')).toEqual(jobQueries.empSkills('j-1').queryKey)
+	})
+
+	it('accessoriesForJob key matches query queryKey', () => {
+		expect(jobKeys.accessoriesForJob('j-1')).toEqual(
+			jobQueries.accessoriesForJob('j-1').queryKey
+		)
+	})
+
+	it('allSkills key matches query queryKey', () => {
+		expect(jobKeys.allSkills()).toEqual(jobQueries.allSkills().queryKey)
+	})
+})
+
+describe('jobAccessoryKeys', () => {
+	it('produces correct key arrays', () => {
+		expect(jobAccessoryKeys.all).toEqual(['jobAccessories'])
+		expect(jobAccessoryKeys.lists(1)).toEqual(['jobAccessories', { accessoryType: 1 }])
+		expect(jobAccessoryKeys.detail('a-1')).toEqual(['jobAccessories', 'a-1'])
+	})
+
+	it('lists key matches accessoriesList queryKey', () => {
+		expect(jobAccessoryKeys.lists(2)).toEqual(jobQueries.accessoriesList(2).queryKey)
+	})
+
+	it('detail key matches accessoryById queryKey', () => {
+		expect(jobAccessoryKeys.detail('a-1')).toEqual(jobQueries.accessoryById('a-1').queryKey)
+	})
+})
+
+// ============================================================================
+// gwKeys
+// ============================================================================
+
+describe('gwKeys', () => {
+	it('produces correct key arrays', () => {
+		expect(gwKeys.all).toEqual(['gw'])
+		expect(gwKeys.events()).toEqual(['gw', 'events'])
+		expect(gwKeys.event('e-1')).toEqual(['gw', 'events', 'e-1'])
+		expect(gwKeys.participationsAll()).toEqual(['gw', 'participations'])
+		expect(gwKeys.participation('p-1')).toEqual(['gw', 'participations', 'p-1'])
+		expect(gwKeys.memberGwScores('m-1')).toEqual(['crew', 'member', 'm-1', 'gw_scores'])
+		expect(gwKeys.memberGwScoresByUsername('alice')).toEqual([
+			'crew',
+			'member',
+			'username',
+			'alice',
+			'gw_scores'
+		])
+		expect(gwKeys.phantomGwScores('ph-1')).toEqual(['crew', 'phantom', 'ph-1', 'gw_scores'])
+	})
+
+	it('events key matches query queryKey', () => {
+		expect(gwKeys.events()).toEqual(gwQueries.events().queryKey)
+	})
+
+	it('event key matches query queryKey', () => {
+		expect(gwKeys.event('e-1')).toEqual(gwQueries.event('e-1').queryKey)
+	})
+
+	it('participation key matches query queryKey', () => {
+		expect(gwKeys.participation('p-1')).toEqual(gwQueries.participation('p-1').queryKey)
+	})
+
+	it('memberGwScores key matches query queryKey', () => {
+		expect(gwKeys.memberGwScores('m-1')).toEqual(gwQueries.memberGwScores('m-1').queryKey)
+	})
+
+	it('phantomGwScores key matches query queryKey', () => {
+		expect(gwKeys.phantomGwScores('ph-1')).toEqual(gwQueries.phantomGwScores('ph-1').queryKey)
+	})
+})
+
+// ============================================================================
+// raidKeys
+// ============================================================================
+
+describe('raidKeys', () => {
+	it('produces correct key arrays', () => {
+		expect(raidKeys.all).toEqual(['raids'])
+		expect(raidKeys.groups()).toEqual(['raids', 'groups'])
+		expect(raidKeys.detail('proto-bahamut')).toEqual(['raids', 'proto-bahamut'])
+	})
+
+	it('groups key matches query queryKey', () => {
+		expect(raidKeys.groups()).toEqual(raidQueries.groups().queryKey)
+	})
+
+	it('detail key matches bySlug queryKey', () => {
+		expect(raidKeys.detail('proto-bahamut')).toEqual(
+			raidQueries.bySlug('proto-bahamut').queryKey
+		)
+	})
+})
+
+// ============================================================================
+// searchQueries (no separate keys export — test queryKey from factories)
+// ============================================================================
+
+describe('searchQueries queryKeys', () => {
+	it('weapons queryKey includes search type', () => {
+		const opts = searchQueries.weapons('sword', { element: [1] }, 'ja')
+		expect(opts.queryKey).toEqual(['search', 'weapons', 'sword', { element: [1] }, 'ja'])
+	})
+
+	it('characters queryKey includes exclude', () => {
+		const opts = searchQueries.characters('hero', undefined, 'en', ['exc-1'])
+		expect(opts.queryKey).toEqual(['search', 'characters', 'hero', undefined, 'en', ['exc-1']])
+	})
+
+	it('summons queryKey includes search type', () => {
+		const opts = searchQueries.summons('', { rarity: [3] })
+		expect(opts.queryKey).toEqual(['search', 'summons', '', { rarity: [3] }, 'en'])
+	})
+})

--- a/src/lib/api/queries/__tests__/queryOptions.test.ts
+++ b/src/lib/api/queries/__tests__/queryOptions.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest'
+
+import { userQueries } from '../user.queries'
+import { artifactQueries } from '../artifact.queries'
+import { collectionQueries } from '../collection.queries'
+import { crewQueries } from '../crew.queries'
+import { partyQueries } from '../party.queries'
+import { raidQueries } from '../raid.queries'
+import { searchQueries } from '../search.queries'
+
+// ============================================================================
+// Enabled Conditions
+// ============================================================================
+
+describe('enabled conditions', () => {
+	describe('userQueries.checkUsername', () => {
+		it('disabled for empty string', () => {
+			expect(userQueries.checkUsername('').enabled).toBe(false)
+		})
+
+		it('disabled for short username (< 3 chars)', () => {
+			expect(userQueries.checkUsername('ab').enabled).toBe(false)
+		})
+
+		it('enabled for username >= 3 chars', () => {
+			expect(userQueries.checkUsername('abc').enabled).toBe(true)
+		})
+	})
+
+	describe('userQueries.checkEmail', () => {
+		it('disabled for empty string', () => {
+			expect(userQueries.checkEmail('').enabled).toBe(false)
+		})
+
+		it('disabled when missing @', () => {
+			expect(userQueries.checkEmail('nope').enabled).toBe(false)
+		})
+
+		it('enabled when contains @', () => {
+			expect(userQueries.checkEmail('a@b').enabled).toBe(true)
+		})
+	})
+
+	describe('artifactQueries.skillsForSlot', () => {
+		it('disabled for slot 0', () => {
+			expect(artifactQueries.skillsForSlot(0).enabled).toBe(false)
+		})
+
+		it('enabled for slot 1', () => {
+			expect(artifactQueries.skillsForSlot(1).enabled).toBe(true)
+		})
+
+		it('enabled for slot 4', () => {
+			expect(artifactQueries.skillsForSlot(4).enabled).toBe(true)
+		})
+
+		it('disabled for slot 5', () => {
+			expect(artifactQueries.skillsForSlot(5).enabled).toBe(false)
+		})
+	})
+
+	describe('collectionQueries.counts', () => {
+		it('disabled for empty userId', () => {
+			expect(collectionQueries.counts('').enabled).toBe(false)
+		})
+
+		it('disabled when enabled=false', () => {
+			expect(collectionQueries.counts('u-1', false).enabled).toBe(false)
+		})
+
+		it('enabled for valid userId with enabled=true', () => {
+			expect(collectionQueries.counts('u-1', true).enabled).toBe(true)
+		})
+	})
+
+	describe('generic !!id enabled', () => {
+		it('partyQueries.byShortcode disabled for empty string', () => {
+			expect(partyQueries.byShortcode('').enabled).toBe(false)
+		})
+
+		it('partyQueries.byShortcode enabled for truthy string', () => {
+			expect(partyQueries.byShortcode('abc').enabled).toBe(true)
+		})
+
+		it('raidQueries.bySlug disabled for empty string', () => {
+			expect(raidQueries.bySlug('').enabled).toBe(false)
+		})
+
+		it('raidQueries.bySlug enabled for truthy string', () => {
+			expect(raidQueries.bySlug('proto').enabled).toBe(true)
+		})
+
+		it('searchQueries.characters can be disabled', () => {
+			const opts = searchQueries.characters('', undefined, 'en', undefined, false)
+			expect(opts.enabled).toBe(false)
+		})
+	})
+})
+
+// ============================================================================
+// Retry Logic
+// ============================================================================
+
+describe('retry logic', () => {
+	describe('crewQueries.myCrew', () => {
+		const opts = crewQueries.myCrew()
+		const retry = opts.retry as (failureCount: number, error: unknown) => boolean
+
+		it('does not retry on 404', () => {
+			expect(retry(0, { status: 404 })).toBe(false)
+		})
+
+		it('retries on 500 when failureCount < 3', () => {
+			expect(retry(0, { status: 500 })).toBe(true)
+			expect(retry(2, { status: 500 })).toBe(true)
+		})
+
+		it('stops retrying after 3 failures', () => {
+			expect(retry(3, { status: 500 })).toBe(false)
+		})
+
+		it('retries on generic error', () => {
+			expect(retry(0, new Error('network'))).toBe(true)
+		})
+	})
+
+	describe('collectionQueries.granblueIds', () => {
+		const opts = collectionQueries.granblueIds('u-1')
+		const retry = opts.retry as (failureCount: number, error: unknown) => boolean
+
+		it('does not retry on 403', () => {
+			expect(retry(0, { status: 403 })).toBe(false)
+		})
+
+		it('does not retry on 404', () => {
+			expect(retry(0, { status: 404 })).toBe(false)
+		})
+
+		it('retries on 500 when failureCount < 3', () => {
+			expect(retry(0, { status: 500 })).toBe(true)
+			expect(retry(2, { status: 500 })).toBe(true)
+		})
+
+		it('stops retrying after 3 failures', () => {
+			expect(retry(3, { status: 500 })).toBe(false)
+		})
+	})
+})
+
+// ============================================================================
+// Pagination (getNextPageParam)
+// ============================================================================
+
+describe('getNextPageParam', () => {
+	it('returns next page when more pages available', () => {
+		const opts = partyQueries.list()
+		const getNext = opts.getNextPageParam!
+		const result = getNext({ results: [], page: 2, totalPages: 5 } as any, [], 2, [])
+		expect(result).toBe(3)
+	})
+
+	it('returns undefined on last page', () => {
+		const opts = partyQueries.list()
+		const getNext = opts.getNextPageParam!
+		const result = getNext({ results: [], page: 5, totalPages: 5 } as any, [], 5, [])
+		expect(result).toBeUndefined()
+	})
+
+	it('works for search queries', () => {
+		const opts = searchQueries.weapons()
+		const getNext = opts.getNextPageParam!
+		expect(getNext({ results: [], page: 1, totalPages: 3 } as any, [], 1, [])).toBe(2)
+		expect(getNext({ results: [], page: 3, totalPages: 3 } as any, [], 3, [])).toBeUndefined()
+	})
+
+	it('works for user parties', () => {
+		const opts = userQueries.parties('alice')
+		const getNext = opts.getNextPageParam!
+		expect(getNext({ results: [], page: 1, totalPages: 2 } as any, [], 1, [])).toBe(2)
+		expect(getNext({ results: [], page: 2, totalPages: 2 } as any, [], 2, [])).toBeUndefined()
+	})
+
+	it('works for crew shared parties', () => {
+		const opts = crewQueries.sharedParties()
+		const getNext = opts.getNextPageParam!
+		expect(getNext({ page: 1, totalPages: 4 } as any, [], 1, [])).toBe(2)
+		expect(getNext({ page: 4, totalPages: 4 } as any, [], 4, [])).toBeUndefined()
+	})
+})

--- a/src/lib/api/queries/__tests__/search.queries.test.ts
+++ b/src/lib/api/queries/__tests__/search.queries.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import { buildSearchParams, type SearchFilters } from '../search.queries'
+
+describe('buildSearchParams', () => {
+	it('returns base params with no query or filters', () => {
+		const result = buildSearchParams('', undefined, 1)
+		expect(result).toEqual({ page: 1, locale: 'en', per: 50 })
+		expect(result.query).toBeUndefined()
+		expect(result.filters).toBeUndefined()
+	})
+
+	it('omits query when empty string', () => {
+		const result = buildSearchParams('', undefined, 1)
+		expect(result.query).toBeUndefined()
+	})
+
+	it('omits query when whitespace only', () => {
+		const result = buildSearchParams('   ', undefined, 1)
+		expect(result.query).toBeUndefined()
+	})
+
+	it('trims query whitespace', () => {
+		const result = buildSearchParams('  sword  ', undefined, 1)
+		expect(result.query).toBe('sword')
+	})
+
+	it('passes through page number', () => {
+		const result = buildSearchParams('', undefined, 3)
+		expect(result.page).toBe(3)
+	})
+
+	it('passes through locale', () => {
+		const result = buildSearchParams('', undefined, 1, 'ja')
+		expect(result.locale).toBe('ja')
+	})
+
+	it('includes exclude array when non-empty', () => {
+		const result = buildSearchParams('', undefined, 1, 'en', ['id-1', 'id-2'])
+		expect(result.exclude).toEqual(['id-1', 'id-2'])
+	})
+
+	it('omits exclude when empty array', () => {
+		const result = buildSearchParams('', undefined, 1, 'en', [])
+		expect(result.exclude).toBeUndefined()
+	})
+
+	it('omits filters key when no filters provided', () => {
+		const result = buildSearchParams('test', undefined, 1)
+		expect(result.filters).toBeUndefined()
+	})
+
+	it('omits filters key when all filter arrays are empty', () => {
+		const filters: SearchFilters = { element: [], rarity: [], proficiency: [] }
+		const result = buildSearchParams('test', filters, 1)
+		expect(result.filters).toBeUndefined()
+	})
+
+	it('passes through element filter', () => {
+		const filters: SearchFilters = { element: [1, 2] }
+		const result = buildSearchParams('', filters, 1)
+		expect(result.filters!.element).toEqual([1, 2])
+	})
+
+	it('passes through rarity filter', () => {
+		const filters: SearchFilters = { rarity: [3] }
+		const result = buildSearchParams('', filters, 1)
+		expect(result.filters!.rarity).toEqual([3])
+	})
+
+	it('renames proficiency to proficiency1', () => {
+		const filters: SearchFilters = { proficiency: [1, 7] }
+		const result = buildSearchParams('', filters, 1)
+		expect(result.filters!.proficiency1).toEqual([1, 7])
+		expect((result.filters as any).proficiency).toBeUndefined()
+	})
+
+	it('passes through proficiency2', () => {
+		const filters: SearchFilters = { proficiency2: [2, 3] }
+		const result = buildSearchParams('', filters, 1)
+		expect(result.filters!.proficiency2).toEqual([2, 3])
+	})
+
+	it('includes boolean filters when defined', () => {
+		const filters: SearchFilters = { subaura: true, extra: false }
+		const result = buildSearchParams('', filters, 1)
+		expect(result.filters!.subaura).toBe(true)
+		expect(result.filters!.extra).toBe(false)
+	})
+
+	it('omits boolean filters when undefined', () => {
+		const filters: SearchFilters = { element: [1] }
+		const result = buildSearchParams('', filters, 1)
+		expect(result.filters!.subaura).toBeUndefined()
+		expect(result.filters!.extra).toBeUndefined()
+	})
+
+	it('passes through series filter', () => {
+		const filters: SearchFilters = { series: ['dark-opus', 'draconic'] }
+		const result = buildSearchParams('', filters, 1)
+		expect(result.filters!.series).toEqual(['dark-opus', 'draconic'])
+	})
+
+	it('passes through character-specific filters', () => {
+		const filters: SearchFilters = {
+			season: [3, 5],
+			characterSeries: [1, 2],
+			gachaAvailable: true
+		}
+		const result = buildSearchParams('', filters, 1)
+		expect(result.filters!.season).toEqual([3, 5])
+		expect(result.filters!.characterSeries).toEqual([1, 2])
+		expect(result.filters!.gachaAvailable).toBe(true)
+	})
+
+	it('combines multiple filters', () => {
+		const filters: SearchFilters = {
+			element: [1],
+			rarity: [3],
+			proficiency: [1]
+		}
+		const result = buildSearchParams('sword', filters, 2, 'ja', ['exc-1'])
+		expect(result.query).toBe('sword')
+		expect(result.page).toBe(2)
+		expect(result.locale).toBe('ja')
+		expect(result.exclude).toEqual(['exc-1'])
+		expect(result.filters!.element).toEqual([1])
+		expect(result.filters!.rarity).toEqual([3])
+		expect(result.filters!.proficiency1).toEqual([1])
+	})
+})

--- a/src/lib/api/queries/party.queries.ts
+++ b/src/lib/api/queries/party.queries.ts
@@ -66,7 +66,7 @@ export interface RaidPartiesFilters {
 /**
  * Strips default/inactive filter values so the API only gets meaningful filters
  */
-function buildFilterQuery(filters: ExploreFilterParams): Partial<ExploreFilterParams> {
+export function buildFilterQuery(filters: ExploreFilterParams): Partial<ExploreFilterParams> {
 	const query: Record<string, unknown> = {}
 
 	if (filters.element && filters.element.length > 0) query.element = filters.element

--- a/src/lib/api/queries/search.queries.ts
+++ b/src/lib/api/queries/search.queries.ts
@@ -58,7 +58,7 @@ const SEARCH_PER_PAGE = 50
 /**
  * Builds search parameters from query string and filters
  */
-function buildSearchParams(
+export function buildSearchParams(
 	query: string,
 	filters: SearchFilters | undefined,
 	page: number,

--- a/src/lib/api/schemas/__tests__/transforms.test.ts
+++ b/src/lib/api/schemas/__tests__/transforms.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vitest'
+import { snakeToCamel, camelToSnake, transformResponse, transformRequest } from '../transforms'
+
+// ============================================================================
+// snakeToCamel
+// ============================================================================
+
+describe('snakeToCamel', () => {
+	it('converts simple keys', () => {
+		expect(snakeToCamel({ first_name: 'Alice', last_name: 'Bob' })).toEqual({
+			firstName: 'Alice',
+			lastName: 'Bob'
+		})
+	})
+
+	it('handles multi-underscore keys', () => {
+		expect(snakeToCamel({ created_at_date: '2025' })).toEqual({ createdAtDate: '2025' })
+	})
+
+	it('handles nested objects', () => {
+		expect(snakeToCamel({ user_data: { first_name: 'A' } })).toEqual({
+			userData: { firstName: 'A' }
+		})
+	})
+
+	it('handles arrays', () => {
+		expect(snakeToCamel([{ skill_level: 1 }, { skill_level: 2 }])).toEqual([
+			{ skillLevel: 1 },
+			{ skillLevel: 2 }
+		])
+	})
+
+	it('handles arrays inside objects', () => {
+		expect(snakeToCamel({ my_list: [{ item_name: 'x' }] })).toEqual({
+			myList: [{ itemName: 'x' }]
+		})
+	})
+
+	it('passes through primitives', () => {
+		expect(snakeToCamel('hello')).toBe('hello')
+		expect(snakeToCamel(42)).toBe(42)
+		expect(snakeToCamel(true)).toBe(true)
+	})
+
+	it('handles null and undefined', () => {
+		expect(snakeToCamel(null)).toBeNull()
+		expect(snakeToCamel(undefined)).toBeUndefined()
+	})
+
+	it('preserves already camelCase keys', () => {
+		expect(snakeToCamel({ firstName: 'A' })).toEqual({ firstName: 'A' })
+	})
+})
+
+// ============================================================================
+// camelToSnake
+// ============================================================================
+
+describe('camelToSnake', () => {
+	it('converts simple keys', () => {
+		expect(camelToSnake({ firstName: 'Alice', lastName: 'Bob' })).toEqual({
+			first_name: 'Alice',
+			last_name: 'Bob'
+		})
+	})
+
+	it('handles nested objects', () => {
+		expect(camelToSnake({ userData: { firstName: 'A' } })).toEqual({
+			user_data: { first_name: 'A' }
+		})
+	})
+
+	it('handles arrays', () => {
+		expect(camelToSnake([{ skillLevel: 1 }])).toEqual([{ skill_level: 1 }])
+	})
+
+	it('passes through primitives', () => {
+		expect(camelToSnake('hello')).toBe('hello')
+		expect(camelToSnake(42)).toBe(42)
+	})
+
+	it('handles null and undefined', () => {
+		expect(camelToSnake(null)).toBeNull()
+		expect(camelToSnake(undefined)).toBeUndefined()
+	})
+
+	it('preserves wiki_data/wikiData values as-is', () => {
+		const input = { wikiData: { 'Page Name': { some_key: 'val' } } }
+		const result = camelToSnake(input)
+		// wikiData key gets converted to wiki_data, but value is not transformed
+		expect(result).toHaveProperty('wiki_data')
+		expect(result.wiki_data).toEqual({ 'Page Name': { some_key: 'val' } })
+	})
+
+	it('preserves wiki_data when key is already snake_case', () => {
+		const input = { wiki_data: { 'Page/Name': { nested_key: 'v' } } }
+		const result = camelToSnake(input)
+		expect(result.wiki_data).toEqual({ 'Page/Name': { nested_key: 'v' } })
+	})
+})
+
+// ============================================================================
+// transformResponse
+// ============================================================================
+
+describe('transformResponse', () => {
+	it('converts snake_case and renames object → entity', () => {
+		const apiResponse = {
+			id: 'party-1',
+			user_id: 'u-1',
+			weapons: [
+				{ id: 'gw-1', position: 0, object: { id: 'w-1', weapon_name: 'Sword' } }
+			],
+			characters: [
+				{ id: 'gc-1', position: 0, object: { id: 'c-1', char_name: 'Alice' } }
+			],
+			summons: [
+				{ id: 'gs-1', position: 0, object: { id: 's-1', summon_name: 'Bahamut' } }
+			]
+		}
+
+		const result = transformResponse<any>(apiResponse)
+
+		// snake → camel
+		expect(result.userId).toBe('u-1')
+
+		// object → weapon
+		expect(result.weapons[0].weapon).toBeDefined()
+		expect(result.weapons[0].weapon.weaponName).toBe('Sword')
+		expect(result.weapons[0].object).toBeUndefined()
+
+		// object → character
+		expect(result.characters[0].character).toBeDefined()
+		expect(result.characters[0].character.charName).toBe('Alice')
+
+		// object → summon
+		expect(result.summons[0].summon).toBeDefined()
+		expect(result.summons[0].summon.summonName).toBe('Bahamut')
+	})
+
+	it('handles non-entity arrays in weapons/characters/summons', () => {
+		const input = {
+			weapons: [{ id: 'w-1', name: 'plain' }] // no "object" key
+		}
+		const result = transformResponse<any>(input)
+		expect(result.weapons[0].name).toBe('plain')
+	})
+
+	it('handles null/undefined', () => {
+		expect(transformResponse(null)).toBeNull()
+		expect(transformResponse(undefined)).toBeUndefined()
+	})
+})
+
+// ============================================================================
+// transformRequest
+// ============================================================================
+
+describe('transformRequest', () => {
+	it('converts camelCase and renames entity → object', () => {
+		const requestData = {
+			userId: 'u-1',
+			weapons: [
+				{ id: 'gw-1', position: 0, weapon: { id: 'w-1', weaponName: 'Sword' } }
+			],
+			characters: [
+				{ id: 'gc-1', position: 0, character: { id: 'c-1', charName: 'Alice' } }
+			],
+			summons: [
+				{ id: 'gs-1', position: 0, summon: { id: 's-1', summonName: 'Bahamut' } }
+			]
+		}
+
+		const result = transformRequest(requestData)
+
+		// camel → snake
+		expect(result.user_id).toBe('u-1')
+
+		// weapon → object
+		expect(result.weapons[0].object).toBeDefined()
+		expect(result.weapons[0].object.weapon_name).toBe('Sword')
+		expect(result.weapons[0].weapon).toBeUndefined()
+
+		// character → object
+		expect(result.characters[0].object).toBeDefined()
+		expect(result.characters[0].object.char_name).toBe('Alice')
+
+		// summon → object
+		expect(result.summons[0].object).toBeDefined()
+		expect(result.summons[0].object.summon_name).toBe('Bahamut')
+	})
+
+	it('handles null/undefined', () => {
+		expect(transformRequest(null)).toBeNull()
+		expect(transformRequest(undefined)).toBeUndefined()
+	})
+})
+
+// ============================================================================
+// Round-trip consistency
+// ============================================================================
+
+describe('round-trip', () => {
+	it('transformResponse → transformRequest preserves structure', () => {
+		const original = {
+			party_id: 'p-1',
+			weapons: [
+				{ id: 'gw-1', main_hand: true, object: { id: 'w-1', weapon_type: 'sword' } }
+			]
+		}
+
+		const toClient = transformResponse<any>(original)
+		expect(toClient.partyId).toBe('p-1')
+		expect(toClient.weapons[0].weapon.weaponType).toBe('sword')
+
+		const toServer = transformRequest(toClient)
+		expect(toServer.party_id).toBe('p-1')
+		expect(toServer.weapons[0].object.weapon_type).toBe('sword')
+	})
+})

--- a/src/lib/query/__tests__/ssr.test.ts
+++ b/src/lib/query/__tests__/ssr.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest'
+import { withInitialData, prefetchQuery, prefetchInfiniteQuery, setQueryData } from '../ssr'
+
+// ============================================================================
+// withInitialData
+// ============================================================================
+
+describe('withInitialData', () => {
+	it('passes data through', () => {
+		const result = withInitialData({ name: 'test' })
+		expect(result.initialData).toEqual({ name: 'test' })
+	})
+
+	it('converts null to undefined', () => {
+		const result = withInitialData(null)
+		expect(result.initialData).toBeUndefined()
+	})
+
+	it('passes undefined through', () => {
+		const result = withInitialData(undefined)
+		expect(result.initialData).toBeUndefined()
+	})
+
+	it('defaults updatedAt to 0', () => {
+		const result = withInitialData('data')
+		expect(result.initialDataUpdatedAt).toBe(0)
+	})
+
+	it('uses provided updatedAt', () => {
+		const result = withInitialData('data', 1234567890)
+		expect(result.initialDataUpdatedAt).toBe(1234567890)
+	})
+})
+
+// ============================================================================
+// prefetchQuery
+// ============================================================================
+
+describe('prefetchQuery', () => {
+	it('calls queryClient.prefetchQuery with options', async () => {
+		const queryClient = {
+			prefetchQuery: vi.fn().mockResolvedValue(undefined)
+		} as any
+
+		const queryFn = vi.fn()
+		await prefetchQuery(queryClient, {
+			queryKey: ['test', 'key'],
+			queryFn,
+			staleTime: 5000,
+			gcTime: 10000
+		})
+
+		expect(queryClient.prefetchQuery).toHaveBeenCalledWith({
+			queryKey: ['test', 'key'],
+			queryFn,
+			staleTime: 5000,
+			gcTime: 10000
+		})
+	})
+})
+
+// ============================================================================
+// prefetchInfiniteQuery
+// ============================================================================
+
+describe('prefetchInfiniteQuery', () => {
+	it('calls queryClient.prefetchInfiniteQuery with options', async () => {
+		const queryClient = {
+			prefetchInfiniteQuery: vi.fn().mockResolvedValue(undefined)
+		} as any
+
+		const queryFn = vi.fn()
+		await prefetchInfiniteQuery(queryClient, {
+			queryKey: ['infinite', 'key'],
+			queryFn,
+			initialPageParam: 1,
+			staleTime: 5000
+		})
+
+		expect(queryClient.prefetchInfiniteQuery).toHaveBeenCalledWith({
+			queryKey: ['infinite', 'key'],
+			queryFn,
+			initialPageParam: 1,
+			staleTime: 5000,
+			gcTime: undefined
+		})
+	})
+})
+
+// ============================================================================
+// setQueryData
+// ============================================================================
+
+describe('setQueryData', () => {
+	it('calls queryClient.setQueryData with key and data', () => {
+		const queryClient = {
+			setQueryData: vi.fn()
+		} as any
+
+		setQueryData(queryClient, ['my', 'key'], { value: 42 })
+		expect(queryClient.setQueryData).toHaveBeenCalledWith(['my', 'key'], { value: 42 })
+	})
+})

--- a/src/lib/utils/__tests__/artifactValidation.test.ts
+++ b/src/lib/utils/__tests__/artifactValidation.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect } from 'vitest'
+import {
+	getSkillGroupForSlot,
+	validateSkillLevelSum,
+	getExpectedSkillLevelSum,
+	getCurrentSkillLevelSum,
+	validateDuplicateModifiers,
+	isCompatibleWithCharacter,
+	getArtifactProficiency,
+	isQuirkArtifact,
+	validateArtifactSkills,
+	calculateAvailableLevelPoints
+} from '../artifactValidation'
+import type { ArtifactSkillInstance, GridArtifact, CollectionArtifact } from '$lib/types/api/artifact'
+import type { Character } from '$lib/types/api/entities'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeSkill(modifier: number, level: number): ArtifactSkillInstance {
+	return { modifier, strength: 10, level }
+}
+
+function makeArtifact(overrides: Partial<GridArtifact> = {}): GridArtifact {
+	return {
+		id: 'art-1',
+		element: 1,
+		level: 5,
+		skills: [],
+		grade: { letter: null, score: null, breakdown: null, lines: null, recommendation: null },
+		artifact: {
+			id: 'ref-1',
+			granblueId: 'g-1',
+			name: { en: 'Test', jp: 'テスト' },
+			proficiency: 1,
+			rarity: 'standard'
+		},
+		...overrides
+	}
+}
+
+function makeCharacter(overrides: Partial<Character> = {}): Character {
+	return {
+		id: 'char-1',
+		granblueId: 'c-1',
+		name: { en: 'Test Char', jp: 'テスト' },
+		element: 1,
+		proficiency: [1],
+		rarity: 3,
+		...overrides
+	} as Character
+}
+
+// ============================================================================
+// getSkillGroupForSlot
+// ============================================================================
+
+describe('getSkillGroupForSlot', () => {
+	it('maps slots 1-2 to group_i', () => {
+		expect(getSkillGroupForSlot(1)).toBe('group_i')
+		expect(getSkillGroupForSlot(2)).toBe('group_i')
+	})
+
+	it('maps slot 3 to group_ii', () => {
+		expect(getSkillGroupForSlot(3)).toBe('group_ii')
+	})
+
+	it('maps slot 4 to group_iii', () => {
+		expect(getSkillGroupForSlot(4)).toBe('group_iii')
+	})
+
+	it('throws for invalid slot', () => {
+		expect(() => getSkillGroupForSlot(0)).toThrow('Invalid slot number')
+		expect(() => getSkillGroupForSlot(5)).toThrow('Invalid slot number')
+	})
+})
+
+// ============================================================================
+// Skill level sum validation
+// ============================================================================
+
+describe('getExpectedSkillLevelSum', () => {
+	it('returns artifactLevel + 3', () => {
+		expect(getExpectedSkillLevelSum(1)).toBe(4)
+		expect(getExpectedSkillLevelSum(5)).toBe(8)
+		expect(getExpectedSkillLevelSum(20)).toBe(23)
+	})
+})
+
+describe('getCurrentSkillLevelSum', () => {
+	it('sums skill levels', () => {
+		expect(getCurrentSkillLevelSum([makeSkill(1, 2), makeSkill(2, 3)])).toBe(5)
+	})
+
+	it('treats null skills as 0', () => {
+		expect(getCurrentSkillLevelSum([makeSkill(1, 2), null, null, makeSkill(2, 1)])).toBe(3)
+	})
+
+	it('returns 0 for empty array', () => {
+		expect(getCurrentSkillLevelSum([])).toBe(0)
+	})
+})
+
+describe('validateSkillLevelSum', () => {
+	it('returns true when sum matches expected', () => {
+		const skills = [makeSkill(1, 2), makeSkill(2, 2), makeSkill(3, 2), makeSkill(4, 2)]
+		expect(validateSkillLevelSum(5, skills)).toBe(true) // 8 === 5 + 3
+	})
+
+	it('returns false when sum is too low', () => {
+		const skills = [makeSkill(1, 1), makeSkill(2, 1)]
+		expect(validateSkillLevelSum(5, skills)).toBe(false) // 2 !== 8
+	})
+
+	it('returns false when sum is too high', () => {
+		const skills = [makeSkill(1, 5), makeSkill(2, 5), makeSkill(3, 5), makeSkill(4, 5)]
+		expect(validateSkillLevelSum(5, skills)).toBe(false) // 20 !== 8
+	})
+})
+
+// ============================================================================
+// Duplicate modifier validation
+// ============================================================================
+
+describe('validateDuplicateModifiers', () => {
+	it('returns true when modifiers differ', () => {
+		expect(validateDuplicateModifiers(makeSkill(1, 1), makeSkill(2, 1))).toBe(true)
+	})
+
+	it('returns false when modifiers match', () => {
+		expect(validateDuplicateModifiers(makeSkill(1, 1), makeSkill(1, 1))).toBe(false)
+	})
+
+	it('returns true when either skill is null', () => {
+		expect(validateDuplicateModifiers(makeSkill(1, 1), null)).toBe(true)
+		expect(validateDuplicateModifiers(null, makeSkill(1, 1))).toBe(true)
+	})
+
+	it('returns true when both are null', () => {
+		expect(validateDuplicateModifiers(null, null)).toBe(true)
+	})
+
+	it('returns true when either is undefined', () => {
+		expect(validateDuplicateModifiers(undefined, makeSkill(1, 1))).toBe(true)
+		expect(validateDuplicateModifiers(makeSkill(1, 1), undefined)).toBe(true)
+	})
+})
+
+// ============================================================================
+// Character compatibility
+// ============================================================================
+
+describe('isCompatibleWithCharacter', () => {
+	it('matches when element and proficiency align', () => {
+		const artifact = makeArtifact({ element: 1 })
+		const character = makeCharacter({ element: 1, proficiency: [1] })
+		expect(isCompatibleWithCharacter(artifact, character)).toBe(true)
+	})
+
+	it('rejects element mismatch', () => {
+		const artifact = makeArtifact({ element: 2 })
+		const character = makeCharacter({ element: 1, proficiency: [1] })
+		expect(isCompatibleWithCharacter(artifact, character)).toBe(false)
+	})
+
+	it('element 0 is universal', () => {
+		const artifact = makeArtifact({ element: 0 })
+		const character = makeCharacter({ element: 5, proficiency: [1] })
+		expect(isCompatibleWithCharacter(artifact, character)).toBe(true)
+	})
+
+	it('rejects proficiency mismatch', () => {
+		const artifact = makeArtifact({ element: 1 })
+		const character = makeCharacter({ element: 1, proficiency: [2, 3] })
+		expect(isCompatibleWithCharacter(artifact, character)).toBe(false)
+	})
+
+	it('matches if character has artifact proficiency as second prof', () => {
+		const artifact = makeArtifact({ element: 1 })
+		const character = makeCharacter({ element: 1, proficiency: [2, 1] })
+		expect(isCompatibleWithCharacter(artifact, character)).toBe(true)
+	})
+
+	it('compatible when artifact has no proficiency (quirk)', () => {
+		const artifact = makeArtifact({
+			element: 1,
+			artifact: {
+				id: 'ref-1',
+				granblueId: 'g-1',
+				name: { en: 'Quirk', jp: 'クーク' },
+				proficiency: null,
+				rarity: 'quirk'
+			}
+		})
+		const character = makeCharacter({ element: 1 })
+		expect(isCompatibleWithCharacter(artifact, character)).toBe(true)
+	})
+})
+
+// ============================================================================
+// getArtifactProficiency
+// ============================================================================
+
+describe('getArtifactProficiency', () => {
+	it('returns artifact.artifact.proficiency for standard', () => {
+		const artifact = makeArtifact()
+		expect(getArtifactProficiency(artifact)).toBe(1)
+	})
+
+	it('returns instance proficiency for quirk', () => {
+		const artifact = makeArtifact({
+			proficiency: 3,
+			artifact: {
+				id: 'ref-1',
+				granblueId: 'g-1',
+				name: { en: 'Q', jp: 'Q' },
+				proficiency: null,
+				rarity: 'quirk'
+			}
+		})
+		expect(getArtifactProficiency(artifact)).toBe(3)
+	})
+
+	it('returns undefined when no proficiency set', () => {
+		const artifact = makeArtifact({
+			artifact: {
+				id: 'ref-1',
+				granblueId: 'g-1',
+				name: { en: 'Q', jp: 'Q' },
+				proficiency: null,
+				rarity: 'quirk'
+			}
+		})
+		expect(getArtifactProficiency(artifact)).toBeUndefined()
+	})
+})
+
+// ============================================================================
+// isQuirkArtifact
+// ============================================================================
+
+describe('isQuirkArtifact', () => {
+	it('returns true for quirk', () => {
+		const artifact = makeArtifact({
+			artifact: {
+				id: 'r', granblueId: 'g', name: { en: '', jp: '' }, proficiency: null, rarity: 'quirk'
+			}
+		})
+		expect(isQuirkArtifact(artifact)).toBe(true)
+	})
+
+	it('returns false for standard', () => {
+		expect(isQuirkArtifact(makeArtifact())).toBe(false)
+	})
+})
+
+// ============================================================================
+// validateArtifactSkills
+// ============================================================================
+
+describe('validateArtifactSkills', () => {
+	it('returns valid for correct level sum and no duplicates', () => {
+		const skills = [makeSkill(1, 2), makeSkill(2, 2), makeSkill(3, 2), makeSkill(4, 2)]
+		const result = validateArtifactSkills(5, skills)
+		expect(result.isValid).toBe(true)
+		expect(result.levelSumValid).toBe(true)
+		expect(result.noDuplicates).toBe(true)
+		expect(result.errors).toHaveLength(0)
+	})
+
+	it('returns invalid with level sum error', () => {
+		const skills = [makeSkill(1, 1), makeSkill(2, 1), makeSkill(3, 1), makeSkill(4, 1)]
+		const result = validateArtifactSkills(5, skills)
+		expect(result.isValid).toBe(false)
+		expect(result.levelSumValid).toBe(false)
+		expect(result.errors).toContainEqual(expect.stringContaining('Skill level sum'))
+	})
+
+	it('returns invalid with duplicate error', () => {
+		const skills = [makeSkill(1, 2), makeSkill(1, 2), makeSkill(3, 2), makeSkill(4, 2)]
+		const result = validateArtifactSkills(5, skills)
+		expect(result.isValid).toBe(false)
+		expect(result.noDuplicates).toBe(false)
+		expect(result.errors).toContainEqual(expect.stringContaining('same modifier'))
+	})
+
+	it('returns both errors when both fail', () => {
+		const skills = [makeSkill(1, 1), makeSkill(1, 1)]
+		const result = validateArtifactSkills(5, skills)
+		expect(result.errors).toHaveLength(2)
+	})
+})
+
+// ============================================================================
+// calculateAvailableLevelPoints
+// ============================================================================
+
+describe('calculateAvailableLevelPoints', () => {
+	it('returns total minus used', () => {
+		const skills = [makeSkill(1, 2), makeSkill(2, 3), makeSkill(3, 1), null]
+		expect(calculateAvailableLevelPoints(5, skills)).toBe(2) // 8 - 6
+	})
+
+	it('excludes specified slot from used', () => {
+		const skills = [makeSkill(1, 2), makeSkill(2, 3), makeSkill(3, 1), null]
+		// Exclude slot 1 (index 1, level 3) → used = 3, available = 8 - 3 = 5
+		expect(calculateAvailableLevelPoints(5, skills, 1)).toBe(5)
+	})
+
+	it('returns full total for empty skills', () => {
+		expect(calculateAvailableLevelPoints(5, [null, null, null, null])).toBe(8)
+	})
+})

--- a/src/lib/utils/__tests__/element.test.ts
+++ b/src/lib/utils/__tests__/element.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('$lib/utils/images', () => ({
+	getBasePath: vi.fn(() => '/images')
+}))
+
+import {
+	ELEMENTS,
+	ELEMENT_LABELS,
+	getElementLabel,
+	getElementClass,
+	getElementIcon,
+	getElementOptions,
+	getElementName,
+	getOppositeElement,
+	getElementImage
+} from '../element'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+describe('ELEMENTS', () => {
+	it('maps 0-6 with en/ja/opposite_id', () => {
+		expect(ELEMENTS[0]!.en).toBe('Null')
+		expect(ELEMENTS[1]!.ja).toBe('風')
+		expect(ELEMENTS[2]!.opposite_id).toBe(3)
+		expect(ELEMENTS[6]!.en).toBe('Light')
+	})
+})
+
+// ============================================================================
+// getElementLabel
+// ============================================================================
+
+describe('getElementLabel', () => {
+	it('returns label for valid element', () => {
+		expect(getElementLabel(1)).toBe('Wind')
+		expect(getElementLabel(0)).toBe('Null')
+	})
+
+	it('returns dash for undefined/null', () => {
+		expect(getElementLabel(undefined)).toBe('—')
+		expect(getElementLabel(null as any)).toBe('—')
+	})
+
+	it('returns dash for unknown element', () => {
+		expect(getElementLabel(99)).toBe('—')
+	})
+})
+
+// ============================================================================
+// getElementClass
+// ============================================================================
+
+describe('getElementClass', () => {
+	it('returns lowercase CSS class', () => {
+		expect(getElementClass(2)).toBe('element-fire')
+		expect(getElementClass(5)).toBe('element-dark')
+	})
+
+	it('returns empty string for undefined/null', () => {
+		expect(getElementClass(undefined)).toBe('')
+		expect(getElementClass(null as any)).toBe('')
+	})
+
+	it('returns empty string for unknown', () => {
+		expect(getElementClass(99)).toBe('')
+	})
+})
+
+// ============================================================================
+// getElementIcon
+// ============================================================================
+
+describe('getElementIcon', () => {
+	it('returns label image path for valid element', () => {
+		expect(getElementIcon(2)).toBe('/images/labels/element/Label_Element_Fire.png')
+	})
+
+	it('returns empty for undefined or Null element', () => {
+		expect(getElementIcon(undefined)).toBe('')
+		expect(getElementIcon(0)).toBe('')
+	})
+})
+
+// ============================================================================
+// getElementOptions
+// ============================================================================
+
+describe('getElementOptions', () => {
+	it('returns all 7 options (0-6)', () => {
+		const options = getElementOptions()
+		expect(options).toHaveLength(7)
+		expect(options[0]).toEqual({ value: 0, label: 'Null' })
+		expect(options[6]).toEqual({ value: 6, label: 'Light' })
+	})
+})
+
+// ============================================================================
+// getElementName
+// ============================================================================
+
+describe('getElementName', () => {
+	it('returns English name by default', () => {
+		expect(getElementName(1)).toBe('Wind')
+	})
+
+	it('returns Japanese name', () => {
+		expect(getElementName(2, 'ja')).toBe('火')
+	})
+
+	it('returns dash for undefined/null', () => {
+		expect(getElementName(undefined)).toBe('—')
+		expect(getElementName(null as any)).toBe('—')
+	})
+
+	it('returns dash for unknown', () => {
+		expect(getElementName(99)).toBe('—')
+	})
+})
+
+// ============================================================================
+// getOppositeElement
+// ============================================================================
+
+describe('getOppositeElement', () => {
+	it('returns opposite element pairs', () => {
+		expect(getOppositeElement(1)).toBe(4) // Wind → Earth
+		expect(getOppositeElement(4)).toBe(1) // Earth → Wind
+		expect(getOppositeElement(2)).toBe(3) // Fire → Water
+		expect(getOppositeElement(3)).toBe(2) // Water → Fire
+		expect(getOppositeElement(5)).toBe(6) // Dark → Light
+		expect(getOppositeElement(6)).toBe(5) // Light → Dark
+	})
+
+	it('returns 0 for Null element', () => {
+		expect(getOppositeElement(0)).toBe(0)
+	})
+
+	it('returns undefined for undefined/null', () => {
+		expect(getOppositeElement(undefined)).toBeUndefined()
+		expect(getOppositeElement(null as any)).toBeUndefined()
+	})
+})
+
+// ============================================================================
+// getElementImage
+// ============================================================================
+
+describe('getElementImage', () => {
+	it('returns element image path', () => {
+		expect(getElementImage(2)).toBe('/images/elements/fire.png')
+	})
+
+	it('returns null element image', () => {
+		expect(getElementImage(0)).toBe('/images/elements/null.png')
+	})
+
+	it('returns empty string for undefined/null', () => {
+		expect(getElementImage(undefined)).toBe('')
+		expect(getElementImage(null as any)).toBe('')
+	})
+})

--- a/src/lib/utils/__tests__/filterParams.test.ts
+++ b/src/lib/utils/__tests__/filterParams.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect } from 'vitest'
+import {
+	parseFiltersFromUrl,
+	buildUrlFromFilters,
+	hasActiveFilters,
+	ELEMENT_TO_PARAM,
+	PARAM_TO_ELEMENT,
+	RARITY_TO_PARAM,
+	PARAM_TO_RARITY,
+	PROFICIENCY_TO_PARAM,
+	PARAM_TO_PROFICIENCY,
+	SEASON_TO_PARAM,
+	PARAM_TO_SEASON,
+	CHARACTER_SERIES_TO_PARAM,
+	PARAM_TO_CHARACTER_SERIES
+} from '../filterParams'
+import type { CollectionFilterState } from '$lib/components/collection/CollectionFilters.svelte'
+import type { WeaponSeries } from '$lib/types/api/weaponSeries'
+
+function emptyFilters(): CollectionFilterState {
+	return {
+		element: [],
+		rarity: [],
+		proficiency: [],
+		season: [],
+		series: [],
+		race: [],
+		gender: []
+	}
+}
+
+const MOCK_WEAPON_SERIES: WeaponSeries[] = [
+	{
+		id: 'ws-1',
+		slug: 'dark-opus',
+		name: { en: 'Dark Opus', ja: 'オプス' },
+		hasWeaponKeys: true,
+		hasAwakening: true,
+		augmentType: 'no_augment',
+		extra: false,
+		elementChangeable: false
+	},
+	{
+		id: 'ws-2',
+		slug: 'draconic',
+		name: { en: 'Draconic', ja: 'ドラゴニック' },
+		hasWeaponKeys: true,
+		hasAwakening: false,
+		augmentType: 'no_augment',
+		extra: false,
+		elementChangeable: false
+	}
+] as WeaponSeries[]
+
+// ============================================================================
+// Mapping Constants
+// ============================================================================
+
+describe('bidirectional mappings', () => {
+	it('element mappings are consistent', () => {
+		for (const [num, param] of Object.entries(ELEMENT_TO_PARAM)) {
+			expect(PARAM_TO_ELEMENT[param]).toBe(Number(num))
+		}
+	})
+
+	it('rarity mappings are consistent', () => {
+		for (const [num, param] of Object.entries(RARITY_TO_PARAM)) {
+			expect(PARAM_TO_RARITY[param]).toBe(Number(num))
+		}
+	})
+
+	it('proficiency mappings are consistent', () => {
+		for (const [num, param] of Object.entries(PROFICIENCY_TO_PARAM)) {
+			expect(PARAM_TO_PROFICIENCY[param]).toBe(Number(num))
+		}
+	})
+
+	it('season mappings are consistent', () => {
+		for (const [num, param] of Object.entries(SEASON_TO_PARAM)) {
+			expect(PARAM_TO_SEASON[param]).toBe(Number(num))
+		}
+	})
+
+	it('character series mappings are consistent', () => {
+		for (const [num, param] of Object.entries(CHARACTER_SERIES_TO_PARAM)) {
+			expect(PARAM_TO_CHARACTER_SERIES[param]).toBe(Number(num))
+		}
+	})
+})
+
+// ============================================================================
+// parseFiltersFromUrl
+// ============================================================================
+
+describe('parseFiltersFromUrl', () => {
+	it('returns empty filters for empty params', () => {
+		const result = parseFiltersFromUrl(new URLSearchParams(), 'character')
+		expect(result.element).toEqual([])
+		expect(result.rarity).toEqual([])
+		expect(result.proficiency).toEqual([])
+		expect(result.season).toEqual([])
+		expect(result.series).toEqual([])
+		expect(result.searchQuery).toBe('')
+		expect(result.page).toBe(1)
+	})
+
+	it('parses element filter', () => {
+		const params = new URLSearchParams('element=fire,water')
+		const result = parseFiltersFromUrl(params, 'character')
+		expect(result.element).toEqual([2, 3])
+	})
+
+	it('parses rarity filter', () => {
+		const params = new URLSearchParams('rarity=ssr')
+		const result = parseFiltersFromUrl(params, 'character')
+		expect(result.rarity).toEqual([3])
+	})
+
+	it('parses proficiency filter', () => {
+		const params = new URLSearchParams('proficiency=sabre,katana')
+		const result = parseFiltersFromUrl(params, 'character')
+		expect(result.proficiency).toEqual([1, 10])
+	})
+
+	it('parses season only for characters', () => {
+		const charParams = new URLSearchParams('season=summer,valentine')
+		expect(parseFiltersFromUrl(charParams, 'character').season).toEqual([3, 1])
+
+		const weaponParams = new URLSearchParams('season=summer')
+		expect(parseFiltersFromUrl(weaponParams, 'weapon').season).toEqual([])
+	})
+
+	it('parses character series as numeric', () => {
+		const params = new URLSearchParams('series=grand,zodiac')
+		const result = parseFiltersFromUrl(params, 'character')
+		expect(result.series).toEqual([1, 2])
+	})
+
+	it('parses weapon series as UUIDs via slug lookup', () => {
+		const params = new URLSearchParams('series=dark-opus,draconic')
+		const result = parseFiltersFromUrl(params, 'weapon', MOCK_WEAPON_SERIES)
+		expect(result.series).toEqual(['ws-1', 'ws-2'])
+	})
+
+	it('ignores unknown weapon series slugs', () => {
+		const params = new URLSearchParams('series=nonexistent')
+		const result = parseFiltersFromUrl(params, 'weapon', MOCK_WEAPON_SERIES)
+		expect(result.series).toEqual([])
+	})
+
+	it('parses search query', () => {
+		const params = new URLSearchParams('q=Yuel')
+		const result = parseFiltersFromUrl(params, 'character')
+		expect(result.searchQuery).toBe('Yuel')
+	})
+
+	it('parses page number', () => {
+		const params = new URLSearchParams('page=3')
+		const result = parseFiltersFromUrl(params, 'character')
+		expect(result.page).toBe(3)
+	})
+
+	it('clamps page to minimum 1', () => {
+		const params = new URLSearchParams('page=0')
+		const result = parseFiltersFromUrl(params, 'character')
+		expect(result.page).toBe(1)
+	})
+
+	it('ignores invalid values in mappings', () => {
+		const params = new URLSearchParams('element=fire,invalid,water')
+		const result = parseFiltersFromUrl(params, 'character')
+		expect(result.element).toEqual([2, 3])
+	})
+})
+
+// ============================================================================
+// buildUrlFromFilters
+// ============================================================================
+
+describe('buildUrlFromFilters', () => {
+	it('returns empty params for empty filters', () => {
+		const params = buildUrlFromFilters(emptyFilters(), '', 1, 'character')
+		expect(params.toString()).toBe('')
+	})
+
+	it('builds element param', () => {
+		const filters = { ...emptyFilters(), element: [2, 3] }
+		const params = buildUrlFromFilters(filters, '', 1, 'character')
+		expect(params.get('element')).toBe('fire,water')
+	})
+
+	it('builds rarity param', () => {
+		const filters = { ...emptyFilters(), rarity: [3] }
+		const params = buildUrlFromFilters(filters, '', 1, 'character')
+		expect(params.get('rarity')).toBe('ssr')
+	})
+
+	it('builds proficiency param', () => {
+		const filters = { ...emptyFilters(), proficiency: [1, 10] }
+		const params = buildUrlFromFilters(filters, '', 1, 'character')
+		expect(params.get('proficiency')).toBe('sabre,katana')
+	})
+
+	it('builds season param for characters only', () => {
+		const filters = { ...emptyFilters(), season: [3] }
+		const charParams = buildUrlFromFilters(filters, '', 1, 'character')
+		expect(charParams.get('season')).toBe('summer')
+
+		const weaponParams = buildUrlFromFilters(filters, '', 1, 'weapon')
+		expect(weaponParams.get('season')).toBeNull()
+	})
+
+	it('builds character series param', () => {
+		const filters = { ...emptyFilters(), series: [1, 2] as (number | string)[] }
+		const params = buildUrlFromFilters(filters, '', 1, 'character')
+		expect(params.get('series')).toBe('grand,zodiac')
+	})
+
+	it('builds weapon series param via UUID lookup', () => {
+		const filters = {
+			...emptyFilters(),
+			series: ['ws-1', 'ws-2'] as (number | string)[]
+		}
+		const params = buildUrlFromFilters(filters, '', 1, 'weapon', MOCK_WEAPON_SERIES)
+		expect(params.get('series')).toBe('dark-opus,draconic')
+	})
+
+	it('includes search query', () => {
+		const params = buildUrlFromFilters(emptyFilters(), 'Yuel', 1, 'character')
+		expect(params.get('q')).toBe('Yuel')
+	})
+
+	it('trims search query whitespace', () => {
+		const params = buildUrlFromFilters(emptyFilters(), '  Yuel  ', 1, 'character')
+		expect(params.get('q')).toBe('Yuel')
+	})
+
+	it('omits page when 1', () => {
+		const params = buildUrlFromFilters(emptyFilters(), '', 1, 'character')
+		expect(params.get('page')).toBeNull()
+	})
+
+	it('includes page when > 1', () => {
+		const params = buildUrlFromFilters(emptyFilters(), '', 3, 'character')
+		expect(params.get('page')).toBe('3')
+	})
+})
+
+// ============================================================================
+// hasActiveFilters
+// ============================================================================
+
+describe('hasActiveFilters', () => {
+	it('returns false when all empty', () => {
+		expect(hasActiveFilters(emptyFilters(), '')).toBe(false)
+	})
+
+	it('returns true when element is set', () => {
+		expect(hasActiveFilters({ ...emptyFilters(), element: [1] }, '')).toBe(true)
+	})
+
+	it('returns true when rarity is set', () => {
+		expect(hasActiveFilters({ ...emptyFilters(), rarity: [3] }, '')).toBe(true)
+	})
+
+	it('returns true when search query is set', () => {
+		expect(hasActiveFilters(emptyFilters(), 'search')).toBe(true)
+	})
+
+	it('returns false for whitespace-only search', () => {
+		expect(hasActiveFilters(emptyFilters(), '   ')).toBe(false)
+	})
+
+	it('returns true when race is set', () => {
+		expect(hasActiveFilters({ ...emptyFilters(), race: [1] }, '')).toBe(true)
+	})
+
+	it('returns true when gender is set', () => {
+		expect(hasActiveFilters({ ...emptyFilters(), gender: [1] }, '')).toBe(true)
+	})
+})

--- a/src/lib/utils/__tests__/gridHelpers.test.ts
+++ b/src/lib/utils/__tests__/gridHelpers.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { findNextEmptySlot, SLOT_NOT_FOUND } from '../gridHelpers'
+import { GridType } from '$lib/types/enums'
+import type { Party } from '$lib/types/api/party'
+
+function makeParty(overrides: Partial<Party> = {}): Party {
+	return {
+		id: 'p-1',
+		shortcode: 'ABC123',
+		name: { en: 'Test Party', ja: 'テスト' },
+		extra: false,
+		weapons: [],
+		characters: [],
+		summons: [],
+		...overrides
+	} as Party
+}
+
+// ============================================================================
+// Weapon Grid
+// ============================================================================
+
+describe('findNextEmptySlot — weapons', () => {
+	it('returns -1 (mainhand) for empty weapon grid', () => {
+		const party = makeParty()
+		expect(findNextEmptySlot(party, GridType.Weapon)).toBe(-1)
+	})
+
+	it('returns 0 when mainhand is occupied', () => {
+		const party = makeParty({
+			weapons: [{ id: 'w-1', position: -1, mainhand: true }] as any[]
+		})
+		expect(findNextEmptySlot(party, GridType.Weapon)).toBe(0)
+	})
+
+	it('skips occupied regular slots', () => {
+		const party = makeParty({
+			weapons: [
+				{ id: 'w-1', position: -1, mainhand: true },
+				{ id: 'w-2', position: 0 },
+				{ id: 'w-3', position: 1 }
+			] as any[]
+		})
+		expect(findNextEmptySlot(party, GridType.Weapon)).toBe(2)
+	})
+
+	it('returns SLOT_NOT_FOUND when all weapon slots are full', () => {
+		const weapons = [{ id: 'w-mh', position: -1, mainhand: true }] as any[]
+		for (let i = 0; i <= 8; i++) {
+			weapons.push({ id: `w-${i}`, position: i })
+		}
+		const party = makeParty({ weapons })
+		expect(findNextEmptySlot(party, GridType.Weapon)).toBe(SLOT_NOT_FOUND)
+	})
+})
+
+// ============================================================================
+// Summon Grid
+// ============================================================================
+
+describe('findNextEmptySlot — summons', () => {
+	it('returns -1 (main summon) for empty summon grid', () => {
+		const party = makeParty()
+		expect(findNextEmptySlot(party, GridType.Summon)).toBe(-1)
+	})
+
+	it('returns 6 (friend) when main and regular slots are full', () => {
+		const summons = [{ id: 's-main', position: -1, main: true }] as any[]
+		for (let i = 0; i <= 5; i++) {
+			summons.push({ id: `s-${i}`, position: i })
+		}
+		const party = makeParty({ summons })
+		expect(findNextEmptySlot(party, GridType.Summon)).toBe(6)
+	})
+
+	it('returns SLOT_NOT_FOUND when all summon slots are full', () => {
+		const summons = [
+			{ id: 's-main', position: -1, main: true },
+			{ id: 's-friend', position: 6, friend: true }
+		] as any[]
+		for (let i = 0; i <= 5; i++) {
+			summons.push({ id: `s-${i}`, position: i })
+		}
+		const party = makeParty({ summons })
+		expect(findNextEmptySlot(party, GridType.Summon)).toBe(SLOT_NOT_FOUND)
+	})
+})
+
+// ============================================================================
+// Character Grid
+// ============================================================================
+
+describe('findNextEmptySlot — characters', () => {
+	it('returns 0 for empty character grid', () => {
+		const party = makeParty()
+		expect(findNextEmptySlot(party, GridType.Character)).toBe(0)
+	})
+
+	it('skips occupied character slots', () => {
+		const party = makeParty({
+			characters: [
+				{ id: 'c-1', position: 0 },
+				{ id: 'c-2', position: 1 }
+			] as any[]
+		})
+		expect(findNextEmptySlot(party, GridType.Character)).toBe(2)
+	})
+
+	it('returns SLOT_NOT_FOUND when all character slots are full', () => {
+		const characters = [] as any[]
+		for (let i = 0; i <= 4; i++) {
+			characters.push({ id: `c-${i}`, position: i })
+		}
+		const party = makeParty({ characters })
+		expect(findNextEmptySlot(party, GridType.Character)).toBe(SLOT_NOT_FOUND)
+	})
+})

--- a/src/lib/utils/__tests__/gridValidation.test.ts
+++ b/src/lib/utils/__tests__/gridValidation.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest'
+import { validateGridWeapon, validateGridCharacter, validateGridSummon } from '../gridValidation'
+
+// Suppress console.warn from validation functions
+vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+// ============================================================================
+// validateGridWeapon
+// ============================================================================
+
+describe('validateGridWeapon', () => {
+	it('returns null for null input', () => {
+		expect(validateGridWeapon(null)).toBeNull()
+	})
+
+	it('returns null for undefined input', () => {
+		expect(validateGridWeapon(undefined)).toBeNull()
+	})
+
+	it('returns null for non-object input', () => {
+		expect(validateGridWeapon('string')).toBeNull()
+		expect(validateGridWeapon(42)).toBeNull()
+	})
+
+	it('returns null when weapon data is missing', () => {
+		expect(validateGridWeapon({ id: '1', position: 0 })).toBeNull()
+	})
+
+	it('returns null when weapon has no granblueId', () => {
+		expect(validateGridWeapon({ id: '1', weapon: { name: 'test' } })).toBeNull()
+	})
+
+	it('validates data with weapon property', () => {
+		const raw = { id: '1', position: 0, weapon: { granblueId: '1040001' } }
+		const result = validateGridWeapon(raw)
+		expect(result).not.toBeNull()
+		expect(result!.weapon.granblueId).toBe('1040001')
+	})
+
+	it('normalizes legacy object property to weapon', () => {
+		const raw = { id: '1', position: 0, object: { granblueId: '1040001' } }
+		const result = validateGridWeapon(raw)
+		expect(result).not.toBeNull()
+		expect(result!.weapon.granblueId).toBe('1040001')
+		expect((result as any).object).toBeUndefined()
+	})
+
+	it('prefers weapon over object when both present', () => {
+		const raw = {
+			id: '1',
+			weapon: { granblueId: 'weapon-id' },
+			object: { granblueId: 'object-id' }
+		}
+		const result = validateGridWeapon(raw)
+		expect(result!.weapon.granblueId).toBe('weapon-id')
+	})
+})
+
+// ============================================================================
+// validateGridCharacter
+// ============================================================================
+
+describe('validateGridCharacter', () => {
+	it('returns null for null input', () => {
+		expect(validateGridCharacter(null)).toBeNull()
+	})
+
+	it('returns null for non-object input', () => {
+		expect(validateGridCharacter(123)).toBeNull()
+	})
+
+	it('returns null when character data is missing', () => {
+		expect(validateGridCharacter({ id: '1', position: 0 })).toBeNull()
+	})
+
+	it('returns null when character has no granblueId', () => {
+		expect(validateGridCharacter({ id: '1', character: { name: 'test' } })).toBeNull()
+	})
+
+	it('validates data with character property', () => {
+		const raw = { id: '1', position: 0, character: { granblueId: '3040001' } }
+		const result = validateGridCharacter(raw)
+		expect(result).not.toBeNull()
+		expect(result!.character.granblueId).toBe('3040001')
+	})
+
+	it('normalizes legacy object property to character', () => {
+		const raw = { id: '1', position: 0, object: { granblueId: '3040001' } }
+		const result = validateGridCharacter(raw)
+		expect(result).not.toBeNull()
+		expect(result!.character.granblueId).toBe('3040001')
+		expect((result as any).object).toBeUndefined()
+	})
+})
+
+// ============================================================================
+// validateGridSummon
+// ============================================================================
+
+describe('validateGridSummon', () => {
+	it('returns null for null input', () => {
+		expect(validateGridSummon(null)).toBeNull()
+	})
+
+	it('returns null for non-object input', () => {
+		expect(validateGridSummon(false)).toBeNull()
+	})
+
+	it('returns null when summon data is missing', () => {
+		expect(validateGridSummon({ id: '1', position: 0 })).toBeNull()
+	})
+
+	it('returns null when summon has no granblueId', () => {
+		expect(validateGridSummon({ id: '1', summon: { name: 'test' } })).toBeNull()
+	})
+
+	it('validates data with summon property', () => {
+		const raw = { id: '1', position: 0, summon: { granblueId: '2040001' } }
+		const result = validateGridSummon(raw)
+		expect(result).not.toBeNull()
+		expect(result!.summon.granblueId).toBe('2040001')
+	})
+
+	it('normalizes legacy object property to summon', () => {
+		const raw = { id: '1', position: 0, object: { granblueId: '2040001' } }
+		const result = validateGridSummon(raw)
+		expect(result).not.toBeNull()
+		expect(result!.summon.granblueId).toBe('2040001')
+		expect((result as any).object).toBeUndefined()
+	})
+})

--- a/src/lib/utils/__tests__/gw.test.ts
+++ b/src/lib/utils/__tests__/gw.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from 'vitest'
+import {
+	formatScore,
+	formatScoreCompact,
+	parseScore,
+	getElementColor,
+	toPlayerChartData,
+	toCrewBattleChartData,
+	toMultiPlayerChartData,
+	toCrewHistoryChartData,
+	toPlayerHistoryChartData,
+	ELEMENT_LABELS,
+	ELEMENT_CSS_CLASSES,
+	ELEMENT_HEX_COLORS
+} from '../gw'
+import type { GwIndividualScore, GwCrewScore, GwEvent, EventScoreSummary } from '$lib/types/api/gw'
+
+// ============================================================================
+// Formatting
+// ============================================================================
+
+describe('formatScore', () => {
+	it('formats with locale separators', () => {
+		// toLocaleString is locale-dependent, just verify it returns a string
+		expect(typeof formatScore(1000000)).toBe('string')
+		expect(formatScore(0)).toBe('0')
+	})
+})
+
+describe('formatScoreCompact', () => {
+	it('formats billions', () => {
+		expect(formatScoreCompact(1_000_000_000)).toBe('1b')
+		expect(formatScoreCompact(1_500_000_000)).toBe('1.5b')
+		expect(formatScoreCompact(2_000_000_000)).toBe('2b')
+	})
+
+	it('formats millions', () => {
+		expect(formatScoreCompact(1_000_000)).toBe('1m')
+		expect(formatScoreCompact(250_000_000)).toBe('250m')
+		expect(formatScoreCompact(1_500_000)).toBe('1.5m')
+	})
+
+	it('formats thousands', () => {
+		expect(formatScoreCompact(1_000)).toBe('1k')
+		expect(formatScoreCompact(50_000)).toBe('50k')
+		expect(formatScoreCompact(1_500)).toBe('1.5k')
+	})
+
+	it('returns raw number below 1000', () => {
+		expect(formatScoreCompact(999)).toBe('999')
+		expect(formatScoreCompact(0)).toBe('0')
+		expect(formatScoreCompact(1)).toBe('1')
+	})
+
+	it('handles negative values', () => {
+		expect(formatScoreCompact(-1_000_000)).toBe('-1m')
+		expect(formatScoreCompact(-500)).toBe('-500')
+	})
+})
+
+describe('parseScore', () => {
+	it('parses comma-separated string', () => {
+		expect(parseScore('1,000,000')).toBe(1000000)
+	})
+
+	it('parses plain number string', () => {
+		expect(parseScore('12345')).toBe(12345)
+	})
+})
+
+// ============================================================================
+// Element utilities
+// ============================================================================
+
+describe('ELEMENT_LABELS', () => {
+	it('maps all elements 0-6', () => {
+		expect(ELEMENT_LABELS[0]).toBe('Null')
+		expect(ELEMENT_LABELS[1]).toBe('Wind')
+		expect(ELEMENT_LABELS[6]).toBe('Light')
+	})
+})
+
+describe('ELEMENT_CSS_CLASSES', () => {
+	it('maps all elements 0-6', () => {
+		expect(ELEMENT_CSS_CLASSES[0]).toBe('null')
+		expect(ELEMENT_CSS_CLASSES[2]).toBe('fire')
+	})
+})
+
+describe('getElementColor', () => {
+	it('returns hex color for valid element', () => {
+		expect(getElementColor(1)).toBe(ELEMENT_HEX_COLORS['wind'])
+		expect(getElementColor(2)).toBe(ELEMENT_HEX_COLORS['fire'])
+	})
+
+	it('returns #888 for unknown element', () => {
+		expect(getElementColor(99)).toBe('#888')
+	})
+
+	it('returns #888 for null element (0)', () => {
+		// ELEMENT_CSS_CLASSES[0] = 'null', which is not in ELEMENT_HEX_COLORS
+		expect(getElementColor(0)).toBe('#888')
+	})
+})
+
+// ============================================================================
+// Chart data transformations
+// ============================================================================
+
+function makeIndividualScore(
+	round: 0 | 1 | 2 | 3 | 4 | 5,
+	score: number,
+	playerName = 'Player1',
+	memberId?: string
+): GwIndividualScore {
+	return {
+		id: `score-${round}-${score}`,
+		round,
+		score,
+		isCumulative: false,
+		excused: false,
+		playerName,
+		playerType: 'member',
+		member: memberId ? { id: memberId } as any : undefined
+	}
+}
+
+describe('toPlayerChartData', () => {
+	it('produces 6 round entries with cumulative totals', () => {
+		const scores = [
+			makeIndividualScore(0, 100),
+			makeIndividualScore(1, 200),
+			makeIndividualScore(2, 300),
+			makeIndividualScore(3, 400),
+			makeIndividualScore(4, 500),
+			makeIndividualScore(5, 600)
+		]
+
+		const result = toPlayerChartData(scores)
+		expect(result).toHaveLength(6)
+		expect(result[0]!.round).toBe(0)
+		expect(result[0]!.score).toBe(100)
+		expect(result[0]!.cumulative).toBe(100)
+		expect(result[5]!.cumulative).toBe(2100)
+	})
+
+	it('fills missing rounds with 0', () => {
+		const scores = [makeIndividualScore(2, 500)]
+		const result = toPlayerChartData(scores)
+		expect(result[0]!.score).toBe(0)
+		expect(result[1]!.score).toBe(0)
+		expect(result[2]!.score).toBe(500)
+		expect(result[2]!.cumulative).toBe(500)
+	})
+
+	it('aggregates duplicate rounds', () => {
+		const scores = [
+			makeIndividualScore(0, 100),
+			makeIndividualScore(0, 200) // same round
+		]
+		const result = toPlayerChartData(scores)
+		expect(result[0]!.score).toBe(300)
+	})
+
+	it('handles empty input', () => {
+		const result = toPlayerChartData([])
+		expect(result).toHaveLength(6)
+		expect(result.every((r) => r.score === 0)).toBe(true)
+	})
+
+	it('includes round labels', () => {
+		const result = toPlayerChartData([])
+		expect(result[0]!.roundLabel).toBe('Preliminaries')
+		expect(result[2]!.roundLabel).toBe('Finals Day 1')
+	})
+})
+
+describe('toCrewBattleChartData', () => {
+	it('filters to finals rounds only (>= 2)', () => {
+		const crewScores: GwCrewScore[] = [
+			{ id: '1', round: 0, crewScore: 100, opponentScore: 50, opponentName: null, opponentGranblueId: null, victory: null },
+			{ id: '2', round: 1, crewScore: 200, opponentScore: 150, opponentName: null, opponentGranblueId: null, victory: null },
+			{ id: '3', round: 2, crewScore: 300, opponentScore: 250, opponentName: 'OppCrew', opponentGranblueId: null, victory: true },
+			{ id: '4', round: 3, crewScore: 400, opponentScore: 350, opponentName: 'OppCrew2', opponentGranblueId: null, victory: true }
+		]
+
+		const result = toCrewBattleChartData(crewScores)
+		expect(result).toHaveLength(2)
+		expect(result[0]!.round).toBe(2)
+		expect(result[1]!.round).toBe(3)
+	})
+
+	it('sorts by round', () => {
+		const crewScores: GwCrewScore[] = [
+			{ id: '1', round: 5, crewScore: 500, opponentScore: 400, opponentName: null, opponentGranblueId: null, victory: null },
+			{ id: '2', round: 2, crewScore: 200, opponentScore: 100, opponentName: null, opponentGranblueId: null, victory: null }
+		]
+
+		const result = toCrewBattleChartData(crewScores)
+		expect(result[0]!.round).toBe(2)
+		expect(result[1]!.round).toBe(5)
+	})
+
+	it('returns empty array when no finals rounds', () => {
+		const crewScores: GwCrewScore[] = [
+			{ id: '1', round: 0, crewScore: 100, opponentScore: 50, opponentName: null, opponentGranblueId: null, victory: null }
+		]
+		expect(toCrewBattleChartData(crewScores)).toHaveLength(0)
+	})
+})
+
+describe('toMultiPlayerChartData', () => {
+	it('groups scores by player', () => {
+		const scores = [
+			makeIndividualScore(0, 100, 'Alice', 'alice-id'),
+			makeIndividualScore(1, 200, 'Alice', 'alice-id'),
+			makeIndividualScore(0, 300, 'Bob', 'bob-id')
+		]
+
+		const result = toMultiPlayerChartData(scores)
+		expect(result.size).toBe(2)
+
+		const alice = result.get('alice-id')
+		expect(alice).toBeDefined()
+		expect(alice!.name).toBe('Alice')
+		expect(alice!.scores).toHaveLength(6)
+		expect(alice!.scores[0]!.score).toBe(100)
+	})
+
+	it('uses playerName as key when no member/phantom id', () => {
+		const scores = [makeIndividualScore(0, 100, 'Anonymous')]
+		const result = toMultiPlayerChartData(scores)
+		expect(result.has('Anonymous')).toBe(true)
+	})
+})
+
+describe('toCrewHistoryChartData', () => {
+	const formatDate = (d: string) => `formatted:${d}`
+
+	it('transforms events into history points', () => {
+		const events: GwEvent[] = [
+			{ id: '1', element: 1, startDate: '2025-01', endDate: '2025-02', eventNumber: 72, crewTotalScore: 5000 },
+			{ id: '2', element: 2, startDate: '2025-03', endDate: '2025-04', eventNumber: 73, crewTotalScore: 8000 }
+		]
+
+		const result = toCrewHistoryChartData(events, formatDate)
+		expect(result).toHaveLength(2)
+		expect(result[0]!.eventLabel).toBe('GW #72')
+		expect(result[0]!.totalScore).toBe(5000)
+		expect(result[0]!.date).toBe('formatted:2025-01')
+		expect(result[0]!.isGap).toBe(false)
+	})
+
+	it('sorts by event number', () => {
+		const events: GwEvent[] = [
+			{ id: '2', element: 2, startDate: '', endDate: '', eventNumber: 73, crewTotalScore: 100 },
+			{ id: '1', element: 1, startDate: '', endDate: '', eventNumber: 71, crewTotalScore: 200 }
+		]
+
+		const result = toCrewHistoryChartData(events, formatDate)
+		expect(result[0]!.eventNumber).toBe(71)
+		expect(result[1]!.eventNumber).toBe(73)
+	})
+
+	it('filters out events with no/zero score', () => {
+		const events: GwEvent[] = [
+			{ id: '1', element: 1, startDate: '', endDate: '', eventNumber: 71 },
+			{ id: '2', element: 2, startDate: '', endDate: '', eventNumber: 72, crewTotalScore: 0 },
+			{ id: '3', element: 3, startDate: '', endDate: '', eventNumber: 73, crewTotalScore: 100 }
+		]
+
+		const result = toCrewHistoryChartData(events, formatDate)
+		expect(result).toHaveLength(1)
+		expect(result[0]!.eventNumber).toBe(73)
+	})
+})
+
+describe('toPlayerHistoryChartData', () => {
+	const formatDate = (d: string) => `fmt:${d}`
+
+	it('marks in-crew events with score', () => {
+		const eventScores: EventScoreSummary[] = [
+			{
+				gwEvent: { id: '1', element: 1, eventNumber: 72, startDate: '2025-01', endDate: '2025-02' },
+				totalScore: 5000,
+				inCrew: true
+			}
+		]
+
+		const result = toPlayerHistoryChartData(eventScores, formatDate)
+		expect(result[0]!.totalScore).toBe(5000)
+		expect(result[0]!.isGap).toBe(false)
+	})
+
+	it('marks gap events with null score', () => {
+		const eventScores: EventScoreSummary[] = [
+			{
+				gwEvent: { id: '1', element: 1, eventNumber: 72, startDate: '2025-01', endDate: '2025-02' },
+				totalScore: null,
+				inCrew: false
+			}
+		]
+
+		const result = toPlayerHistoryChartData(eventScores, formatDate)
+		expect(result[0]!.totalScore).toBeNull()
+		expect(result[0]!.isGap).toBe(true)
+	})
+
+	it('sorts by event number', () => {
+		const eventScores: EventScoreSummary[] = [
+			{
+				gwEvent: { id: '2', element: 1, eventNumber: 74, startDate: '', endDate: '' },
+				totalScore: 100,
+				inCrew: true
+			},
+			{
+				gwEvent: { id: '1', element: 1, eventNumber: 72, startDate: '', endDate: '' },
+				totalScore: 200,
+				inCrew: true
+			}
+		]
+
+		const result = toPlayerHistoryChartData(eventScores, formatDate)
+		expect(result[0]!.eventNumber).toBe(72)
+		expect(result[1]!.eventNumber).toBe(74)
+	})
+})

--- a/src/lib/utils/__tests__/images.test.ts
+++ b/src/lib/utils/__tests__/images.test.ts
@@ -1,0 +1,606 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('$lib/api/adapters/config', () => ({
+	getImageBaseUrl: vi.fn(() => '')
+}))
+
+import { getImageBaseUrl } from '$lib/api/adapters/config'
+import {
+	getBasePath,
+	getPlaceholderImage,
+	getGenericPlaceholder,
+	getCharacterPose,
+	getImageUrl,
+	getCharacterImage,
+	getCharacterDetailImage,
+	getWeaponImage,
+	getWeaponBaseImage,
+	getSummonImage,
+	getSummonDetailImage,
+	getSummonWideImage,
+	getCharacterImageWithPose,
+	getWeaponGridImage,
+	getJobSkillIcon,
+	getAccessoryImage,
+	getAwakeningImage,
+	getWeaponKeyImage,
+	getAxSkillImage,
+	getMasteryImage,
+	getElementLabelImage,
+	getProficiencyLabelImage,
+	getRaceLabelImage,
+	getGenderLabelImage,
+	getElementIcon,
+	getArtifactImage,
+	getGameCdnCharacterImage,
+	getGameCdnWeaponImage,
+	getGameCdnSummonImage,
+	getGuidebookImage,
+	getRaidImage,
+	getRaidCdnImage
+} from '../images'
+
+const mockedGetImageBaseUrl = vi.mocked(getImageBaseUrl)
+
+beforeEach(() => {
+	mockedGetImageBaseUrl.mockReturnValue('')
+})
+
+// ============================================================================
+// getBasePath
+// ============================================================================
+
+describe('getBasePath', () => {
+	it('returns /images when no remote URL configured', () => {
+		expect(getBasePath()).toBe('/images')
+	})
+
+	it('returns remote URL when configured', () => {
+		mockedGetImageBaseUrl.mockReturnValue('https://cdn.example.com')
+		expect(getBasePath()).toBe('https://cdn.example.com')
+	})
+})
+
+// ============================================================================
+// Placeholders
+// ============================================================================
+
+describe('getPlaceholderImage', () => {
+	it('returns placeholder path for each type/variant combo', () => {
+		expect(getPlaceholderImage('character', 'grid')).toBe(
+			'/images/placeholders/placeholder-character-grid.png'
+		)
+		expect(getPlaceholderImage('weapon', 'main')).toBe(
+			'/images/placeholders/placeholder-weapon-main.png'
+		)
+		expect(getPlaceholderImage('summon', 'square')).toBe(
+			'/images/placeholders/placeholder-summon-square.png'
+		)
+	})
+})
+
+describe('getGenericPlaceholder', () => {
+	it('returns weapon-grid placeholder', () => {
+		expect(getGenericPlaceholder()).toBe('/images/placeholders/placeholder-weapon-grid.png')
+	})
+})
+
+// ============================================================================
+// getCharacterPose
+// ============================================================================
+
+describe('getCharacterPose', () => {
+	it('returns 01 with no args', () => {
+		expect(getCharacterPose()).toBe('01')
+	})
+
+	it('returns 01 for uncap <= 2', () => {
+		expect(getCharacterPose(0)).toBe('01')
+		expect(getCharacterPose(1)).toBe('01')
+		expect(getCharacterPose(2)).toBe('01')
+	})
+
+	it('returns 02 for uncap 3-4', () => {
+		expect(getCharacterPose(3)).toBe('02')
+		expect(getCharacterPose(4)).toBe('02')
+	})
+
+	it('returns 03 for uncap >= 5', () => {
+		expect(getCharacterPose(5)).toBe('03')
+		expect(getCharacterPose(6)).toBe('03')
+	})
+
+	it('returns 04 for transcendence > 0', () => {
+		expect(getCharacterPose(5, 1)).toBe('04')
+		expect(getCharacterPose(6, 3)).toBe('04')
+	})
+
+	it('transcendence 0 does not trigger 04', () => {
+		expect(getCharacterPose(5, 0)).toBe('03')
+	})
+})
+
+// ============================================================================
+// getImageUrl
+// ============================================================================
+
+describe('getImageUrl', () => {
+	it('returns placeholder when id is null/undefined', () => {
+		expect(getImageUrl('character', null, 'grid')).toBe(
+			'/images/placeholders/placeholder-character-grid.png'
+		)
+		expect(getImageUrl('weapon', undefined, 'main')).toBe(
+			'/images/placeholders/placeholder-weapon-main.png'
+		)
+	})
+
+	it('returns character URL with pose', () => {
+		expect(getImageUrl('character', '3040001', 'main', { pose: '02' })).toBe(
+			'/images/character-main/3040001_02.jpg'
+		)
+	})
+
+	it('defaults character pose to 01', () => {
+		expect(getImageUrl('character', '3040001', 'grid')).toBe(
+			'/images/character-grid/3040001_01.jpg'
+		)
+	})
+
+	it('returns weapon URL without element', () => {
+		expect(getImageUrl('weapon', '1040001', 'main')).toBe('/images/weapon-main/1040001.jpg')
+	})
+
+	it('returns weapon grid URL with element suffix', () => {
+		expect(getImageUrl('weapon', '1040001', 'grid', { element: 3 })).toBe(
+			'/images/weapon-grid/1040001_3.jpg'
+		)
+	})
+
+	it('weapon grid element 0 is valid', () => {
+		expect(getImageUrl('weapon', '1040001', 'grid', { element: 0 })).toBe(
+			'/images/weapon-grid/1040001_0.jpg'
+		)
+	})
+
+	it('returns summon URL', () => {
+		expect(getImageUrl('summon', '2040001', 'main')).toBe('/images/summon-main/2040001.jpg')
+	})
+
+	describe('file extensions', () => {
+		it('uses .png for character-detail', () => {
+			expect(getImageUrl('character', '3040001', 'detail', { pose: '01' })).toMatch(/\.png$/)
+		})
+
+		it('uses .png for weapon-base', () => {
+			expect(getImageUrl('weapon', '1040001', 'base')).toMatch(/\.png$/)
+		})
+
+		it('uses .png for summon-detail', () => {
+			expect(getImageUrl('summon', '2040001', 'detail')).toMatch(/\.png$/)
+		})
+
+		it('uses .jpg for everything else', () => {
+			expect(getImageUrl('character', '3040001', 'grid')).toMatch(/\.jpg$/)
+			expect(getImageUrl('weapon', '1040001', 'main')).toMatch(/\.jpg$/)
+			expect(getImageUrl('summon', '2040001', 'grid')).toMatch(/\.jpg$/)
+		})
+	})
+})
+
+// ============================================================================
+// Convenience functions
+// ============================================================================
+
+describe('getCharacterImage', () => {
+	it('defaults to main variant', () => {
+		expect(getCharacterImage('3040001')).toBe('/images/character-main/3040001_01.jpg')
+	})
+
+	it('accepts pose override', () => {
+		expect(getCharacterImage('3040001', 'grid', '03')).toBe(
+			'/images/character-grid/3040001_03.jpg'
+		)
+	})
+
+	it('returns placeholder for null', () => {
+		expect(getCharacterImage(null)).toContain('placeholder')
+	})
+})
+
+describe('getCharacterDetailImage', () => {
+	it('returns detail PNG', () => {
+		expect(getCharacterDetailImage('3040001', '02')).toBe(
+			'/images/character-detail/3040001_02.png'
+		)
+	})
+})
+
+describe('getWeaponImage', () => {
+	it('defaults to main variant', () => {
+		expect(getWeaponImage('1040001')).toBe('/images/weapon-main/1040001.jpg')
+	})
+
+	it('returns placeholder for null', () => {
+		expect(getWeaponImage(null)).toContain('placeholder')
+	})
+
+	it('adds element suffix for grid variant', () => {
+		expect(getWeaponImage('1040001', 'grid', 2)).toBe('/images/weapon-grid/1040001_2.jpg')
+	})
+
+	it('element 0 produces _0 suffix', () => {
+		expect(getWeaponImage('1040001', 'grid', 0)).toBe('/images/weapon-grid/1040001_0.jpg')
+	})
+
+	it('adds transformation suffix', () => {
+		expect(getWeaponImage('1040001', 'main', undefined, '02')).toBe(
+			'/images/weapon-main/1040001_02.jpg'
+		)
+	})
+})
+
+describe('getWeaponBaseImage', () => {
+	it('returns base PNG', () => {
+		expect(getWeaponBaseImage('1040001')).toBe('/images/weapon-base/1040001.png')
+	})
+})
+
+describe('getSummonImage', () => {
+	it('defaults to main', () => {
+		expect(getSummonImage('2040001')).toBe('/images/summon-main/2040001.jpg')
+	})
+
+	it('adds transformation suffix', () => {
+		expect(getSummonImage('2040001', 'main', '02')).toBe('/images/summon-main/2040001_02.jpg')
+	})
+
+	it('returns placeholder for null', () => {
+		expect(getSummonImage(null)).toContain('placeholder')
+	})
+})
+
+describe('getSummonDetailImage', () => {
+	it('returns detail PNG', () => {
+		expect(getSummonDetailImage('2040001')).toBe('/images/summon-detail/2040001.png')
+	})
+})
+
+describe('getSummonWideImage', () => {
+	it('returns wide JPG', () => {
+		expect(getSummonWideImage('2040001')).toBe('/images/summon-wide/2040001.jpg')
+	})
+})
+
+// ============================================================================
+// Special handlers
+// ============================================================================
+
+describe('getCharacterImageWithPose', () => {
+	it('returns placeholder for null id', () => {
+		expect(getCharacterImageWithPose(null, 'grid')).toContain('placeholder')
+	})
+
+	it('calculates pose from uncap/transcendence', () => {
+		expect(getCharacterImageWithPose('3040001', 'main', 3)).toBe(
+			'/images/character-main/3040001_02.jpg'
+		)
+		expect(getCharacterImageWithPose('3040001', 'main', 5)).toBe(
+			'/images/character-main/3040001_03.jpg'
+		)
+		expect(getCharacterImageWithPose('3040001', 'main', 5, 1)).toBe(
+			'/images/character-main/3040001_04.jpg'
+		)
+	})
+
+	it('handles Gran/Djeeta (3030182000) with element suffix', () => {
+		const url = getCharacterImageWithPose('3030182000', 'main', 3, 0, 2, null)
+		expect(url).toBe('/images/character-main/3030182000_02_02.jpg')
+	})
+
+	it('Gran/Djeeta falls back to partyElement then 1', () => {
+		const withParty = getCharacterImageWithPose('3030182000', 'main', 0, 0, null, 5)
+		expect(withParty).toContain('_01_05')
+
+		const noElement = getCharacterImageWithPose('3030182000', 'main', 0, 0, null, null)
+		expect(noElement).toContain('_01_01')
+	})
+})
+
+describe('getWeaponGridImage', () => {
+	it('returns grid URL without element for normal weapons', () => {
+		expect(getWeaponGridImage('1040001')).toBe('/images/weapon-grid/1040001.jpg')
+	})
+
+	it('handles element-changeable weapons (element === 0) with instance element', () => {
+		expect(getWeaponGridImage('1040001', 0, 3)).toBe('/images/weapon-grid/1040001_3.jpg')
+	})
+
+	it('element-changeable without instanceElement defaults to 0', () => {
+		expect(getWeaponGridImage('1040001', 0)).toBe('/images/weapon-grid/1040001_0.jpg')
+	})
+
+	it('returns placeholder for null id', () => {
+		expect(getWeaponGridImage(null)).toContain('placeholder')
+	})
+})
+
+// ============================================================================
+// Job/Accessory images
+// ============================================================================
+
+describe('getJobSkillIcon', () => {
+	it('returns default for undefined', () => {
+		expect(getJobSkillIcon(undefined)).toBe('/images/job-skills/default.png')
+	})
+
+	it('handles string input', () => {
+		expect(getJobSkillIcon('rage-iv')).toBe('/images/job-skills/rage-iv.png')
+	})
+
+	it('uses slug from object', () => {
+		expect(getJobSkillIcon({ slug: 'miserable-mist' })).toBe(
+			'/images/job-skills/miserable-mist.png'
+		)
+	})
+
+	it('returns default when object has no slug', () => {
+		expect(getJobSkillIcon({})).toBe('/images/job-skills/default.png')
+	})
+})
+
+describe('getAccessoryImage', () => {
+	it('returns accessory URL', () => {
+		expect(getAccessoryImage('399001')).toBe('/images/accessory-square/399001.jpg')
+	})
+
+	it('returns generic placeholder for undefined', () => {
+		expect(getAccessoryImage(undefined)).toContain('placeholder')
+	})
+})
+
+// ============================================================================
+// Modification images
+// ============================================================================
+
+describe('getAwakeningImage', () => {
+	it('returns awakening URL with default jpg', () => {
+		expect(getAwakeningImage('attack')).toBe('/images/awakening/attack.jpg')
+	})
+
+	it('supports png extension', () => {
+		expect(getAwakeningImage('attack', 'png')).toBe('/images/awakening/attack.png')
+	})
+
+	it('returns empty string for undefined', () => {
+		expect(getAwakeningImage(undefined)).toBe('')
+	})
+})
+
+describe('getWeaponKeyImage', () => {
+	it('returns key image without element', () => {
+		expect(getWeaponKeyImage('alpha')).toBe('/images/weapon-keys/alpha.png')
+	})
+
+	it('adds element suffix for elemental keys', () => {
+		expect(getWeaponKeyImage('pendulum', 3)).toBe('/images/weapon-keys/pendulum-3.png')
+		expect(getWeaponKeyImage('elemental-teluma', 1)).toBe(
+			'/images/weapon-keys/elemental-teluma-1.png'
+		)
+		expect(getWeaponKeyImage('chain-of-causality', 5)).toBe(
+			'/images/weapon-keys/chain-of-causality-5.png'
+		)
+		expect(getWeaponKeyImage('ultima', 2)).toBe('/images/weapon-keys/ultima-2.png')
+	})
+
+	it('does not add element for non-elemental keys', () => {
+		expect(getWeaponKeyImage('alpha', 3)).toBe('/images/weapon-keys/alpha.png')
+	})
+})
+
+describe('getAxSkillImage', () => {
+	it('returns ax URL', () => {
+		expect(getAxSkillImage('might')).toBe('/images/ax/might.png')
+	})
+
+	it('returns empty string for undefined', () => {
+		expect(getAxSkillImage(undefined)).toBe('')
+	})
+})
+
+describe('getMasteryImage', () => {
+	it('returns mastery URL', () => {
+		expect(getMasteryImage('atk')).toBe('/images/mastery/atk.png')
+	})
+
+	it('returns empty string for undefined', () => {
+		expect(getMasteryImage(undefined)).toBe('')
+	})
+})
+
+// ============================================================================
+// Label images
+// ============================================================================
+
+describe('getElementLabelImage', () => {
+	it('capitalizes element name', () => {
+		expect(getElementLabelImage('fire')).toBe('/images/labels/element/Label_Element_Fire.png')
+		expect(getElementLabelImage('WIND')).toBe('/images/labels/element/Label_Element_Wind.png')
+	})
+})
+
+describe('getProficiencyLabelImage', () => {
+	it('capitalizes proficiency name', () => {
+		expect(getProficiencyLabelImage('sword')).toBe(
+			'/images/labels/proficiency/Label_Weapon_Sword.png'
+		)
+	})
+})
+
+describe('getRaceLabelImage', () => {
+	it('returns race label path', () => {
+		expect(getRaceLabelImage('Human')).toBe('/images/labels/race/Label_Race_Human.png')
+	})
+})
+
+describe('getGenderLabelImage', () => {
+	it('replaces / with _ in gender label', () => {
+		expect(getGenderLabelImage('Male/Female')).toBe(
+			'/images/labels/gender/Label_Gender_Male_Female.png'
+		)
+	})
+
+	it('handles simple label', () => {
+		expect(getGenderLabelImage('Male')).toBe('/images/labels/gender/Label_Gender_Male.png')
+	})
+})
+
+// ============================================================================
+// Element icons
+// ============================================================================
+
+describe('getElementIcon', () => {
+	it('maps element IDs to names', () => {
+		expect(getElementIcon(1)).toBe('/images/elements/element-wind.png')
+		expect(getElementIcon(2)).toBe('/images/elements/element-fire.png')
+		expect(getElementIcon(3)).toBe('/images/elements/element-water.png')
+		expect(getElementIcon(4)).toBe('/images/elements/element-earth.png')
+		expect(getElementIcon(5)).toBe('/images/elements/element-dark.png')
+		expect(getElementIcon(6)).toBe('/images/elements/element-light.png')
+	})
+
+	it('returns none for unknown element', () => {
+		expect(getElementIcon(99)).toBe('/images/elements/element-none.png')
+	})
+})
+
+// ============================================================================
+// Artifact images
+// ============================================================================
+
+describe('getArtifactImage', () => {
+	it('returns square by default', () => {
+		expect(getArtifactImage('500001')).toBe('/images/artifact-square/500001.jpg')
+	})
+
+	it('returns wide variant', () => {
+		expect(getArtifactImage('500001', 'wide')).toBe('/images/artifact-wide/500001.jpg')
+	})
+
+	it('returns generic placeholder for null', () => {
+		expect(getArtifactImage(null)).toContain('placeholder')
+	})
+})
+
+// ============================================================================
+// Game CDN images
+// ============================================================================
+
+describe('getGameCdnCharacterImage', () => {
+	it('returns CDN URL with pose', () => {
+		expect(getGameCdnCharacterImage('3040001')).toContain('npc/s/3040001_01.jpg')
+	})
+
+	it('accepts custom pose', () => {
+		expect(getGameCdnCharacterImage('3040001', '03')).toContain('npc/s/3040001_03.jpg')
+	})
+
+	it('returns placeholder for null', () => {
+		expect(getGameCdnCharacterImage(null)).toContain('placeholder')
+	})
+})
+
+describe('getGameCdnWeaponImage', () => {
+	it('returns CDN URL', () => {
+		expect(getGameCdnWeaponImage('1040001')).toContain('weapon/s/1040001.jpg')
+	})
+
+	it('returns placeholder for null', () => {
+		expect(getGameCdnWeaponImage(null)).toContain('placeholder')
+	})
+})
+
+describe('getGameCdnSummonImage', () => {
+	it('returns CDN URL', () => {
+		expect(getGameCdnSummonImage('2040001')).toContain('summon/s/2040001.jpg')
+	})
+
+	it('returns placeholder for null', () => {
+		expect(getGameCdnSummonImage(null)).toContain('placeholder')
+	})
+})
+
+// ============================================================================
+// Other game images
+// ============================================================================
+
+describe('getGuidebookImage', () => {
+	it('returns guidebook URL', () => {
+		expect(getGuidebookImage('101')).toBe('/images/guidebooks/book_101.png')
+	})
+
+	it('returns generic placeholder for undefined', () => {
+		expect(getGuidebookImage(undefined)).toContain('placeholder')
+	})
+})
+
+// ============================================================================
+// Raid images
+// ============================================================================
+
+describe('getRaidImage', () => {
+	it('returns stored raid image by variant', () => {
+		expect(getRaidImage('proto-bahamut', 'icon')).toBe(
+			'/images/raid-icon/proto-bahamut.png'
+		)
+		expect(getRaidImage('proto-bahamut', 'thumbnail')).toBe(
+			'/images/raid-thumbnail/proto-bahamut.png'
+		)
+	})
+
+	it('defaults to thumbnail', () => {
+		expect(getRaidImage('proto-bahamut')).toBe('/images/raid-thumbnail/proto-bahamut.png')
+	})
+
+	it('returns generic placeholder for undefined', () => {
+		expect(getRaidImage(undefined)).toContain('placeholder')
+	})
+})
+
+describe('getRaidCdnImage', () => {
+	it('returns icon from enemy CDN', () => {
+		expect(getRaidCdnImage('icon', 12345)).toContain('/enemy/m/12345.png')
+	})
+
+	it('returns thumbnail with _high suffix', () => {
+		expect(getRaidCdnImage('thumbnail', 12345)).toContain('/summon/qm/12345_high.png')
+	})
+
+	it('returns lobby with 1 suffix', () => {
+		expect(getRaidCdnImage('lobby', 12345)).toContain('/lobby/123451.png')
+	})
+
+	it('returns background with raid_image_new path', () => {
+		expect(getRaidCdnImage('background', 12345)).toContain('/12345/raid_image_new.png')
+	})
+
+	it('returns generic placeholder for undefined id', () => {
+		expect(getRaidCdnImage('icon', undefined)).toContain('placeholder')
+	})
+})
+
+// ============================================================================
+// Remote URL integration
+// ============================================================================
+
+describe('with remote base URL', () => {
+	beforeEach(() => {
+		mockedGetImageBaseUrl.mockReturnValue('https://cdn.example.com')
+	})
+
+	it('prefixes all paths with remote URL', () => {
+		expect(getCharacterImage('3040001')).toMatch(/^https:\/\/cdn\.example\.com\//)
+		expect(getWeaponImage('1040001')).toMatch(/^https:\/\/cdn\.example\.com\//)
+		expect(getSummonImage('2040001')).toMatch(/^https:\/\/cdn\.example\.com\//)
+		expect(getPlaceholderImage('character', 'grid')).toMatch(/^https:\/\/cdn\.example\.com\//)
+	})
+})

--- a/src/lib/utils/__tests__/jobAccessoryUtils.test.ts
+++ b/src/lib/utils/__tests__/jobAccessoryUtils.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import {
+	ACCESSORY_TYPES,
+	getAccessoryTypeName,
+	getAccessoryTypeOptions,
+	getJobAccessoryImageUrl
+} from '../jobAccessoryUtils'
+
+describe('ACCESSORY_TYPES', () => {
+	it('defines shield and manatura', () => {
+		expect(ACCESSORY_TYPES.SHIELD).toBe(1)
+		expect(ACCESSORY_TYPES.MANATURA).toBe(2)
+	})
+})
+
+describe('getAccessoryTypeName', () => {
+	it('returns Shield for type 1', () => {
+		expect(getAccessoryTypeName(1)).toBe('Shield')
+	})
+
+	it('returns Manatura for type 2', () => {
+		expect(getAccessoryTypeName(2)).toBe('Manatura')
+	})
+
+	it('returns Unknown for invalid type', () => {
+		expect(getAccessoryTypeName(99)).toBe('Unknown')
+	})
+})
+
+describe('getAccessoryTypeOptions', () => {
+	it('returns both options', () => {
+		const options = getAccessoryTypeOptions()
+		expect(options).toEqual([
+			{ value: 1, label: 'Shield' },
+			{ value: 2, label: 'Manatura' }
+		])
+	})
+})
+
+describe('getJobAccessoryImageUrl', () => {
+	it('returns shield path for type 1', () => {
+		expect(getJobAccessoryImageUrl('399001', 1)).toBe('/images/job-accessories/shield/399001.png')
+	})
+
+	it('returns manatura path for type 2', () => {
+		expect(getJobAccessoryImageUrl('399002', 2)).toBe(
+			'/images/job-accessories/manatura/399002.png'
+		)
+	})
+})

--- a/src/lib/utils/__tests__/jobSkills.test.ts
+++ b/src/lib/utils/__tests__/jobSkills.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { transformSkillsToArray, updateSkillInSlot } from '../jobSkills'
+import type { JobSkill } from '$lib/types/api/entities'
+import type { JobSkillsMap } from '../jobSkills'
+
+function makeSkill(id: string): JobSkill {
+	return {
+		id,
+		name: { en: `Skill ${id}`, ja: `スキル${id}` },
+		main: false,
+		sub: false,
+		emp: false,
+		base: false
+	} as JobSkill
+}
+
+// ============================================================================
+// transformSkillsToArray
+// ============================================================================
+
+describe('transformSkillsToArray', () => {
+	it('converts skills map to array with slot numbers', () => {
+		const map: JobSkillsMap = {
+			'0': makeSkill('s-1'),
+			'1': makeSkill('s-2')
+		}
+		const result = transformSkillsToArray(map)
+		expect(result).toEqual([
+			{ id: 's-1', slot: 0 },
+			{ id: 's-2', slot: 1 }
+		])
+	})
+
+	it('filters out null values', () => {
+		const map: JobSkillsMap = {
+			'0': makeSkill('s-1'),
+			'1': null,
+			'2': makeSkill('s-3')
+		}
+		const result = transformSkillsToArray(map)
+		expect(result).toHaveLength(2)
+		expect(result.map((r) => r.id)).toEqual(['s-1', 's-3'])
+	})
+
+	it('filters out undefined values', () => {
+		const map: JobSkillsMap = {
+			'0': makeSkill('s-1'),
+			'1': undefined
+		}
+		const result = transformSkillsToArray(map)
+		expect(result).toHaveLength(1)
+	})
+
+	it('returns empty array for empty map', () => {
+		expect(transformSkillsToArray({})).toEqual([])
+	})
+})
+
+// ============================================================================
+// updateSkillInSlot
+// ============================================================================
+
+describe('updateSkillInSlot', () => {
+	it('sets a skill in the specified slot', () => {
+		const current: JobSkillsMap = { '0': makeSkill('s-1') }
+		const result = updateSkillInSlot(current, 1, makeSkill('s-2'))
+		expect(result['1']!.id).toBe('s-2')
+	})
+
+	it('removes a skill when null is passed', () => {
+		const current: JobSkillsMap = { '0': makeSkill('s-1'), '1': makeSkill('s-2') }
+		const result = updateSkillInSlot(current, 1, null)
+		expect(result['1']).toBeUndefined()
+		expect('1' in result).toBe(false)
+	})
+
+	it('returns a new object (immutable)', () => {
+		const current: JobSkillsMap = { '0': makeSkill('s-1') }
+		const result = updateSkillInSlot(current, 1, makeSkill('s-2'))
+		expect(result).not.toBe(current)
+		expect(current['1']).toBeUndefined()
+	})
+
+	it('preserves existing slots', () => {
+		const current: JobSkillsMap = { '0': makeSkill('s-1'), '2': makeSkill('s-3') }
+		const result = updateSkillInSlot(current, 1, makeSkill('s-2'))
+		expect(result['0']!.id).toBe('s-1')
+		expect(result['2']!.id).toBe('s-3')
+	})
+})

--- a/src/lib/utils/__tests__/jobUtils.test.ts
+++ b/src/lib/utils/__tests__/jobUtils.test.ts
@@ -1,0 +1,416 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+	Gender,
+	getJobPortraitUrl,
+	getJobFullImageUrl,
+	getJobIconUrl,
+	getJobWideImageUrl,
+	getJobTierName,
+	getJobTierOrder,
+	jobSupportsAccessories,
+	getJobSkillSlotCount,
+	isSkillSlotAvailable,
+	isSkillSlotLocked,
+	getSkillCategoryName,
+	getSkillCategoryColor,
+	formatJobProficiency,
+	isAdvancedJob,
+	countSkillsByType,
+	validateSkillConfiguration
+} from '../jobUtils'
+import type { Job, JobSkill } from '$lib/types/api/entities'
+import type { JobSkillList } from '$lib/types/api/party'
+
+vi.mock('$lib/api/adapters/config', () => ({
+	getImageBaseUrl: vi.fn(() => '')
+}))
+
+vi.mock('../images', () => ({
+	getGenericPlaceholder: vi.fn(() => '/images/placeholders/placeholder-weapon-grid.png')
+}))
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+	return {
+		id: 'job-1',
+		granblueId: '100101',
+		name: { en: 'Dark Fencer', ja: 'ダークフェンサー' },
+		row: 3,
+		accessory: false,
+		...overrides
+	} as Job
+}
+
+function makeSkill(overrides: Partial<JobSkill> = {}): JobSkill {
+	return {
+		id: 'skill-1',
+		name: { en: 'Test Skill', ja: 'テストスキル' },
+		main: false,
+		sub: false,
+		emp: false,
+		base: false,
+		...overrides
+	} as JobSkill
+}
+
+// ============================================================================
+// URL Generators
+// ============================================================================
+
+describe('getJobPortraitUrl', () => {
+	it('returns placeholder for undefined job', () => {
+		expect(getJobPortraitUrl(undefined)).toContain('placeholder')
+	})
+
+	it('generates slug from job name with Gran (default)', () => {
+		const job = makeJob({ name: { en: 'Dark Fencer', ja: '' } })
+		const url = getJobPortraitUrl(job)
+		expect(url).toBe('/images/job-portraits/dark-fencer_a.png')
+	})
+
+	it('uses gender suffix b for Djeeta', () => {
+		const job = makeJob({ name: { en: 'Dark Fencer', ja: '' } })
+		const url = getJobPortraitUrl(job, Gender.Djeeta)
+		expect(url).toBe('/images/job-portraits/dark-fencer_b.png')
+	})
+})
+
+describe('getJobFullImageUrl', () => {
+	it('returns placeholder for undefined job', () => {
+		expect(getJobFullImageUrl(undefined)).toContain('placeholder')
+	})
+
+	it('uses granblueId with gender suffix', () => {
+		const job = makeJob({ granblueId: '100101' })
+		expect(getJobFullImageUrl(job)).toBe('/images/job-zoom/100101_a.png')
+		expect(getJobFullImageUrl(job, Gender.Djeeta)).toBe('/images/job-zoom/100101_b.png')
+	})
+})
+
+describe('getJobIconUrl', () => {
+	it('returns placeholder for undefined granblueId', () => {
+		expect(getJobIconUrl(undefined)).toContain('placeholder')
+	})
+
+	it('generates icon path from granblueId', () => {
+		expect(getJobIconUrl('100101')).toBe('/images/job-icons/100101.png')
+	})
+})
+
+describe('getJobWideImageUrl', () => {
+	it('returns placeholder for undefined job', () => {
+		expect(getJobWideImageUrl(undefined)).toContain('placeholder')
+	})
+
+	it('uses jpg extension and granblueId', () => {
+		const job = makeJob({ granblueId: '100101' })
+		expect(getJobWideImageUrl(job)).toBe('/images/job-wide/100101_a.jpg')
+	})
+})
+
+// ============================================================================
+// Tier Functions
+// ============================================================================
+
+describe('getJobTierName', () => {
+	it('maps numeric tiers', () => {
+		expect(getJobTierName('1')).toBe('Class I')
+		expect(getJobTierName('2')).toBe('Class II')
+		expect(getJobTierName('3')).toBe('Class III')
+		expect(getJobTierName('4')).toBe('Class IV')
+		expect(getJobTierName('5')).toBe('Class V')
+	})
+
+	it('maps EX tiers', () => {
+		expect(getJobTierName('ex')).toBe('EX')
+		expect(getJobTierName('ex1')).toBe('EX')
+		expect(getJobTierName('ex2')).toBe('EXII')
+	})
+
+	it('maps Origin tier', () => {
+		expect(getJobTierName('o1')).toBe('Origin I')
+	})
+
+	it('handles numeric input', () => {
+		expect(getJobTierName(1)).toBe('Class I')
+	})
+
+	it('falls back for unknown tiers', () => {
+		expect(getJobTierName('unknown')).toBe('Class unknown')
+	})
+})
+
+describe('getJobTierOrder', () => {
+	it('returns correct sort order', () => {
+		expect(getJobTierOrder('1')).toBe(1)
+		expect(getJobTierOrder('4')).toBe(4)
+		expect(getJobTierOrder('ex')).toBe(6)
+		expect(getJobTierOrder('ex2')).toBe(7)
+		expect(getJobTierOrder('o1')).toBe(8)
+	})
+
+	it('returns 99 for unknown tiers', () => {
+		expect(getJobTierOrder('xyz')).toBe(99)
+	})
+})
+
+// ============================================================================
+// Job Properties
+// ============================================================================
+
+describe('jobSupportsAccessories', () => {
+	it('returns true when accessory is true', () => {
+		expect(jobSupportsAccessories(makeJob({ accessory: true }))).toBe(true)
+	})
+
+	it('returns false when accessory is false', () => {
+		expect(jobSupportsAccessories(makeJob({ accessory: false }))).toBe(false)
+	})
+
+	it('returns false for undefined job', () => {
+		expect(jobSupportsAccessories(undefined)).toBe(false)
+	})
+})
+
+describe('getJobSkillSlotCount', () => {
+	it('returns 0 for undefined job', () => {
+		expect(getJobSkillSlotCount(undefined)).toBe(0)
+	})
+
+	it('returns 3 for row 1 jobs', () => {
+		expect(getJobSkillSlotCount(makeJob({ row: 1 }))).toBe(3)
+	})
+
+	it('returns 4 for other rows', () => {
+		expect(getJobSkillSlotCount(makeJob({ row: 3 }))).toBe(4)
+		expect(getJobSkillSlotCount(makeJob({ row: 4 }))).toBe(4)
+	})
+})
+
+describe('isSkillSlotAvailable', () => {
+	it('returns false for undefined job', () => {
+		expect(isSkillSlotAvailable(undefined, 0)).toBe(false)
+	})
+
+	it('returns true for valid slot within range', () => {
+		expect(isSkillSlotAvailable(makeJob({ row: 4 }), 3)).toBe(true)
+	})
+
+	it('returns false for slot out of range', () => {
+		expect(isSkillSlotAvailable(makeJob({ row: 1 }), 3)).toBe(false)
+	})
+
+	it('returns false for negative slot', () => {
+		expect(isSkillSlotAvailable(makeJob(), -1)).toBe(false)
+	})
+})
+
+describe('isSkillSlotLocked', () => {
+	it('returns true for slot 0 with main skill', () => {
+		const skills: JobSkillList = { 0: makeSkill({ main: true }) }
+		expect(isSkillSlotLocked(0, makeJob(), skills)).toBe(true)
+	})
+
+	it('returns false for slot 0 without main skill', () => {
+		const skills: JobSkillList = { 0: makeSkill({ sub: true }) }
+		expect(isSkillSlotLocked(0, makeJob(), skills)).toBe(false)
+	})
+
+	it('returns false for non-zero slots', () => {
+		const skills: JobSkillList = { 1: makeSkill({ main: true }) }
+		expect(isSkillSlotLocked(1, makeJob(), skills)).toBe(false)
+	})
+
+	it('returns false when skills is undefined', () => {
+		expect(isSkillSlotLocked(0, makeJob(), undefined)).toBe(false)
+	})
+})
+
+// ============================================================================
+// Skill Categories
+// ============================================================================
+
+describe('getSkillCategoryName', () => {
+	it('returns Main for main skill', () => {
+		expect(getSkillCategoryName(makeSkill({ main: true }))).toBe('Main')
+	})
+
+	it('returns Subskill for sub skill', () => {
+		expect(getSkillCategoryName(makeSkill({ sub: true }))).toBe('Subskill')
+	})
+
+	it('returns EMP for emp skill', () => {
+		expect(getSkillCategoryName(makeSkill({ emp: true }))).toBe('EMP')
+	})
+
+	it('returns Base for base skill', () => {
+		expect(getSkillCategoryName(makeSkill({ base: true }))).toBe('Base')
+	})
+
+	it('returns Unknown when no type set', () => {
+		expect(getSkillCategoryName(makeSkill())).toBe('Unknown')
+	})
+})
+
+describe('getSkillCategoryColor', () => {
+	it('returns correct color for each type', () => {
+		expect(getSkillCategoryColor(makeSkill({ main: true }))).toContain('--skill-main')
+		expect(getSkillCategoryColor(makeSkill({ sub: true }))).toContain('--skill-sub')
+		expect(getSkillCategoryColor(makeSkill({ emp: true }))).toContain('--skill-emp')
+		expect(getSkillCategoryColor(makeSkill({ base: true }))).toContain('--skill-base')
+		expect(getSkillCategoryColor(makeSkill())).toContain('--skill-default')
+	})
+})
+
+// ============================================================================
+// Proficiency
+// ============================================================================
+
+describe('formatJobProficiency', () => {
+	it('maps both proficiency values', () => {
+		expect(formatJobProficiency([1, 2])).toEqual(['Sabre', 'Dagger'])
+	})
+
+	it('handles single proficiency', () => {
+		expect(formatJobProficiency([1, 0])).toEqual(['Sabre'])
+	})
+
+	it('handles no proficiency', () => {
+		expect(formatJobProficiency([0, 0])).toEqual([])
+	})
+
+	it('maps all weapon types', () => {
+		expect(formatJobProficiency([7, 10])).toEqual(['Melee', 'Katana'])
+	})
+})
+
+// ============================================================================
+// Advanced Jobs
+// ============================================================================
+
+describe('isAdvancedJob', () => {
+	it('returns true for row 4', () => {
+		expect(isAdvancedJob(makeJob({ row: 4 }))).toBe(true)
+	})
+
+	it('returns true for row 5', () => {
+		expect(isAdvancedJob(makeJob({ row: 5 }))).toBe(true)
+	})
+
+	it('returns true for ex2', () => {
+		expect(isAdvancedJob(makeJob({ row: 'ex2' as any }))).toBe(true)
+	})
+
+	it('returns false for row 1', () => {
+		expect(isAdvancedJob(makeJob({ row: 1 }))).toBe(false)
+	})
+
+	it('returns false for row 3', () => {
+		expect(isAdvancedJob(makeJob({ row: 3 }))).toBe(false)
+	})
+})
+
+// ============================================================================
+// Skill Counting & Validation
+// ============================================================================
+
+describe('countSkillsByType', () => {
+	it('counts skills by type', () => {
+		const skills: JobSkillList = {
+			0: makeSkill({ main: true }),
+			1: makeSkill({ sub: true }),
+			2: makeSkill({ emp: true }),
+			3: makeSkill({ base: true })
+		}
+		expect(countSkillsByType(skills)).toEqual({ main: 1, sub: 1, emp: 1, base: 1 })
+	})
+
+	it('handles empty skills', () => {
+		expect(countSkillsByType({} as JobSkillList)).toEqual({ main: 0, sub: 0, emp: 0, base: 0 })
+	})
+
+	it('counts multiple of same type', () => {
+		const skills: JobSkillList = {
+			0: makeSkill({ sub: true, id: 's-1' }),
+			1: makeSkill({ sub: true, id: 's-2' }),
+			2: makeSkill({ emp: true, id: 's-3' })
+		}
+		expect(countSkillsByType(skills)).toEqual({ main: 0, sub: 2, emp: 1, base: 0 })
+	})
+})
+
+describe('validateSkillConfiguration', () => {
+	it('returns valid for correct configuration', () => {
+		const job = makeJob({ row: 4 })
+		const skills: JobSkillList = {
+			0: makeSkill({ main: true, id: 's-1' }),
+			1: makeSkill({ sub: true, id: 's-2' }),
+			2: makeSkill({ emp: true, id: 's-3' })
+		}
+		const result = validateSkillConfiguration(job, skills)
+		expect(result.valid).toBe(true)
+		expect(result.errors).toHaveLength(0)
+	})
+
+	it('errors when advanced job has >2 subskills', () => {
+		const job = makeJob({ row: 4 })
+		const skills: JobSkillList = {
+			0: makeSkill({ sub: true, id: 's-1' }),
+			1: makeSkill({ sub: true, id: 's-2' }),
+			2: makeSkill({ sub: true, id: 's-3' })
+		}
+		const result = validateSkillConfiguration(job, skills)
+		expect(result.valid).toBe(false)
+		expect(result.errors).toContainEqual(expect.stringContaining('subskills'))
+	})
+
+	it('errors when advanced job has >2 EMP skills', () => {
+		const job = makeJob({ row: 4 })
+		const skills: JobSkillList = {
+			0: makeSkill({ emp: true, id: 's-1' }),
+			1: makeSkill({ emp: true, id: 's-2' }),
+			2: makeSkill({ emp: true, id: 's-3' })
+		}
+		const result = validateSkillConfiguration(job, skills)
+		expect(result.valid).toBe(false)
+		expect(result.errors).toContainEqual(expect.stringContaining('EMP'))
+	})
+
+	it('errors when row 1 job has 4th skill', () => {
+		const job = makeJob({ row: 1 })
+		const skills: JobSkillList = {
+			0: makeSkill({ id: 's-1' }),
+			1: makeSkill({ id: 's-2' }),
+			2: makeSkill({ id: 's-3' }),
+			3: makeSkill({ id: 's-4' })
+		}
+		const result = validateSkillConfiguration(job, skills)
+		expect(result.valid).toBe(false)
+		expect(result.errors).toContainEqual(expect.stringContaining('Row I'))
+	})
+
+	it('errors on duplicate skills', () => {
+		const job = makeJob({ row: 4 })
+		const skills: JobSkillList = {
+			0: makeSkill({ id: 'same-id', main: true }),
+			1: makeSkill({ id: 'same-id', sub: true })
+		}
+		const result = validateSkillConfiguration(job, skills)
+		expect(result.valid).toBe(false)
+		expect(result.errors).toContainEqual(expect.stringContaining('Duplicate'))
+	})
+
+	it('allows >2 subskills for non-advanced jobs', () => {
+		const job = makeJob({ row: 3 })
+		const skills: JobSkillList = {
+			0: makeSkill({ sub: true, id: 's-1' }),
+			1: makeSkill({ sub: true, id: 's-2' }),
+			2: makeSkill({ sub: true, id: 's-3' })
+		}
+		const result = validateSkillConfiguration(job, skills)
+		expect(result.valid).toBe(true)
+	})
+})

--- a/src/lib/utils/__tests__/masteryUtils.test.ts
+++ b/src/lib/utils/__tests__/masteryUtils.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+import {
+	getRingMasteryCategory,
+	getRingStat,
+	getEarringStat,
+	getElementalizedEarringStat
+} from '../masteryUtils'
+import { overMastery, aetherialMastery } from '$lib/data/overMastery'
+
+// ============================================================================
+// getRingMasteryCategory
+// ============================================================================
+
+describe('getRingMasteryCategory', () => {
+	it('returns primary (a) for modifiers 1-2', () => {
+		expect(getRingMasteryCategory(1)).toBe(overMastery.a)
+		expect(getRingMasteryCategory(2)).toBe(overMastery.a)
+	})
+
+	it('returns secondary (b) for modifiers 3-9', () => {
+		expect(getRingMasteryCategory(3)).toBe(overMastery.b)
+		expect(getRingMasteryCategory(9)).toBe(overMastery.b)
+	})
+
+	it('returns tertiary (c) for modifiers 10+', () => {
+		expect(getRingMasteryCategory(10)).toBe(overMastery.c)
+		expect(getRingMasteryCategory(15)).toBe(overMastery.c)
+	})
+})
+
+// ============================================================================
+// getRingStat
+// ============================================================================
+
+describe('getRingStat', () => {
+	it('finds ATK (modifier 1)', () => {
+		const stat = getRingStat(1)
+		expect(stat).toBeDefined()
+		expect(stat!.name.en).toBe('ATK')
+	})
+
+	it('finds HP (modifier 2)', () => {
+		const stat = getRingStat(2)
+		expect(stat!.name.en).toBe('HP')
+	})
+
+	it('finds secondary stats (3-9)', () => {
+		const stat = getRingStat(3)
+		expect(stat).toBeDefined()
+		expect(stat!.name.en).toBe('Debuff Success')
+	})
+
+	it('finds tertiary stats (10+)', () => {
+		const stat = getRingStat(10)
+		expect(stat).toBeDefined()
+		expect(stat!.name.en).toBe('Double Attack')
+	})
+
+	it('returns undefined for non-existent modifier', () => {
+		expect(getRingStat(999)).toBeUndefined()
+	})
+})
+
+// ============================================================================
+// getEarringStat
+// ============================================================================
+
+describe('getEarringStat', () => {
+	it('finds Double Attack (modifier 1)', () => {
+		const stat = getEarringStat(1)
+		expect(stat).toBeDefined()
+		expect(stat!.name.en).toBe('Double Attack')
+	})
+
+	it('finds element ATK (modifier 3) with placeholder', () => {
+		const stat = getEarringStat(3)
+		expect(stat!.name.en).toContain('{Element}')
+	})
+
+	it('returns undefined for non-existent modifier', () => {
+		expect(getEarringStat(999)).toBeUndefined()
+	})
+})
+
+// ============================================================================
+// getElementalizedEarringStat
+// ============================================================================
+
+describe('getElementalizedEarringStat', () => {
+	it('substitutes element name for modifier 3 (en)', () => {
+		const stat = getElementalizedEarringStat(3, 2, 'en')
+		expect(stat).toBeDefined()
+		expect(stat!.name.en).toContain('Fire')
+		expect(stat!.name.en).not.toContain('{Element}')
+		expect(stat!.slug).toBe('ele-2')
+	})
+
+	it('substitutes element name for modifier 3 (ja)', () => {
+		const stat = getElementalizedEarringStat(3, 1, 'ja')
+		expect(stat!.name.ja).toContain('風')
+		expect(stat!.name.ja).not.toContain('{属性}')
+	})
+
+	it('substitutes opposite element for modifier 4', () => {
+		// Fire (2) → opposite is Water (3)
+		const stat = getElementalizedEarringStat(4, 2, 'en')
+		expect(stat).toBeDefined()
+		expect(stat!.name.en).toContain('Water')
+		expect(stat!.slug).toBe('ele-3')
+	})
+
+	it('returns unmodified stat for non-element modifiers', () => {
+		const stat = getElementalizedEarringStat(1, 2)
+		expect(stat!.name.en).toBe('Double Attack')
+	})
+
+	it('returns undefined for non-existent modifier', () => {
+		expect(getElementalizedEarringStat(999, 1)).toBeUndefined()
+	})
+
+	it('does not mutate original data', () => {
+		const original = getEarringStat(3)
+		const originalName = original!.name.en
+		getElementalizedEarringStat(3, 2)
+		expect(getEarringStat(3)!.name.en).toBe(originalName)
+	})
+})

--- a/src/lib/utils/__tests__/modificationDetector.test.ts
+++ b/src/lib/utils/__tests__/modificationDetector.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+	detectModifications,
+	hasAnyModification,
+	canWeaponBeModified,
+	canCharacterBeModified
+} from '../modificationDetector'
+import type { GridCharacter, GridWeapon, GridSummon } from '$lib/types/api/party'
+
+vi.mock('$lib/utils/weaponSeries', () => ({
+	seriesHasWeaponKeys: vi.fn((series) => series?.hasWeaponKeys === true)
+}))
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeGridCharacter(overrides: Partial<GridCharacter> = {}): GridCharacter {
+	return {
+		id: 'gc-1',
+		position: 1,
+		character: {
+			id: 'c-1',
+			granblueId: '3040001000',
+			name: { en: 'Test Char', ja: 'テスト' },
+			element: 1,
+			rarity: 3,
+			maxLevel: 100,
+			uncap: { flb: false, ulb: false },
+			special: false,
+			recruits: null,
+			gender: 1,
+			race: { race1: 1, race2: 0 },
+			proficiency: [1]
+		},
+		...overrides
+	} as GridCharacter
+}
+
+function makeGridWeapon(overrides: Partial<GridWeapon> = {}): GridWeapon {
+	return {
+		id: 'gw-1',
+		position: 0,
+		weapon: {
+			id: 'w-1',
+			granblueId: '1040001000',
+			name: { en: 'Test Weapon', ja: 'テスト武器' },
+			element: 1,
+			proficiency: 1,
+			rarity: 3,
+			maxLevel: 150,
+			maxSkillLevel: 15,
+			maxAwakeningLevel: 0,
+			series: null,
+			ax: false,
+			axType: 0,
+			hp: { minHp: 0, maxHp: 100, maxHpFlb: 120, maxHpUlb: 140 },
+			atk: { minAtk: 0, maxAtk: 1000, maxAtkFlb: 1200, maxAtkUlb: 1400 }
+		},
+		...overrides
+	} as GridWeapon
+}
+
+function makeGridSummon(overrides: Partial<GridSummon> = {}): GridSummon {
+	return {
+		id: 'gs-1',
+		position: 0,
+		summon: {
+			id: 's-1',
+			granblueId: '2040001000',
+			name: { en: 'Test Summon', ja: 'テスト召喚' },
+			element: 1,
+			rarity: 3,
+			maxLevel: 150,
+			uncap: { flb: false, ulb: false, transcendence: false },
+			subaura: false,
+			hp: { minHp: 0, maxHp: 100, maxHpFlb: 120, maxHpUlb: 140 },
+			atk: { minAtk: 0, maxAtk: 500, maxAtkFlb: 600, maxAtkUlb: 700 }
+		},
+		...overrides
+	} as GridSummon
+}
+
+// ============================================================================
+// detectModifications
+// ============================================================================
+
+describe('detectModifications', () => {
+	it('returns all false for undefined item', () => {
+		const status = detectModifications('character', undefined)
+		expect(status.hasModifications).toBe(false)
+		expect(status.hasAwakening).toBe(false)
+		expect(status.hasRings).toBe(false)
+	})
+
+	// --- Character ---
+
+	it('detects character awakening', () => {
+		const char = makeGridCharacter({ awakening: { type: { id: 'a-1' } as any, level: 1 } })
+		const status = detectModifications('character', char)
+		expect(status.hasAwakening).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('detects character rings (overMastery)', () => {
+		const char = makeGridCharacter({ overMastery: [{ modifier: 1, strength: 10 }] })
+		const status = detectModifications('character', char)
+		expect(status.hasRings).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('detects character earring (aetherialMastery)', () => {
+		const char = makeGridCharacter({ aetherialMastery: { modifier: 1, strength: 5 } })
+		const status = detectModifications('character', char)
+		expect(status.hasEarring).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('detects character perpetuity', () => {
+		const char = makeGridCharacter({ perpetuity: true })
+		const status = detectModifications('character', char)
+		expect(status.hasPerpetuity).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('detects character transcendence', () => {
+		const char = makeGridCharacter({ transcendenceStep: 3 })
+		const status = detectModifications('character', char)
+		expect(status.hasTranscendence).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('detects character uncapLevel', () => {
+		const char = makeGridCharacter({ uncapLevel: 4 })
+		const status = detectModifications('character', char)
+		expect(status.hasUncapLevel).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('returns no character modifications when all empty', () => {
+		const char = makeGridCharacter()
+		const status = detectModifications('character', char)
+		expect(status.hasModifications).toBe(false)
+	})
+
+	// --- Weapon ---
+
+	it('detects weapon awakening', () => {
+		const weapon = makeGridWeapon({ awakening: { type: { id: 'a-1' } as any, level: 1 } })
+		const status = detectModifications('weapon', weapon)
+		expect(status.hasAwakening).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('detects weapon keys', () => {
+		const weapon = makeGridWeapon({ weaponKeys: [{ id: 'k-1' } as any] })
+		const status = detectModifications('weapon', weapon)
+		expect(status.hasWeaponKeys).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('detects weapon ax skills', () => {
+		const weapon = makeGridWeapon({ ax: [{ modifier: 1, strength: 5 } as any] })
+		const status = detectModifications('weapon', weapon)
+		expect(status.hasAxSkills).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('detects weapon befoulment', () => {
+		const weapon = makeGridWeapon({ befoulment: { modifier: 1 } as any })
+		const status = detectModifications('weapon', weapon)
+		expect(status.hasBefoulment).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('detects weapon element change (element set, base element 0)', () => {
+		const weapon = makeGridWeapon({ element: 3 })
+		// Need weapon.element === 0 on the nested weapon
+		weapon.weapon.element = 0
+		const status = detectModifications('weapon', weapon)
+		expect(status.hasElement).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('does not flag element when base weapon element is not 0', () => {
+		const weapon = makeGridWeapon({ element: 3 })
+		weapon.weapon.element = 1 // not zero
+		const status = detectModifications('weapon', weapon)
+		expect(status.hasElement).toBe(false)
+	})
+
+	// --- Summon ---
+
+	it('detects summon transcendence', () => {
+		const summon = makeGridSummon({ transcendenceStep: 2 })
+		const status = detectModifications('summon', summon)
+		expect(status.hasTranscendence).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('detects summon quickSummon', () => {
+		const summon = makeGridSummon({ quickSummon: true })
+		const status = detectModifications('summon', summon)
+		expect(status.hasQuickSummon).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('detects summon friend flag', () => {
+		const summon = makeGridSummon({ friend: true })
+		const status = detectModifications('summon', summon)
+		expect(status.hasFriendSummon).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+
+	it('detects summon uncapLevel', () => {
+		const summon = makeGridSummon({ uncapLevel: 3 })
+		const status = detectModifications('summon', summon)
+		expect(status.hasUncapLevel).toBe(true)
+		expect(status.hasModifications).toBe(true)
+	})
+})
+
+// ============================================================================
+// hasAnyModification
+// ============================================================================
+
+describe('hasAnyModification', () => {
+	it('returns false for unmodified item', () => {
+		expect(hasAnyModification('character', makeGridCharacter())).toBe(false)
+	})
+
+	it('returns true when any modification exists', () => {
+		const char = makeGridCharacter({ perpetuity: true })
+		expect(hasAnyModification('character', char)).toBe(true)
+	})
+
+	it('returns false for undefined', () => {
+		expect(hasAnyModification('weapon', undefined)).toBe(false)
+	})
+})
+
+// ============================================================================
+// canWeaponBeModified
+// ============================================================================
+
+describe('canWeaponBeModified', () => {
+	it('returns false for undefined', () => {
+		expect(canWeaponBeModified(undefined)).toBe(false)
+	})
+
+	it('returns false when weapon has no nested weapon', () => {
+		expect(canWeaponBeModified({} as any)).toBe(false)
+	})
+
+	it('returns true when weapon element is 0 (any element)', () => {
+		const weapon = makeGridWeapon()
+		weapon.weapon.element = 0
+		expect(canWeaponBeModified(weapon)).toBe(true)
+	})
+
+	it('returns true when series has weapon keys', () => {
+		const weapon = makeGridWeapon()
+		weapon.weapon.series = {
+			id: 'ws-1',
+			slug: 'test-series',
+			name: { en: 'Test', ja: 'テスト' },
+			hasWeaponKeys: true,
+			hasAwakening: false,
+			augmentType: 'no_augment',
+			extra: false,
+			elementChangeable: false
+		}
+		expect(canWeaponBeModified(weapon)).toBe(true)
+	})
+
+	it('returns true when series has augments (ax)', () => {
+		const weapon = makeGridWeapon()
+		weapon.weapon.series = {
+			id: 'ws-1',
+			slug: 'test-series',
+			name: { en: 'Test', ja: 'テスト' },
+			hasWeaponKeys: false,
+			hasAwakening: false,
+			augmentType: 'ax',
+			extra: false,
+			elementChangeable: false
+		}
+		expect(canWeaponBeModified(weapon)).toBe(true)
+	})
+
+	it('returns true when weapon has awakening', () => {
+		const weapon = makeGridWeapon()
+		weapon.weapon.maxAwakeningLevel = 5
+		expect(canWeaponBeModified(weapon)).toBe(true)
+	})
+
+	it('returns false when nothing is modifiable', () => {
+		const weapon = makeGridWeapon()
+		weapon.weapon.element = 1 // not zero
+		weapon.weapon.maxAwakeningLevel = 0
+		weapon.weapon.series = null
+		expect(canWeaponBeModified(weapon)).toBe(false)
+	})
+})
+
+// ============================================================================
+// canCharacterBeModified
+// ============================================================================
+
+describe('canCharacterBeModified', () => {
+	it('returns false for undefined', () => {
+		expect(canCharacterBeModified(undefined)).toBe(false)
+	})
+
+	it('returns false when no nested character', () => {
+		expect(canCharacterBeModified({} as any)).toBe(false)
+	})
+
+	it('returns true for position 0 (MC) — can have rings and earring', () => {
+		const char = makeGridCharacter({ position: 0 })
+		expect(canCharacterBeModified(char)).toBe(true)
+	})
+
+	it('returns true for position > 0 — can have perpetuity', () => {
+		const char = makeGridCharacter({ position: 1 })
+		expect(canCharacterBeModified(char)).toBe(true)
+	})
+
+	it('returns true when character has awakening', () => {
+		const char = makeGridCharacter()
+		char.character.maxAwakeningLevel = 3
+		expect(canCharacterBeModified(char)).toBe(true)
+	})
+})

--- a/src/lib/utils/__tests__/modificationFormatters.test.ts
+++ b/src/lib/utils/__tests__/modificationFormatters.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest'
+import {
+	formatRingStat,
+	formatEarringStat,
+	formatAxSkill,
+	getWeaponKeyTitle,
+	formatUncapLevel,
+	formatTranscendenceStep,
+	getElementName
+} from '../modificationFormatters'
+import type { WeaponSeriesRef } from '$lib/types/api/weaponSeries'
+
+function makeSeries(slug: string): WeaponSeriesRef {
+	return {
+		id: 's-1',
+		slug,
+		name: { en: slug, ja: slug },
+		hasWeaponKeys: true,
+		hasAwakening: false,
+		augmentType: 'no_augment',
+		extra: false,
+		elementChangeable: false
+	}
+}
+
+// ============================================================================
+// formatRingStat
+// ============================================================================
+
+describe('formatRingStat', () => {
+	it('formats ATK stat (no suffix)', () => {
+		expect(formatRingStat(1, 3000)).toBe('ATK +3000')
+	})
+
+	it('formats stat with % suffix', () => {
+		expect(formatRingStat(3, 15)).toBe('Debuff Success +15%')
+	})
+
+	it('returns Unknown for invalid modifier', () => {
+		expect(formatRingStat(999, 10)).toBe('Unknown +10')
+	})
+
+	it('supports Japanese locale', () => {
+		expect(formatRingStat(1, 3000, 'ja')).toBe('攻撃 +3000')
+	})
+})
+
+// ============================================================================
+// formatEarringStat
+// ============================================================================
+
+describe('formatEarringStat', () => {
+	it('formats non-element stat', () => {
+		expect(formatEarringStat(1, 17)).toBe('Double Attack +17%')
+	})
+
+	it('formats element-specific stat with character element', () => {
+		const result = formatEarringStat(3, 22, 'en', 2)
+		expect(result).toContain('Fire')
+		expect(result).toContain('+22')
+	})
+
+	it('formats opposite element stat', () => {
+		// Fire (2) → Water (3)
+		const result = formatEarringStat(4, 12, 'en', 2)
+		expect(result).toContain('Water')
+	})
+
+	it('returns Unknown for invalid modifier', () => {
+		expect(formatEarringStat(999, 5)).toBe('Unknown +5')
+	})
+})
+
+// ============================================================================
+// formatAxSkill
+// ============================================================================
+
+describe('formatAxSkill', () => {
+	it('formats AX skill with name and strength', () => {
+		const ax = {
+			modifier: { nameEn: 'Might', nameJp: '攻刃', slug: 'might', suffix: '%' },
+			strength: 3
+		} as any
+		expect(formatAxSkill(ax)).toBe('Might +3%')
+	})
+
+	it('uses Japanese name with ja locale', () => {
+		const ax = {
+			modifier: { nameEn: 'Might', nameJp: '攻刃', slug: 'might', suffix: '%' },
+			strength: 3
+		} as any
+		expect(formatAxSkill(ax, 'ja')).toBe('攻刃 +3%')
+	})
+
+	it('handles missing suffix', () => {
+		const ax = {
+			modifier: { nameEn: 'Test', nameJp: 'テスト', slug: 'test' },
+			strength: 5
+		} as any
+		expect(formatAxSkill(ax)).toBe('Test +5')
+	})
+})
+
+// ============================================================================
+// getWeaponKeyTitle
+// ============================================================================
+
+describe('getWeaponKeyTitle', () => {
+	it('returns Pendulums & Chains for dark-opus', () => {
+		expect(getWeaponKeyTitle(makeSeries('dark-opus'))).toBe('Pendulums & Chains')
+	})
+
+	it('returns Telumas for draconic series', () => {
+		expect(getWeaponKeyTitle(makeSeries('draconic'))).toBe('Telumas')
+		expect(getWeaponKeyTitle(makeSeries('draconic-providence'))).toBe('Telumas')
+		expect(getWeaponKeyTitle(makeSeries('superlative'))).toBe('Telumas')
+	})
+
+	it('returns Ultima Keys for ultima', () => {
+		expect(getWeaponKeyTitle(makeSeries('ultima'))).toBe('Ultima Keys')
+	})
+
+	it('returns Emblems for astral', () => {
+		expect(getWeaponKeyTitle(makeSeries('astral'))).toBe('Emblems')
+	})
+
+	it('returns generic Weapon Keys for unknown series', () => {
+		expect(getWeaponKeyTitle(makeSeries('unknown'))).toBe('Weapon Keys')
+	})
+
+	it('returns Weapon Keys for null', () => {
+		expect(getWeaponKeyTitle(null)).toBe('Weapon Keys')
+		expect(getWeaponKeyTitle(undefined)).toBe('Weapon Keys')
+	})
+})
+
+// ============================================================================
+// formatUncapLevel / formatTranscendenceStep
+// ============================================================================
+
+describe('formatUncapLevel', () => {
+	it('formats level with star', () => {
+		expect(formatUncapLevel(5)).toBe('5★')
+	})
+
+	it('returns 0★ for undefined/null', () => {
+		expect(formatUncapLevel(undefined)).toBe('0★')
+		expect(formatUncapLevel(null)).toBe('0★')
+	})
+})
+
+describe('formatTranscendenceStep', () => {
+	it('formats non-zero step', () => {
+		expect(formatTranscendenceStep(3)).toBe('Stage 3')
+	})
+
+	it('returns empty for 0/null/undefined', () => {
+		expect(formatTranscendenceStep(0)).toBe('')
+		expect(formatTranscendenceStep(null)).toBe('')
+		expect(formatTranscendenceStep(undefined)).toBe('')
+	})
+})
+
+// ============================================================================
+// getElementName
+// ============================================================================
+
+describe('getElementName', () => {
+	it('maps element IDs to names', () => {
+		expect(getElementName(0)).toBe('Null')
+		expect(getElementName(1)).toBe('Wind')
+		expect(getElementName(2)).toBe('Fire')
+		expect(getElementName(3)).toBe('Water')
+		expect(getElementName(4)).toBe('Earth')
+		expect(getElementName(5)).toBe('Dark')
+		expect(getElementName(6)).toBe('Light')
+	})
+
+	it('returns Unknown for null/undefined/invalid', () => {
+		expect(getElementName(null)).toBe('Unknown')
+		expect(getElementName(undefined)).toBe('Unknown')
+		expect(getElementName(99)).toBe('Unknown')
+	})
+})

--- a/src/lib/utils/__tests__/modifiers.test.ts
+++ b/src/lib/utils/__tests__/modifiers.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('$lib/utils/images', () => ({
+	getBasePath: vi.fn(() => '/images')
+}))
+
+vi.mock('$lib/types/api/weaponSeries', () => ({
+	isWeaponSeriesRef: vi.fn((s: any) => s !== null && typeof s === 'object' && 'slug' in s && 'id' in s && 'name' in s)
+}))
+
+import {
+	getAwakeningImage,
+	getWeaponKeyImage,
+	getWeaponKeyImages,
+	getAxSkillImage,
+	getAxSkillImages
+} from '../modifiers'
+import type { WeaponKey } from '$lib/types/api/entities'
+import type { WeaponSeriesRef } from '$lib/types/api/weaponSeries'
+
+function makeKey(overrides: Partial<WeaponKey> = {}): WeaponKey {
+	return {
+		slug: 'alpha',
+		slot: 0,
+		granblue_id: 10000,
+		name: { en: 'Alpha', ja: 'アルファ' },
+		...overrides
+	} as WeaponKey
+}
+
+function makeSeries(slug: string): WeaponSeriesRef {
+	return {
+		id: 's-1',
+		slug,
+		name: { en: slug, ja: slug },
+		hasWeaponKeys: true,
+		hasAwakening: false,
+		augmentType: 'no_augment',
+		extra: false,
+		elementChangeable: false
+	}
+}
+
+// ============================================================================
+// getAwakeningImage
+// ============================================================================
+
+describe('getAwakeningImage', () => {
+	it('returns null for undefined', () => {
+		expect(getAwakeningImage(undefined)).toBeNull()
+	})
+
+	it('returns null when type has no slug', () => {
+		expect(getAwakeningImage({ type: {} as any })).toBeNull()
+	})
+
+	it('returns null for character-balanced', () => {
+		expect(getAwakeningImage({ type: { slug: 'character-balanced' } as any })).toBeNull()
+	})
+
+	it('returns jpg for character awakenings', () => {
+		const url = getAwakeningImage({ type: { slug: 'character-attack' } as any })
+		expect(url).toBe('/images/awakening/character-attack.jpg')
+	})
+
+	it('returns png for weapon awakenings', () => {
+		const url = getAwakeningImage({ type: { slug: 'attack' } as any })
+		expect(url).toBe('/images/awakening/attack.png')
+	})
+})
+
+// ============================================================================
+// getWeaponKeyImage
+// ============================================================================
+
+describe('getWeaponKeyImage', () => {
+	it('returns empty string when no slug', () => {
+		expect(getWeaponKeyImage(makeKey({ slug: '' }))).toBe('')
+	})
+
+	it('returns basic key image', () => {
+		expect(getWeaponKeyImage(makeKey())).toBe('/images/weapon-keys/alpha.png')
+	})
+
+	it('adds element suffix for elemental teluma keys', () => {
+		const key = makeKey({ slug: 'teluma', granblue_id: 15008 })
+		expect(getWeaponKeyImage(key, 3)).toBe('/images/weapon-keys/teluma-3.png')
+	})
+
+	it('does not add element for non-teluma keys', () => {
+		const key = makeKey({ slug: 'alpha', granblue_id: 10000 })
+		expect(getWeaponKeyImage(key, 3)).toBe('/images/weapon-keys/alpha.png')
+	})
+
+	it('adds proficiency suffix for ultima slot 0', () => {
+		const key = makeKey({ slug: 'strife', slot: 0 })
+		expect(getWeaponKeyImage(key, undefined, 1, makeSeries('ultima'))).toBe(
+			'/images/weapon-keys/strife-1.png'
+		)
+	})
+
+	it('does not add proficiency for non-ultima', () => {
+		const key = makeKey({ slug: 'strife', slot: 0 })
+		expect(getWeaponKeyImage(key, undefined, 1, makeSeries('dark-opus'))).toBe(
+			'/images/weapon-keys/strife.png'
+		)
+	})
+
+	it('adds mod and element suffix for dark-opus slot 1 pendulums', () => {
+		const key = makeKey({ slug: 'pendulum-strength', slot: 1 })
+		const url = getWeaponKeyImage(
+			key,
+			2,
+			undefined,
+			makeSeries('dark-opus'),
+			{ en: 'Repudiation' }
+		)
+		expect(url).toBe('/images/weapon-keys/pendulum-strength-primal-2.png')
+	})
+
+	it('uses magna for non-Repudiation opus weapons', () => {
+		const key = makeKey({ slug: 'pendulum-zeal', slot: 1 })
+		const url = getWeaponKeyImage(
+			key,
+			4,
+			undefined,
+			makeSeries('dark-opus'),
+			{ en: 'Renunciation' }
+		)
+		expect(url).toBe('/images/weapon-keys/pendulum-zeal-magna-4.png')
+	})
+
+	it('does not add opus suffix for non-matching slugs', () => {
+		const key = makeKey({ slug: 'alpha', slot: 1 })
+		const url = getWeaponKeyImage(key, 2, undefined, makeSeries('dark-opus'), { en: 'Repudiation' })
+		expect(url).toBe('/images/weapon-keys/alpha.png')
+	})
+})
+
+// ============================================================================
+// getWeaponKeyImages
+// ============================================================================
+
+describe('getWeaponKeyImages', () => {
+	it('returns empty array for undefined/empty', () => {
+		expect(getWeaponKeyImages(undefined)).toEqual([])
+		expect(getWeaponKeyImages([])).toEqual([])
+	})
+
+	it('returns url/alt pairs for each key', () => {
+		const keys = [makeKey({ slug: 'alpha' }), makeKey({ slug: 'beta', name: { en: 'Beta', ja: 'ベータ' } })]
+		const result = getWeaponKeyImages(keys)
+		expect(result).toHaveLength(2)
+		expect(result[0]!.url).toContain('alpha')
+		expect(result[0]!.alt).toBe('Alpha')
+		expect(result[1]!.alt).toBe('Beta')
+	})
+
+	it('filters out keys without slugs', () => {
+		const keys = [makeKey({ slug: 'alpha' }), makeKey({ slug: '' })]
+		expect(getWeaponKeyImages(keys)).toHaveLength(1)
+	})
+
+	it('handles array proficiency (takes first)', () => {
+		const keys = [makeKey({ slug: 'strife', slot: 0 })]
+		const result = getWeaponKeyImages(keys, undefined, [1, 2], makeSeries('ultima'))
+		expect(result[0]!.url).toContain('strife-1')
+	})
+})
+
+// ============================================================================
+// getAxSkillImage
+// ============================================================================
+
+describe('getAxSkillImage', () => {
+	it('returns null for undefined', () => {
+		expect(getAxSkillImage(undefined)).toBeNull()
+	})
+
+	it('returns null when no slug', () => {
+		expect(getAxSkillImage({})).toBeNull()
+	})
+
+	it('returns ax image path', () => {
+		expect(getAxSkillImage({ slug: 'might' })).toBe('/images/ax/might.png')
+	})
+})
+
+// ============================================================================
+// getAxSkillImages
+// ============================================================================
+
+describe('getAxSkillImages', () => {
+	it('returns empty for undefined/empty', () => {
+		expect(getAxSkillImages(undefined)).toEqual([])
+		expect(getAxSkillImages([])).toEqual([])
+	})
+
+	it('returns url/alt pairs', () => {
+		const ax = [
+			{ modifier: { slug: 'might', nameEn: 'Might', nameJp: '攻刃' }, strength: 3 }
+		] as any
+		const result = getAxSkillImages(ax)
+		expect(result).toHaveLength(1)
+		expect(result[0]!.url).toContain('might')
+		expect(result[0]!.alt).toBe('Might')
+	})
+
+	it('filters out skills without modifier slug', () => {
+		const ax = [
+			{ modifier: { slug: 'might', nameEn: 'Might' }, strength: 3 },
+			{ modifier: { slug: '', nameEn: '' }, strength: 1 }
+		] as any
+		expect(getAxSkillImages(ax)).toHaveLength(1)
+	})
+})

--- a/src/lib/utils/__tests__/uncap.test.ts
+++ b/src/lib/utils/__tests__/uncap.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import {
+	getMaxUncapLevel,
+	getCharacterMaxUncapLevel,
+	getSummonMaxUncapLevel,
+	getDefaultMaxUncapLevel
+} from '../uncap'
+
+// ============================================================================
+// getMaxUncapLevel
+// ============================================================================
+
+describe('getMaxUncapLevel', () => {
+	describe('special characters', () => {
+		it('returns 3 with no FLB/ULB', () => {
+			expect(getMaxUncapLevel(true, false, false)).toBe(3)
+		})
+
+		it('returns 4 with FLB only', () => {
+			expect(getMaxUncapLevel(true, true, false)).toBe(4)
+		})
+
+		it('returns 5 with ULB', () => {
+			expect(getMaxUncapLevel(true, true, true)).toBe(5)
+		})
+	})
+
+	describe('regular characters', () => {
+		it('returns 4 with no FLB/ULB', () => {
+			expect(getMaxUncapLevel(false, false, false)).toBe(4)
+		})
+
+		it('returns 5 with FLB only', () => {
+			expect(getMaxUncapLevel(false, true, false)).toBe(5)
+		})
+
+		it('returns 6 with ULB', () => {
+			expect(getMaxUncapLevel(false, true, true)).toBe(6)
+		})
+	})
+})
+
+// ============================================================================
+// getCharacterMaxUncapLevel
+// ============================================================================
+
+describe('getCharacterMaxUncapLevel', () => {
+	it('delegates to getMaxUncapLevel', () => {
+		expect(getCharacterMaxUncapLevel({ special: true, uncap: { flb: true, ulb: false } })).toBe(4)
+		expect(getCharacterMaxUncapLevel({ special: false, uncap: { flb: true, ulb: true } })).toBe(6)
+	})
+})
+
+// ============================================================================
+// getSummonMaxUncapLevel
+// ============================================================================
+
+describe('getSummonMaxUncapLevel', () => {
+	it('returns 3 base', () => {
+		expect(getSummonMaxUncapLevel({ uncap: { flb: false, ulb: false } })).toBe(3)
+	})
+
+	it('returns 4 with FLB', () => {
+		expect(getSummonMaxUncapLevel({ uncap: { flb: true, ulb: false } })).toBe(4)
+	})
+
+	it('returns 5 with ULB', () => {
+		expect(getSummonMaxUncapLevel({ uncap: { flb: true, ulb: true } })).toBe(5)
+	})
+})
+
+// ============================================================================
+// getDefaultMaxUncapLevel
+// ============================================================================
+
+describe('getDefaultMaxUncapLevel', () => {
+	it('returns 5 for character', () => {
+		expect(getDefaultMaxUncapLevel('character')).toBe(5)
+	})
+
+	it('returns 3 for weapon', () => {
+		expect(getDefaultMaxUncapLevel('weapon')).toBe(3)
+	})
+
+	it('returns 3 for summon', () => {
+		expect(getDefaultMaxUncapLevel('summon')).toBe(3)
+	})
+})

--- a/src/lib/utils/__tests__/weaponSeries.test.ts
+++ b/src/lib/utils/__tests__/weaponSeries.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import {
+	OPUS_DRACONIC_SLUGS,
+	isOpusDraconicSeries,
+	getSeriesDisplayName,
+	getSeriesSlug,
+	seriesHasWeaponKeys,
+	seriesHasAwakening,
+	seriesIsElementChangeable,
+	seriesIsExtra,
+	isWeaponSeriesRef
+} from '../weaponSeries'
+import type { WeaponSeriesRef } from '$lib/types/api/weaponSeries'
+
+function makeSeries(overrides: Partial<WeaponSeriesRef> = {}): WeaponSeriesRef {
+	return {
+		id: 's-1',
+		slug: 'test-series',
+		name: { en: 'Test Series', ja: 'テスト' },
+		hasWeaponKeys: false,
+		hasAwakening: false,
+		augmentType: 'no_augment',
+		extra: false,
+		elementChangeable: false,
+		...overrides
+	}
+}
+
+// ============================================================================
+// isWeaponSeriesRef type guard
+// ============================================================================
+
+describe('isWeaponSeriesRef', () => {
+	it('returns true for valid WeaponSeriesRef', () => {
+		expect(isWeaponSeriesRef(makeSeries())).toBe(true)
+	})
+
+	it('returns false for null/undefined', () => {
+		expect(isWeaponSeriesRef(null)).toBe(false)
+		expect(isWeaponSeriesRef(undefined)).toBe(false)
+	})
+
+	it('returns false for primitives', () => {
+		expect(isWeaponSeriesRef(42)).toBe(false)
+		expect(isWeaponSeriesRef('dark-opus')).toBe(false)
+	})
+
+	it('returns false for objects missing required fields', () => {
+		expect(isWeaponSeriesRef({ slug: 'x' })).toBe(false)
+		expect(isWeaponSeriesRef({ id: '1', slug: 'x' })).toBe(false)
+	})
+})
+
+// ============================================================================
+// isOpusDraconicSeries
+// ============================================================================
+
+describe('isOpusDraconicSeries', () => {
+	it('returns true for opus/draconic slugs', () => {
+		for (const slug of OPUS_DRACONIC_SLUGS) {
+			expect(isOpusDraconicSeries(makeSeries({ slug }))).toBe(true)
+		}
+	})
+
+	it('returns false for other series', () => {
+		expect(isOpusDraconicSeries(makeSeries({ slug: 'ultima' }))).toBe(false)
+	})
+
+	it('returns false for null/undefined', () => {
+		expect(isOpusDraconicSeries(null)).toBe(false)
+		expect(isOpusDraconicSeries(undefined)).toBe(false)
+	})
+})
+
+// ============================================================================
+// getSeriesDisplayName
+// ============================================================================
+
+describe('getSeriesDisplayName', () => {
+	it('returns English name by default', () => {
+		expect(getSeriesDisplayName(makeSeries({ name: { en: 'Dark Opus', ja: '暗黒' } }))).toBe(
+			'Dark Opus'
+		)
+	})
+
+	it('returns Japanese name', () => {
+		expect(getSeriesDisplayName(makeSeries({ name: { en: 'Dark Opus', ja: '暗黒' } }), 'ja')).toBe(
+			'暗黒'
+		)
+	})
+
+	it('returns Unknown for null/undefined', () => {
+		expect(getSeriesDisplayName(null)).toBe('Unknown')
+		expect(getSeriesDisplayName(undefined)).toBe('Unknown')
+	})
+})
+
+// ============================================================================
+// getSeriesSlug
+// ============================================================================
+
+describe('getSeriesSlug', () => {
+	it('returns slug', () => {
+		expect(getSeriesSlug(makeSeries({ slug: 'dark-opus' }))).toBe('dark-opus')
+	})
+
+	it('returns undefined for null', () => {
+		expect(getSeriesSlug(null)).toBeUndefined()
+	})
+})
+
+// ============================================================================
+// Boolean flag helpers
+// ============================================================================
+
+describe('seriesHasWeaponKeys', () => {
+	it('returns the flag value', () => {
+		expect(seriesHasWeaponKeys(makeSeries({ hasWeaponKeys: true }))).toBe(true)
+		expect(seriesHasWeaponKeys(makeSeries({ hasWeaponKeys: false }))).toBe(false)
+	})
+
+	it('returns false for null', () => {
+		expect(seriesHasWeaponKeys(null)).toBe(false)
+	})
+})
+
+describe('seriesHasAwakening', () => {
+	it('returns the flag value', () => {
+		expect(seriesHasAwakening(makeSeries({ hasAwakening: true }))).toBe(true)
+		expect(seriesHasAwakening(makeSeries({ hasAwakening: false }))).toBe(false)
+	})
+
+	it('returns false for null', () => {
+		expect(seriesHasAwakening(null)).toBe(false)
+	})
+})
+
+describe('seriesIsElementChangeable', () => {
+	it('returns the flag value', () => {
+		expect(seriesIsElementChangeable(makeSeries({ elementChangeable: true }))).toBe(true)
+		expect(seriesIsElementChangeable(makeSeries({ elementChangeable: false }))).toBe(false)
+	})
+
+	it('returns false for null', () => {
+		expect(seriesIsElementChangeable(null)).toBe(false)
+	})
+})
+
+describe('seriesIsExtra', () => {
+	it('returns the flag value', () => {
+		expect(seriesIsExtra(makeSeries({ extra: true }))).toBe(true)
+		expect(seriesIsExtra(makeSeries({ extra: false }))).toBe(false)
+	})
+
+	it('returns false for null', () => {
+		expect(seriesIsExtra(null)).toBe(false)
+	})
+})


### PR DESCRIPTION
## Summary
- Export buildSearchParams and buildFilterQuery for direct testing
- 127 query tests (keys, options, search params, filter queries)
- 296 utility tests (images, element, uncap, gw, artifact validation, weapon series, mastery, modifiers, formatters, job accessories, and more)
- 21 transform tests, 10 wiki tests, 8 SSR tests

## Test plan
- [x] `pnpm vitest run` passes