### PR TITLE
Fix CSS variable naming mismatches and missing dark theme vars

### DIFF
--- a/src/themes/themes.scss
+++ b/src/themes/themes.scss
@@ -332,6 +332,7 @@
 	--wind-bg-hover: #{colors.$wind--bg--hover--light};
 	--wind-portrait-bg: #{colors.$wind--portrait--bg--light};
 	--wind-text: #{colors.$wind--text--light};
+	--wind-text-contrast: #{colors.$wind--text--contrast};
 	--wind-raid-text: #{colors.$wind--text--raid--light};
 	--wind-text-hover: #{colors.$wind--text--hover--light};
 	--wind-shadow: #{colors.$wind--shadow--light};
@@ -433,6 +434,8 @@ html[data-theme='dark'] {
 
 	--full-auto-bg: #{colors.$full--auto--bg};
 	--full-auto-text: #{colors.$charge--attack--text};
+	--auto-guard-bg: #{colors.$auto--guard--bg};
+	--auto-guard-text: #{colors.$auto--guard--text};
 
 	--full-auto-label-text: #{colors.$text--full--auto--dark};
 
@@ -649,7 +652,7 @@ html[data-theme='dark'] {
 	--null-bg: #{colors.$null--bg--dark};
 	--null-bg-hover: #{colors.$null--bg--hover--dark};
 	--null-text: #{colors.$null--text--dark};
-	--null-contrast-text: #{colors.$null--text--contrast};
+	--null-text-contrast: #{colors.$null--text--contrast};
 	--null-raid-text: #{colors.$null--text--raid--dark};
 	--null-text-hover: #{colors.$null--text--hover--dark};
 	--null-shadow: #{colors.$null--shadow--dark};


### PR DESCRIPTION
## Summary
- Align extra-purple text variable names between light and dark themes (components were getting light-mode values in dark mode)
- Align null-text-contrast variable name between themes
- Add missing --auto-guard-bg/--auto-guard-text to dark theme
- Add missing --wind-text-contrast to light theme (3 components affected)

## Test plan
- [ ] Toggle dark mode and check extra-purple themed elements render correctly
- [ ] Check wind-element text contrast in light mode
- [ ] Check auto-guard token styling in dark mode