### PR TITLE
Add store tests

### DIFF
--- a/src/lib/stores/__tests__/crew.store.test.ts
+++ b/src/lib/stores/__tests__/crew.store.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { Crew, CrewMembership, CrewInvitation } from '$lib/types/api/crew'
+
+// Dynamic import to ensure Svelte Vite plugin transforms $state runes
+const { crewStore } = await import('../crew.store.svelte')
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeCrew(overrides: Partial<Crew> = {}): Crew {
+	return {
+		id: 'crew-1',
+		name: 'Test Crew',
+		gamertag: null,
+		granblueCrewId: null,
+		description: null,
+		createdAt: '2024-01-01T00:00:00Z',
+		...overrides
+	} as Crew
+}
+
+function makeMembership(role: 'captain' | 'vice_captain' | 'member'): CrewMembership {
+	return {
+		id: 'mem-1',
+		role,
+		retired: false,
+		retiredAt: null,
+		joinedAt: '2024-01-01T00:00:00Z',
+		createdAt: '2024-01-01T00:00:00Z'
+	} as CrewMembership
+}
+
+function makeInvitation(id: string): CrewInvitation {
+	return {
+		id,
+		status: 'pending',
+		expiresAt: '2025-01-01T00:00:00Z',
+		createdAt: '2024-01-01T00:00:00Z'
+	} as CrewInvitation
+}
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+beforeEach(() => {
+	crewStore.clear()
+})
+
+// ============================================================================
+// Computed roles
+// ============================================================================
+
+describe('computed roles', () => {
+	it('isInCrew is false when no crew', () => {
+		expect(crewStore.isInCrew).toBe(false)
+	})
+
+	it('isInCrew is true when crew is set', () => {
+		crewStore.setCrew(makeCrew())
+		expect(crewStore.isInCrew).toBe(true)
+	})
+
+	it('isCaptain when role is captain', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('captain'))
+		expect(crewStore.isCaptain).toBe(true)
+		expect(crewStore.isViceCaptain).toBe(false)
+		expect(crewStore.isMember).toBe(false)
+	})
+
+	it('isViceCaptain when role is vice_captain', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('vice_captain'))
+		expect(crewStore.isViceCaptain).toBe(true)
+		expect(crewStore.isCaptain).toBe(false)
+		expect(crewStore.isMember).toBe(false)
+	})
+
+	it('isMember when role is member', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('member'))
+		expect(crewStore.isMember).toBe(true)
+		expect(crewStore.isCaptain).toBe(false)
+		expect(crewStore.isViceCaptain).toBe(false)
+	})
+
+	it('isOfficer is true for captain', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('captain'))
+		expect(crewStore.isOfficer).toBe(true)
+	})
+
+	it('isOfficer is true for vice_captain', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('vice_captain'))
+		expect(crewStore.isOfficer).toBe(true)
+	})
+
+	it('isOfficer is false for member', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('member'))
+		expect(crewStore.isOfficer).toBe(false)
+	})
+})
+
+// ============================================================================
+// Permission getters
+// ============================================================================
+
+describe('permission getters', () => {
+	it('captain has all management permissions', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('captain'))
+		expect(crewStore.canManageMembers).toBe(true)
+		expect(crewStore.canEditCrew).toBe(true)
+		expect(crewStore.canTransferCaptain).toBe(true)
+		expect(crewStore.canManagePhantoms).toBe(true)
+		expect(crewStore.canRecordOthersScores).toBe(true)
+	})
+
+	it('captain cannot leave crew', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('captain'))
+		expect(crewStore.canLeaveCrew).toBe(false)
+	})
+
+	it('vice_captain has management but not transfer', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('vice_captain'))
+		expect(crewStore.canManageMembers).toBe(true)
+		expect(crewStore.canEditCrew).toBe(true)
+		expect(crewStore.canTransferCaptain).toBe(false)
+		expect(crewStore.canManagePhantoms).toBe(true)
+		expect(crewStore.canRecordOthersScores).toBe(true)
+		expect(crewStore.canLeaveCrew).toBe(true)
+	})
+
+	it('member has no management permissions', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('member'))
+		expect(crewStore.canManageMembers).toBe(false)
+		expect(crewStore.canEditCrew).toBe(false)
+		expect(crewStore.canTransferCaptain).toBe(false)
+		expect(crewStore.canManagePhantoms).toBe(false)
+		expect(crewStore.canRecordOthersScores).toBe(false)
+		expect(crewStore.canLeaveCrew).toBe(true)
+	})
+
+	it('no crew means no permissions', () => {
+		expect(crewStore.canManageMembers).toBe(false)
+		expect(crewStore.canLeaveCrew).toBe(false)
+		expect(crewStore.canTransferCaptain).toBe(false)
+	})
+})
+
+// ============================================================================
+// canActOnMember
+// ============================================================================
+
+describe('canActOnMember', () => {
+	it('captain can act on member', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('captain'))
+		expect(crewStore.canActOnMember('member')).toBe(true)
+	})
+
+	it('captain can act on vice_captain', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('captain'))
+		expect(crewStore.canActOnMember('vice_captain')).toBe(true)
+	})
+
+	it('captain can act on captain', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('captain'))
+		expect(crewStore.canActOnMember('captain')).toBe(true)
+	})
+
+	it('vice_captain can act on member', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('vice_captain'))
+		expect(crewStore.canActOnMember('member')).toBe(true)
+	})
+
+	it('vice_captain cannot act on vice_captain', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('vice_captain'))
+		expect(crewStore.canActOnMember('vice_captain')).toBe(false)
+	})
+
+	it('vice_captain cannot act on captain', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('vice_captain'))
+		expect(crewStore.canActOnMember('captain')).toBe(false)
+	})
+
+	it('member cannot act on anyone', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('member'))
+		expect(crewStore.canActOnMember('member')).toBe(false)
+		expect(crewStore.canActOnMember('vice_captain')).toBe(false)
+		expect(crewStore.canActOnMember('captain')).toBe(false)
+	})
+})
+
+// ============================================================================
+// canPromoteTo / canDemote
+// ============================================================================
+
+describe('canPromoteTo', () => {
+	it('captain can promote to vice_captain', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('captain'))
+		expect(crewStore.canPromoteTo('vice_captain')).toBe(true)
+	})
+
+	it('nobody can promote to captain', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('captain'))
+		expect(crewStore.canPromoteTo('captain')).toBe(false)
+	})
+
+	it('vice_captain cannot promote', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('vice_captain'))
+		expect(crewStore.canPromoteTo('vice_captain')).toBe(false)
+	})
+})
+
+describe('canDemote', () => {
+	it('captain can demote vice_captain', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('captain'))
+		expect(crewStore.canDemote('vice_captain')).toBe(true)
+	})
+
+	it('captain cannot demote captain', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('captain'))
+		expect(crewStore.canDemote('captain')).toBe(false)
+	})
+
+	it('vice_captain cannot demote', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('vice_captain'))
+		expect(crewStore.canDemote('vice_captain')).toBe(false)
+	})
+})
+
+// ============================================================================
+// Actions
+// ============================================================================
+
+describe('actions', () => {
+	it('setCrew sets crew and membership, clears error', () => {
+		crewStore.setError('old error')
+		crewStore.setCrew(makeCrew(), makeMembership('captain'))
+		expect(crewStore.crew).not.toBeNull()
+		expect(crewStore.membership).not.toBeNull()
+		expect(crewStore.error).toBeNull()
+	})
+
+	it('setMembership updates membership independently', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('member'))
+		crewStore.setMembership(makeMembership('captain'))
+		expect(crewStore.isCaptain).toBe(true)
+	})
+
+	it('clear resets all state', () => {
+		crewStore.setCrew(makeCrew(), makeMembership('captain'))
+		crewStore.setPendingInvitations([makeInvitation('inv-1')])
+		crewStore.setLoading(true)
+		crewStore.setError('some error')
+
+		crewStore.clear()
+
+		expect(crewStore.crew).toBeNull()
+		expect(crewStore.membership).toBeNull()
+		expect(crewStore.pendingInvitations).toHaveLength(0)
+		expect(crewStore.isLoading).toBe(false)
+		expect(crewStore.error).toBeNull()
+	})
+})
+
+// ============================================================================
+// Invitation management
+// ============================================================================
+
+describe('invitations', () => {
+	it('setPendingInvitations replaces the list', () => {
+		crewStore.setPendingInvitations([makeInvitation('inv-1'), makeInvitation('inv-2')])
+		expect(crewStore.pendingInvitationCount).toBe(2)
+		expect(crewStore.hasPendingInvitations).toBe(true)
+	})
+
+	it('addPendingInvitation appends', () => {
+		crewStore.setPendingInvitations([makeInvitation('inv-1')])
+		crewStore.addPendingInvitation(makeInvitation('inv-2'))
+		expect(crewStore.pendingInvitationCount).toBe(2)
+	})
+
+	it('removePendingInvitation filters by id', () => {
+		crewStore.setPendingInvitations([makeInvitation('inv-1'), makeInvitation('inv-2')])
+		crewStore.removePendingInvitation('inv-1')
+		expect(crewStore.pendingInvitationCount).toBe(1)
+		expect(crewStore.pendingInvitations[0]?.id).toBe('inv-2')
+	})
+
+	it('hasPendingInvitations is false when empty', () => {
+		expect(crewStore.hasPendingInvitations).toBe(false)
+		expect(crewStore.pendingInvitationCount).toBe(0)
+	})
+})

--- a/src/lib/stores/__tests__/loaderState.test.ts
+++ b/src/lib/stores/__tests__/loaderState.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+const { LoaderState, LoopTracker, STATUS } = await import('../loaderState.svelte')
+
+// ============================================================================
+// LoaderState
+// ============================================================================
+
+describe('LoaderState', () => {
+	let state: InstanceType<typeof LoaderState>
+
+	beforeEach(() => {
+		state = new LoaderState()
+	})
+
+	it('starts as READY with isFirstLoad=true', () => {
+		expect(state.status).toBe(STATUS.READY)
+		expect(state.isFirstLoad).toBe(true)
+	})
+
+	it('loaded() transitions to READY and clears isFirstLoad', () => {
+		state.status = STATUS.LOADING
+		state.loaded()
+		expect(state.status).toBe(STATUS.READY)
+		expect(state.isFirstLoad).toBe(false)
+	})
+
+	it('complete() transitions to COMPLETE', () => {
+		state.status = STATUS.LOADING
+		state.complete()
+		expect(state.status).toBe(STATUS.COMPLETE)
+		expect(state.isFirstLoad).toBe(false)
+	})
+
+	it('error() transitions to ERROR', () => {
+		state.status = STATUS.LOADING
+		state.error()
+		expect(state.status).toBe(STATUS.ERROR)
+	})
+
+	it('reset() restores initial state', () => {
+		state.status = STATUS.COMPLETE
+		state.isFirstLoad = false
+		state.reset()
+		expect(state.status).toBe(STATUS.READY)
+		expect(state.isFirstLoad).toBe(true)
+	})
+
+	it('loaded() is idempotent on isFirstLoad', () => {
+		state.loaded()
+		expect(state.isFirstLoad).toBe(false)
+		state.loaded()
+		expect(state.isFirstLoad).toBe(false)
+	})
+})
+
+// ============================================================================
+// LoopTracker
+// ============================================================================
+
+describe('LoopTracker', () => {
+	let tracker: InstanceType<typeof LoopTracker>
+
+	beforeEach(() => {
+		vi.useFakeTimers()
+		tracker = new LoopTracker()
+	})
+
+	afterEach(() => {
+		tracker.destroy()
+		vi.useRealTimers()
+	})
+
+	it('starts without cooling off', () => {
+		expect(tracker.coolingOff).toBe(false)
+	})
+
+	it('does not cool off under threshold', () => {
+		for (let i = 0; i < 4; i++) tracker.track()
+		expect(tracker.coolingOff).toBe(false)
+	})
+
+	it('cools off at threshold (5 calls)', () => {
+		for (let i = 0; i < 5; i++) tracker.track()
+		expect(tracker.coolingOff).toBe(true)
+	})
+
+	it('resets cooloff after cooldown period (3000ms)', () => {
+		for (let i = 0; i < 5; i++) tracker.track()
+		expect(tracker.coolingOff).toBe(true)
+		vi.advanceTimersByTime(3000)
+		expect(tracker.coolingOff).toBe(false)
+	})
+
+	it('resets count after detection timeout (2000ms)', () => {
+		for (let i = 0; i < 4; i++) tracker.track()
+		vi.advanceTimersByTime(2000)
+		// Count should have reset, so one more call shouldn't trigger cooloff
+		tracker.track()
+		expect(tracker.coolingOff).toBe(false)
+	})
+
+	it('destroy clears timers without error', () => {
+		tracker.track()
+		tracker.destroy()
+		// Advancing timers after destroy should not cause issues
+		vi.advanceTimersByTime(5000)
+		expect(tracker.coolingOff).toBe(false)
+	})
+
+	it('accepts custom thresholds', () => {
+		const custom = new LoopTracker(3, 1000, 500)
+		for (let i = 0; i < 3; i++) custom.track()
+		expect(custom.coolingOff).toBe(true)
+		vi.advanceTimersByTime(500)
+		expect(custom.coolingOff).toBe(false)
+		custom.destroy()
+	})
+})

--- a/src/lib/stores/__tests__/paneStack.test.ts
+++ b/src/lib/stores/__tests__/paneStack.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { PaneConfig } from '../paneStack.svelte'
+
+const { PaneStackStore } = await import('../paneStack.svelte')
+
+function makePane(id: string, overrides: Partial<PaneConfig> = {}): PaneConfig {
+	return {
+		id,
+		title: `Pane ${id}`,
+		component: {} as any,
+		...overrides
+	}
+}
+
+let stack: InstanceType<typeof PaneStackStore>
+
+beforeEach(() => {
+	vi.useFakeTimers()
+	stack = new PaneStackStore()
+})
+
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+// ============================================================================
+// push
+// ============================================================================
+
+describe('push', () => {
+	it('adds a pane to the stack', () => {
+		stack.push(makePane('a'))
+		expect(stack.depth).toBe(1)
+		expect(stack.currentPane?.id).toBe('a')
+	})
+
+	it('sets animation state during push', () => {
+		stack.push(makePane('a'))
+		expect(stack.isAnimating).toBe(true)
+		expect(stack.animationDirection).toBe('push')
+	})
+
+	it('clears animation after 300ms', () => {
+		stack.push(makePane('a'))
+		vi.advanceTimersByTime(300)
+		expect(stack.isAnimating).toBe(false)
+		expect(stack.animationDirection).toBeNull()
+	})
+
+	it('blocks push during animation', () => {
+		stack.push(makePane('a'))
+		stack.push(makePane('b'))
+		expect(stack.depth).toBe(1)
+	})
+
+	it('allows push after animation completes', () => {
+		stack.push(makePane('a'))
+		vi.advanceTimersByTime(300)
+		stack.push(makePane('b'))
+		expect(stack.depth).toBe(2)
+	})
+})
+
+// ============================================================================
+// pop
+// ============================================================================
+
+describe('pop', () => {
+	it('returns false on empty stack', () => {
+		expect(stack.pop()).toBe(false)
+	})
+
+	it('returns false on single pane without onback', () => {
+		stack.reset(makePane('root'))
+		expect(stack.pop()).toBe(false)
+		expect(stack.depth).toBe(1)
+	})
+
+	it('calls root onback when single pane has it', () => {
+		const onback = vi.fn()
+		stack.reset(makePane('root', { onback }))
+		stack.pop()
+		expect(onback).toHaveBeenCalledOnce()
+	})
+
+	it('removes top pane after animation', () => {
+		stack.reset(makePane('root'))
+		vi.advanceTimersByTime(300)
+		stack.push(makePane('child'))
+		vi.advanceTimersByTime(300)
+
+		expect(stack.pop()).toBe(true)
+		vi.advanceTimersByTime(300)
+		expect(stack.depth).toBe(1)
+		expect(stack.currentPane?.id).toBe('root')
+	})
+
+	it('blocks pop during animation', () => {
+		stack.reset(makePane('root'))
+		vi.advanceTimersByTime(300)
+		stack.push(makePane('child'))
+		vi.advanceTimersByTime(300)
+
+		stack.pop()
+		expect(stack.pop()).toBe(false)
+	})
+})
+
+// ============================================================================
+// popTo / popToRoot
+// ============================================================================
+
+describe('popTo', () => {
+	it('pops to a specific pane id', () => {
+		stack.reset(makePane('root'))
+		vi.advanceTimersByTime(300)
+		stack.push(makePane('mid'))
+		vi.advanceTimersByTime(300)
+		stack.push(makePane('top'))
+		vi.advanceTimersByTime(300)
+
+		stack.popTo('root')
+		vi.advanceTimersByTime(300)
+		expect(stack.depth).toBe(1)
+		expect(stack.currentPane?.id).toBe('root')
+	})
+
+	it('no-op if id not found', () => {
+		stack.reset(makePane('root'))
+		vi.advanceTimersByTime(300)
+		stack.push(makePane('child'))
+		vi.advanceTimersByTime(300)
+
+		stack.popTo('nonexistent')
+		expect(stack.depth).toBe(2)
+	})
+
+	it('no-op if already on target pane', () => {
+		stack.reset(makePane('root'))
+		vi.advanceTimersByTime(300)
+		stack.push(makePane('top'))
+		vi.advanceTimersByTime(300)
+
+		stack.popTo('top')
+		expect(stack.depth).toBe(2)
+	})
+})
+
+describe('popToRoot', () => {
+	it('pops all but root', () => {
+		stack.reset(makePane('root'))
+		vi.advanceTimersByTime(300)
+		stack.push(makePane('a'))
+		vi.advanceTimersByTime(300)
+		stack.push(makePane('b'))
+		vi.advanceTimersByTime(300)
+
+		stack.popToRoot()
+		vi.advanceTimersByTime(300)
+		expect(stack.depth).toBe(1)
+	})
+
+	it('no-op if only root', () => {
+		stack.reset(makePane('root'))
+		stack.popToRoot()
+		expect(stack.depth).toBe(1)
+	})
+})
+
+// ============================================================================
+// clear / reset
+// ============================================================================
+
+describe('clear', () => {
+	it('empties the stack', () => {
+		stack.push(makePane('a'))
+		stack.clear()
+		expect(stack.depth).toBe(0)
+		expect(stack.isEmpty).toBe(true)
+		expect(stack.isAnimating).toBe(false)
+	})
+})
+
+describe('reset', () => {
+	it('replaces stack with single pane', () => {
+		stack.push(makePane('a'))
+		vi.advanceTimersByTime(300)
+		stack.push(makePane('b'))
+		vi.advanceTimersByTime(300)
+
+		stack.reset(makePane('new-root'))
+		expect(stack.depth).toBe(1)
+		expect(stack.currentPane?.id).toBe('new-root')
+		expect(stack.isAnimating).toBe(false)
+	})
+})
+
+// ============================================================================
+// updateCurrentProps
+// ============================================================================
+
+describe('updateCurrentProps', () => {
+	it('merges props into current pane', () => {
+		stack.reset(makePane('root', { props: { foo: 1 } }))
+		stack.updateCurrentProps({ bar: 2 })
+		expect(stack.currentPane?.props).toEqual({ foo: 1, bar: 2 })
+	})
+
+	it('no-op on empty stack', () => {
+		stack.updateCurrentProps({ bar: 2 })
+		expect(stack.depth).toBe(0)
+	})
+})
+
+// ============================================================================
+// Getters
+// ============================================================================
+
+describe('getters', () => {
+	it('isEmpty is true for empty stack', () => {
+		expect(stack.isEmpty).toBe(true)
+	})
+
+	it('isEmpty is false when panes exist', () => {
+		stack.push(makePane('a'))
+		expect(stack.isEmpty).toBe(false)
+	})
+
+	it('canGoBack is false with single pane and no onback', () => {
+		stack.reset(makePane('root'))
+		expect(stack.canGoBack).toBe(false)
+	})
+
+	it('canGoBack is true with single pane that has onback', () => {
+		stack.reset(makePane('root', { onback: () => {} }))
+		expect(stack.canGoBack).toBe(true)
+	})
+
+	it('canGoBack is true with multiple panes', () => {
+		stack.reset(makePane('root'))
+		vi.advanceTimersByTime(300)
+		stack.push(makePane('child'))
+		expect(stack.canGoBack).toBe(true)
+	})
+})

--- a/src/lib/stores/__tests__/partyStore.test.ts
+++ b/src/lib/stores/__tests__/partyStore.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Party, GridCharacter, GridWeapon, GridSummon } from '$lib/types/api/party'
+
+vi.mock('$lib/api/adapters/grid.adapter', () => ({
+	gridAdapter: {
+		updateCharacter: vi.fn(),
+		updateWeapon: vi.fn()
+	}
+}))
+
+const { partyStore } = await import('../partyStore.svelte')
+const { gridAdapter } = await import('$lib/api/adapters/grid.adapter')
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeCharacter(id: string, position: number): GridCharacter {
+	return {
+		id,
+		position,
+		character: { id: `char-${id}`, granblueId: '3040001000', name: { en: `Char ${id}` } }
+	} as GridCharacter
+}
+
+function makeWeapon(id: string, position: number): GridWeapon {
+	return {
+		id,
+		position,
+		weapon: { id: `wpn-${id}`, granblueId: '1040001000', name: { en: `Weapon ${id}` } }
+	} as GridWeapon
+}
+
+function makeSummon(id: string, position: number): GridSummon {
+	return {
+		id,
+		position,
+		summon: { id: `smn-${id}`, granblueId: '2040001000', name: { en: `Summon ${id}` } }
+	} as GridSummon
+}
+
+function makeParty(overrides: Partial<Party> = {}): Party {
+	return {
+		id: 'p-1',
+		shortcode: 'ABC123',
+		characters: [makeCharacter('c-1', 0), makeCharacter('c-2', 1)],
+		weapons: [makeWeapon('w-1', 0), makeWeapon('w-2', 1)],
+		summons: [makeSummon('s-1', 0), makeSummon('s-2', 1)],
+		...overrides
+	} as Party
+}
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+beforeEach(() => {
+	partyStore.clear()
+	vi.restoreAllMocks()
+})
+
+// ============================================================================
+// setParty / clear
+// ============================================================================
+
+describe('setParty / clear', () => {
+	it('sets party state', () => {
+		partyStore.setParty(makeParty())
+		expect(partyStore.party).not.toBeNull()
+		expect(partyStore.shortcode).toBe('ABC123')
+	})
+
+	it('clear resets to null', () => {
+		partyStore.setParty(makeParty())
+		partyStore.clear()
+		expect(partyStore.party).toBeNull()
+		expect(partyStore.shortcode).toBeUndefined()
+	})
+})
+
+// ============================================================================
+// Lookups
+// ============================================================================
+
+describe('getCharacter', () => {
+	it('finds by string id', () => {
+		partyStore.setParty(makeParty())
+		expect(partyStore.getCharacter('c-1')?.id).toBe('c-1')
+	})
+
+	it('finds by numeric id via String coercion', () => {
+		partyStore.setParty(makeParty({ characters: [makeCharacter('123', 0)] }))
+		expect(partyStore.getCharacter(123)?.id).toBe('123')
+	})
+
+	it('returns undefined for missing id', () => {
+		partyStore.setParty(makeParty())
+		expect(partyStore.getCharacter('nonexistent')).toBeUndefined()
+	})
+
+	it('returns undefined when party is null', () => {
+		expect(partyStore.getCharacter('c-1')).toBeUndefined()
+	})
+})
+
+describe('getWeapon', () => {
+	it('finds by id', () => {
+		partyStore.setParty(makeParty())
+		expect(partyStore.getWeapon('w-1')?.id).toBe('w-1')
+	})
+})
+
+describe('getSummon', () => {
+	it('finds by id', () => {
+		partyStore.setParty(makeParty())
+		expect(partyStore.getSummon('s-1')?.id).toBe('s-1')
+	})
+})
+
+describe('getItem', () => {
+	it('dispatches to getCharacter', () => {
+		partyStore.setParty(makeParty())
+		expect(partyStore.getItem('character', 'c-1')?.id).toBe('c-1')
+	})
+
+	it('dispatches to getWeapon', () => {
+		partyStore.setParty(makeParty())
+		expect(partyStore.getItem('weapon', 'w-1')?.id).toBe('w-1')
+	})
+
+	it('dispatches to getSummon', () => {
+		partyStore.setParty(makeParty())
+		expect(partyStore.getItem('summon', 's-1')?.id).toBe('s-1')
+	})
+})
+
+// ============================================================================
+// Optimistic updates
+// ============================================================================
+
+describe('updateCharacter', () => {
+	it('optimistically updates then applies server response', async () => {
+		partyStore.setParty(makeParty())
+		const serverResponse = { ...makeCharacter('c-1', 0), uncapLevel: 5 }
+		vi.mocked(gridAdapter.updateCharacter).mockResolvedValue(serverResponse)
+
+		const result = await partyStore.updateCharacter('c-1', { uncapLevel: 5 })
+
+		expect(result.uncapLevel).toBe(5)
+		expect(gridAdapter.updateCharacter).toHaveBeenCalledWith('c-1', { uncapLevel: 5 })
+		expect(partyStore.getCharacter('c-1')?.uncapLevel).toBe(5)
+	})
+})
+
+describe('updateWeapon', () => {
+	it('optimistically updates then applies server response', async () => {
+		partyStore.setParty(makeParty())
+		const serverResponse = { ...makeWeapon('w-1', 0), element: 3 }
+		vi.mocked(gridAdapter.updateWeapon).mockResolvedValue(serverResponse)
+
+		const result = await partyStore.updateWeapon('w-1', { element: 3 })
+
+		expect(result.element).toBe(3)
+		expect(gridAdapter.updateWeapon).toHaveBeenCalledWith('w-1', { element: 3 })
+	})
+})

--- a/src/lib/stores/__tests__/selectionMode.test.ts
+++ b/src/lib/stores/__tests__/selectionMode.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createSelectionModeContext } from '../selectionMode.svelte'
+
+let ctx: ReturnType<typeof createSelectionModeContext>
+
+beforeEach(() => {
+	ctx = createSelectionModeContext()
+})
+
+describe('enter / exit', () => {
+	it('starts inactive', () => {
+		expect(ctx.isActive).toBe(false)
+		expect(ctx.entityType).toBeNull()
+		expect(ctx.selectedCount).toBe(0)
+	})
+
+	it('enter activates with entity type', () => {
+		ctx.enter('characters')
+		expect(ctx.isActive).toBe(true)
+		expect(ctx.entityType).toBe('characters')
+	})
+
+	it('enter clears previous selection', () => {
+		ctx.enter('weapons')
+		ctx.toggle('w-1')
+		ctx.enter('characters')
+		expect(ctx.selectedCount).toBe(0)
+		expect(ctx.entityType).toBe('characters')
+	})
+
+	it('exit deactivates and clears', () => {
+		ctx.enter('characters')
+		ctx.toggle('c-1')
+		ctx.exit()
+		expect(ctx.isActive).toBe(false)
+		expect(ctx.entityType).toBeNull()
+		expect(ctx.selectedCount).toBe(0)
+	})
+})
+
+describe('toggle', () => {
+	it('adds item when not selected', () => {
+		ctx.enter('characters')
+		ctx.toggle('c-1')
+		expect(ctx.isSelected('c-1')).toBe(true)
+		expect(ctx.selectedCount).toBe(1)
+	})
+
+	it('removes item when already selected', () => {
+		ctx.enter('characters')
+		ctx.toggle('c-1')
+		ctx.toggle('c-1')
+		expect(ctx.isSelected('c-1')).toBe(false)
+		expect(ctx.selectedCount).toBe(0)
+	})
+})
+
+describe('selectAll / clearSelection', () => {
+	it('selectAll replaces selection', () => {
+		ctx.enter('weapons')
+		ctx.toggle('w-1')
+		ctx.selectAll(['w-2', 'w-3', 'w-4'])
+		expect(ctx.selectedCount).toBe(3)
+		expect(ctx.isSelected('w-1')).toBe(false)
+		expect(ctx.isSelected('w-2')).toBe(true)
+	})
+
+	it('clearSelection empties without exiting', () => {
+		ctx.enter('summons')
+		ctx.selectAll(['s-1', 's-2'])
+		ctx.clearSelection()
+		expect(ctx.selectedCount).toBe(0)
+		expect(ctx.isActive).toBe(true)
+	})
+})
+
+describe('isSelected', () => {
+	it('returns false for unselected item', () => {
+		ctx.enter('characters')
+		expect(ctx.isSelected('c-99')).toBe(false)
+	})
+})

--- a/src/lib/stores/__tests__/sidebar.test.ts
+++ b/src/lib/stores/__tests__/sidebar.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { Component } from 'svelte'
+
+const { sidebar } = await import('../sidebar.svelte')
+
+const DummyComponent = {} as Component<any, any, any>
+
+beforeEach(() => {
+	vi.useFakeTimers()
+	// Reset sidebar state between tests
+	sidebar.close()
+	vi.advanceTimersByTime(300)
+})
+
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+// ============================================================================
+// open / close / toggle
+// ============================================================================
+
+describe('open / close / toggle', () => {
+	it('starts closed', () => {
+		expect(sidebar.isOpen).toBe(false)
+	})
+
+	it('open() sets open state', () => {
+		sidebar.open()
+		expect(sidebar.isOpen).toBe(true)
+	})
+
+	it('close() sets closed and clears pane stack after delay', () => {
+		sidebar.openWithComponent('Test', DummyComponent)
+		sidebar.close()
+		expect(sidebar.isOpen).toBe(false)
+		// Pane stack not yet cleared
+		expect(sidebar.paneStack.depth).toBe(1)
+		vi.advanceTimersByTime(300)
+		expect(sidebar.paneStack.depth).toBe(0)
+	})
+
+	it('close() clears activeItemId', () => {
+		sidebar.openWithComponent('Test', DummyComponent, { item: { id: 'item-1' } })
+		expect(sidebar.activeItemId).toBe('item-1')
+		sidebar.close()
+		expect(sidebar.activeItemId).toBeUndefined()
+	})
+
+	it('toggle() opens when closed', () => {
+		sidebar.toggle()
+		expect(sidebar.isOpen).toBe(true)
+	})
+
+	it('toggle() closes when open', () => {
+		sidebar.open()
+		sidebar.toggle()
+		expect(sidebar.isOpen).toBe(false)
+	})
+})
+
+// ============================================================================
+// openWithComponent
+// ============================================================================
+
+describe('openWithComponent', () => {
+	it('creates pane config and opens', () => {
+		sidebar.openWithComponent('Details', DummyComponent, { foo: 1 })
+		expect(sidebar.isOpen).toBe(true)
+		expect(sidebar.title).toBe('Details')
+		expect(sidebar.component).toBe(DummyComponent)
+		expect(sidebar.componentProps).toEqual({ foo: 1 })
+	})
+
+	it('handles boolean backward compat for 4th param', () => {
+		sidebar.openWithComponent('Title', DummyComponent, undefined, false)
+		expect(sidebar.scrollable).toBe(false)
+	})
+
+	it('handles options object for 4th param', () => {
+		const onsave = vi.fn()
+		sidebar.openWithComponent('Title', DummyComponent, undefined, {
+			scrollable: false,
+			onsave,
+			saveLabel: 'Save',
+			element: 'fire'
+		})
+		expect(sidebar.scrollable).toBe(false)
+		expect(sidebar.onsave).toBe(onsave)
+		expect(sidebar.saveLabel).toBe('Save')
+		expect(sidebar.element).toBe('fire')
+	})
+
+	it('extracts activeItemId from props.item.id', () => {
+		sidebar.openWithComponent('Test', DummyComponent, { item: { id: 42 } })
+		expect(sidebar.activeItemId).toBe('42')
+	})
+
+	it('cancels pending clear from previous close', () => {
+		sidebar.openWithComponent('First', DummyComponent)
+		sidebar.close()
+		// Re-open before the 300ms clear fires
+		sidebar.openWithComponent('Second', DummyComponent)
+		vi.advanceTimersByTime(300)
+		// Pane stack should have the new pane, not be cleared
+		expect(sidebar.paneStack.depth).toBe(1)
+		expect(sidebar.title).toBe('Second')
+	})
+})
+
+// ============================================================================
+// push / pop delegation
+// ============================================================================
+
+describe('push / pop', () => {
+	it('push delegates to paneStack', () => {
+		sidebar.openWithComponent('Root', DummyComponent)
+		vi.advanceTimersByTime(300)
+		sidebar.push({ id: 'child', title: 'Child', component: DummyComponent })
+		expect(sidebar.paneStack.depth).toBe(2)
+	})
+
+	it('pop delegates to paneStack', () => {
+		sidebar.openWithComponent('Root', DummyComponent)
+		vi.advanceTimersByTime(300)
+		sidebar.push({ id: 'child', title: 'Child', component: DummyComponent })
+		vi.advanceTimersByTime(300)
+		sidebar.pop()
+		vi.advanceTimersByTime(300)
+		expect(sidebar.paneStack.depth).toBe(1)
+	})
+})
+
+// ============================================================================
+// setAction / clearAction
+// ============================================================================
+
+describe('setAction / clearAction', () => {
+	it('sets action on current pane', () => {
+		sidebar.openWithComponent('Test', DummyComponent)
+		const handler = vi.fn()
+		sidebar.setAction(handler, 'Save', 'water')
+		expect(sidebar.onsave).toBe(handler)
+		expect(sidebar.saveLabel).toBe('Save')
+		expect(sidebar.element).toBe('water')
+	})
+
+	it('sets disabled action when handler is undefined', () => {
+		sidebar.openWithComponent('Test', DummyComponent)
+		sidebar.setAction(undefined, 'Save')
+		const pane = sidebar.paneStack.currentPane
+		expect(pane?.action?.disabled).toBe(true)
+	})
+
+	it('clearAction removes action', () => {
+		sidebar.openWithComponent('Test', DummyComponent, undefined, { onsave: vi.fn(), saveLabel: 'Done' })
+		sidebar.clearAction()
+		expect(sidebar.onsave).toBeUndefined()
+	})
+})
+
+// ============================================================================
+// setOverflowMenu / clearOverflowMenu
+// ============================================================================
+
+describe('setOverflowMenu / clearOverflowMenu', () => {
+	it('sets overflow menu on current pane', () => {
+		sidebar.openWithComponent('Test', DummyComponent)
+		const items = [{ label: 'Delete', handler: vi.fn(), variant: 'danger' as const }]
+		sidebar.setOverflowMenu(items)
+		expect(sidebar.paneStack.currentPane?.overflowMenu).toEqual(items)
+	})
+
+	it('clearOverflowMenu removes menu', () => {
+		sidebar.openWithComponent('Test', DummyComponent)
+		sidebar.setOverflowMenu([{ label: 'X', handler: vi.fn() }])
+		sidebar.clearOverflowMenu()
+		expect(sidebar.paneStack.currentPane?.overflowMenu).toBeUndefined()
+	})
+})
+
+// ============================================================================
+// Getters
+// ============================================================================
+
+describe('getters', () => {
+	it('scrollable defaults to true', () => {
+		sidebar.openWithComponent('Test', DummyComponent)
+		expect(sidebar.scrollable).toBe(true)
+	})
+
+	it('content always returns undefined', () => {
+		expect(sidebar.content).toBeUndefined()
+	})
+
+	it('onback returns root pane onback', () => {
+		const onback = vi.fn()
+		sidebar.openWithComponent('Test', DummyComponent, undefined, { onback })
+		expect(sidebar.onback).toBe(onback)
+	})
+})

--- a/src/lib/stores/__tests__/theme.test.ts
+++ b/src/lib/stores/__tests__/theme.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Theme store is a singleton with #initialized guard — need fresh import per test group
+// We use dynamic imports with vi.resetModules() to get fresh instances
+
+let setAttributeMock: ReturnType<typeof vi.fn>
+let addEventListenerMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+	setAttributeMock = vi.fn()
+	addEventListenerMock = vi.fn()
+
+	vi.stubGlobal('document', {
+		documentElement: { setAttribute: setAttributeMock }
+	})
+	vi.stubGlobal('window', {
+		matchMedia: vi.fn().mockReturnValue({
+			matches: false,
+			addEventListener: addEventListenerMock,
+			removeEventListener: vi.fn()
+		})
+	})
+})
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+	vi.resetModules()
+})
+
+describe('init', () => {
+	it('sets preference=light, resolved=light', async () => {
+		const { themeStore } = await import('../theme.svelte')
+		themeStore.init('light')
+		expect(themeStore.preference).toBe('light')
+		expect(themeStore.resolved).toBe('light')
+		expect(setAttributeMock).toHaveBeenCalledWith('data-theme', 'light')
+	})
+
+	it('sets preference=dark, resolved=dark', async () => {
+		const { themeStore } = await import('../theme.svelte')
+		themeStore.init('dark')
+		expect(themeStore.preference).toBe('dark')
+		expect(themeStore.resolved).toBe('dark')
+		expect(setAttributeMock).toHaveBeenCalledWith('data-theme', 'dark')
+	})
+
+	it('resolves system preference via matchMedia', async () => {
+		;(window.matchMedia as ReturnType<typeof vi.fn>).mockReturnValue({
+			matches: true,
+			addEventListener: addEventListenerMock
+		})
+		const { themeStore } = await import('../theme.svelte')
+		themeStore.init('system')
+		expect(themeStore.preference).toBe('system')
+		expect(themeStore.resolved).toBe('dark')
+	})
+
+	it('is idempotent (second call is no-op)', async () => {
+		const { themeStore } = await import('../theme.svelte')
+		themeStore.init('light')
+		themeStore.init('dark')
+		expect(themeStore.preference).toBe('light')
+	})
+})
+
+describe('setTheme', () => {
+	it('updates preference and resolved', async () => {
+		const { themeStore } = await import('../theme.svelte')
+		themeStore.init('light')
+		themeStore.setTheme('dark')
+		expect(themeStore.preference).toBe('dark')
+		expect(themeStore.resolved).toBe('dark')
+		expect(setAttributeMock).toHaveBeenLastCalledWith('data-theme', 'dark')
+	})
+})
+
+describe('system change handler', () => {
+	it('updates resolved when preference is system', async () => {
+		const { themeStore } = await import('../theme.svelte')
+		themeStore.init('system')
+
+		const handler = addEventListenerMock.mock.calls[0]?.[1]
+		handler?.({ matches: true })
+
+		expect(themeStore.resolved).toBe('dark')
+	})
+
+	it('ignores system change when preference is not system', async () => {
+		const { themeStore } = await import('../theme.svelte')
+		themeStore.init('light')
+
+		const handler = addEventListenerMock.mock.calls[0]?.[1]
+		handler?.({ matches: true })
+
+		expect(themeStore.resolved).toBe('light')
+	})
+})

--- a/src/lib/stores/__tests__/viewMode.test.ts
+++ b/src/lib/stores/__tests__/viewMode.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+let getItemMock: ReturnType<typeof vi.fn>
+let setItemMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+	getItemMock = vi.fn().mockReturnValue(null)
+	setItemMock = vi.fn()
+
+	const localStorage = {
+		getItem: getItemMock,
+		setItem: setItemMock,
+		removeItem: vi.fn(),
+		clear: vi.fn()
+	}
+
+	vi.stubGlobal('localStorage', localStorage)
+	vi.stubGlobal('window', { localStorage })
+	vi.resetModules()
+})
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+describe('defaults', () => {
+	it('returns grid when no stored value', async () => {
+		const { viewMode } = await import('../viewMode.svelte')
+		expect(viewMode.collectionView).toBe('grid')
+		expect(viewMode.modalView).toBe('grid')
+	})
+})
+
+describe('loads from localStorage', () => {
+	it('reads stored collection view', async () => {
+		getItemMock.mockImplementation((key: string) =>
+			key === 'collection-view-mode' ? 'list' : null
+		)
+		const { viewMode } = await import('../viewMode.svelte')
+		expect(viewMode.collectionView).toBe('list')
+	})
+
+	it('reads stored modal view', async () => {
+		getItemMock.mockImplementation((key: string) =>
+			key === 'modal-view-mode' ? 'list' : null
+		)
+		const { viewMode } = await import('../viewMode.svelte')
+		expect(viewMode.modalView).toBe('list')
+	})
+
+	it('ignores invalid stored values', async () => {
+		getItemMock.mockReturnValue('invalid')
+		const { viewMode } = await import('../viewMode.svelte')
+		expect(viewMode.collectionView).toBe('grid')
+		expect(viewMode.modalView).toBe('grid')
+	})
+})
+
+describe('setCollectionView', () => {
+	it('updates state and persists to localStorage', async () => {
+		const { viewMode } = await import('../viewMode.svelte')
+		viewMode.setCollectionView('list')
+		expect(viewMode.collectionView).toBe('list')
+		expect(setItemMock).toHaveBeenCalledWith('collection-view-mode', 'list')
+	})
+})
+
+describe('setModalView', () => {
+	it('updates state and persists to localStorage', async () => {
+		const { viewMode } = await import('../viewMode.svelte')
+		viewMode.setModalView('list')
+		expect(viewMode.modalView).toBe('list')
+		expect(setItemMock).toHaveBeenCalledWith('modal-view-mode', 'list')
+	})
+})


### PR DESCRIPTION
## Summary
- 126 tests across 8 store files (crew, paneStack, sidebar, partyStore, loaderState, selectionMode, theme, viewMode)
- Confirms .svelte.ts rune stores are testable in Node via Vite plugin transform

## Test plan
- [x] `pnpm vitest run` passes