### PR TITLE
Persist search filters across grid slot changes

### DIFF
--- a/components/character/CharacterSearchFilterBar/index.tsx
+++ b/components/character/CharacterSearchFilterBar/index.tsx
@@ -18,6 +18,12 @@ interface Props {
   sendFilters: (filters: { [key: string]: number[] }) => void
 }
 
+// Module-level cache so filter selections persist across grid slot changes
+let cachedRarityState: RarityState = emptyRarityState
+let cachedElementState: ElementState = emptyElementState
+let cachedProficiency1State: ProficiencyState = emptyProficiencyState
+let cachedProficiency2State: ProficiencyState = emptyProficiencyState
+
 const CharacterSearchFilterBar = (props: Props) => {
   const t = useTranslations('common')
 
@@ -26,14 +32,15 @@ const CharacterSearchFilterBar = (props: Props) => {
   const [proficiency1Menu, setProficiency1Menu] = useState(false)
   const [proficiency2Menu, setProficiency2Menu] = useState(false)
 
-  const [rarityState, setRarityState] = useState<RarityState>(emptyRarityState)
+  const [rarityState, setRarityState] =
+    useState<RarityState>(cachedRarityState)
   const [elementState, setElementState] =
-    useState<ElementState>(emptyElementState)
+    useState<ElementState>(cachedElementState)
   const [proficiency1State, setProficiency1State] = useState<ProficiencyState>(
-    emptyProficiencyState
+    cachedProficiency1State
   )
   const [proficiency2State, setProficiency2State] = useState<ProficiencyState>(
-    emptyProficiencyState
+    cachedProficiency2State
   )
 
   function rarityMenuOpened(open: boolean) {
@@ -121,6 +128,10 @@ const CharacterSearchFilterBar = (props: Props) => {
   }
 
   useEffect(() => {
+    cachedRarityState = rarityState
+    cachedElementState = elementState
+    cachedProficiency1State = proficiency1State
+    cachedProficiency2State = proficiency2State
     sendFilters()
   }, [rarityState, elementState, proficiency1State, proficiency2State])
 

--- a/components/job/JobSkillSearchFilterBar/index.tsx
+++ b/components/job/JobSkillSearchFilterBar/index.tsx
@@ -10,12 +10,15 @@ interface Props {
   sendFilters: (filters: { [key: string]: number }) => void
 }
 
+// Module-level cache so filter selections persist across grid slot changes
+let cachedGroup = -1
+
 const JobSkillSearchFilterBar = (props: Props) => {
   // Set up translation
   const t = useTranslations('common')
 
   const [open, setOpen] = useState(false)
-  const [currentGroup, setCurrentGroup] = useState(-1)
+  const [currentGroup, setCurrentGroup] = useState(cachedGroup)
 
   function openSelect() {
     // debugger
@@ -35,6 +38,7 @@ const JobSkillSearchFilterBar = (props: Props) => {
   }
 
   useEffect(() => {
+    cachedGroup = currentGroup
     sendFilters()
   }, [currentGroup])
 

--- a/components/summon/SummonSearchFilterBar/index.tsx
+++ b/components/summon/SummonSearchFilterBar/index.tsx
@@ -16,15 +16,20 @@ interface Props {
   sendFilters: (filters: { [key: string]: number[] }) => void
 }
 
+// Module-level cache so filter selections persist across grid slot changes
+let cachedRarityState: RarityState = emptyRarityState
+let cachedElementState: ElementState = emptyElementState
+
 const SummonSearchFilterBar = (props: Props) => {
   const t = useTranslations('common')
 
   const [rarityMenu, setRarityMenu] = useState(false)
   const [elementMenu, setElementMenu] = useState(false)
 
-  const [rarityState, setRarityState] = useState<RarityState>(emptyRarityState)
+  const [rarityState, setRarityState] =
+    useState<RarityState>(cachedRarityState)
   const [elementState, setElementState] =
-    useState<ElementState>(emptyElementState)
+    useState<ElementState>(cachedElementState)
 
   function rarityMenuOpened(open: boolean) {
     if (open) {
@@ -69,6 +74,8 @@ const SummonSearchFilterBar = (props: Props) => {
   }
 
   useEffect(() => {
+    cachedRarityState = rarityState
+    cachedElementState = elementState
     sendFilters()
   }, [rarityState, elementState])
 

--- a/components/weapon/WeaponSearchFilterBar/index.tsx
+++ b/components/weapon/WeaponSearchFilterBar/index.tsx
@@ -20,6 +20,12 @@ interface Props {
   sendFilters: (filters: { [key: string]: number[] }) => void
 }
 
+// Module-level cache so filter selections persist across grid slot changes
+let cachedRarityState: RarityState = emptyRarityState
+let cachedElementState: ElementState = emptyElementState
+let cachedProficiencyState: ProficiencyState = emptyProficiencyState
+let cachedSeriesState: WeaponSeriesState = emptyWeaponSeriesState
+
 const WeaponSearchFilterBar = (props: Props) => {
   const t = useTranslations('common')
 
@@ -28,17 +34,21 @@ const WeaponSearchFilterBar = (props: Props) => {
   const [proficiencyMenu, setProficiencyMenu] = useState(false)
   const [seriesMenu, setSeriesMenu] = useState(false)
 
-  const [rarityState, setRarityState] = useState<RarityState>(emptyRarityState)
+  const [rarityState, setRarityState] = useState<RarityState>(cachedRarityState)
   const [elementState, setElementState] =
-    useState<ElementState>(emptyElementState)
+    useState<ElementState>(cachedElementState)
   const [proficiencyState, setProficiencyState] = useState<ProficiencyState>(
-    emptyProficiencyState
+    cachedProficiencyState
   )
   const [seriesState, setSeriesState] = useState<WeaponSeriesState>(
-    emptyWeaponSeriesState
+    cachedSeriesState
   )
 
   useEffect(() => {
+    cachedRarityState = rarityState
+    cachedElementState = elementState
+    cachedProficiencyState = proficiencyState
+    cachedSeriesState = seriesState
     sendFilters()
   }, [rarityState, elementState, proficiencyState, seriesState])
 


### PR DESCRIPTION
## Summary
- Adds module-level caches to all search filter bar components (weapon, character, summon, job skill) so filter selections are preserved when switching between grid slots in the party editor
- Previously, clicking a different grid slot would remount the SearchModal and its filter bar, resetting all selections to defaults

## Test plan
- [ ] Open a party editor and select the weapon tab
- [ ] Open a weapon slot's search modal and set some filters (e.g., element=Fire, series=Grand)
- [ ] Select a weapon or close the modal, then click a different weapon slot
- [ ] Verify the search modal opens with the previously selected filters still applied
- [ ] Repeat for character, summon, and job skill search modals

🤖 Generated with [Claude Code](https://claude.com/claude-code)