### PR TITLE
Stop double-fetching SSR data, re-enable party adapter cache

### DIFF
--- a/src/lib/api/adapters/party.adapter.ts
+++ b/src/lib/api/adapters/party.adapter.ts
@@ -145,8 +145,6 @@ export interface GridUpdateResponse {
 export class PartyAdapter extends BaseAdapter {
 	constructor(options?: AdapterOptions) {
 		super(options)
-		// Temporarily disable cache until cache invalidation is fixed
-		this.disableCache = true
 	}
 
 	/**

--- a/src/lib/query/ssr.ts
+++ b/src/lib/query/ssr.ts
@@ -22,8 +22,8 @@ export interface InitialDataOptions<TData> {
 
 	/**
 	 * Optional timestamp when the data was fetched on the server.
-	 * If not provided, defaults to 0 (will be considered stale immediately).
-	 * Use Date.now() on the server to get accurate timestamps.
+	 * Defaults to Date.now(), which tells TanStack Query the data is fresh
+	 * and prevents an immediate background refetch.
 	 */
 	initialDataUpdatedAt?: number
 }
@@ -56,7 +56,7 @@ export interface InitialDataOptions<TData> {
  * ```
  *
  * @param initialData - The data fetched on the server (null is converted to undefined)
- * @param updatedAt - Optional timestamp when data was fetched (defaults to 0)
+ * @param updatedAt - Optional timestamp when data was fetched (defaults to Date.now())
  * @returns Query options object with initialData and initialDataUpdatedAt
  */
 export function withInitialData<TData>(
@@ -65,7 +65,7 @@ export function withInitialData<TData>(
 ): InitialDataOptions<NonNullable<TData>> {
 	return {
 		initialData: (initialData ?? undefined) as NonNullable<TData> | undefined,
-		initialDataUpdatedAt: updatedAt ?? 0
+		initialDataUpdatedAt: updatedAt ?? Date.now()
 	}
 }
 

--- a/src/routes/(app)/[username]/+page.svelte
+++ b/src/routes/(app)/[username]/+page.svelte
@@ -38,7 +38,7 @@
 					pageParams: [1]
 				}
 			: undefined,
-		initialDataUpdatedAt: 0
+		initialDataUpdatedAt: Date.now()
 	}))
 
 	// State-gated infinite scroll

--- a/src/routes/(app)/teams/explore/+page.svelte
+++ b/src/routes/(app)/teams/explore/+page.svelte
@@ -139,7 +139,7 @@
             pageParams: [1]
           }
         : undefined,
-    initialDataUpdatedAt: 0
+    initialDataUpdatedAt: Date.now()
   }))
 
   // Infinite scroll


### PR DESCRIPTION
## Summary
- Change `withInitialData` default `initialDataUpdatedAt` from `0` to `Date.now()`. This prevents TanStack Query from immediately refetching data that was just loaded on the server
- Fix two inline `initialDataUpdatedAt: 0` overrides in explore and user profile pages
- Re-enable party adapter's in-memory cache (was disabled with a TODO comment)

## Test plan
- [ ] Verify explore page loads without a redundant background refetch (check network tab)
- [ ] Verify user profile page loads without double-fetch
- [ ] Verify party detail page still shows fresh data
- [ ] Confirm navigating between pages uses cached adapter responses within TTL