### PR TITLE
Store search filter selections in localStorage

### DIFF
--- a/components/character/CharacterSearchFilterBar/index.tsx
+++ b/components/character/CharacterSearchFilterBar/index.tsx
@@ -19,10 +19,25 @@ interface Props {
 }
 
 // Module-level cache so filter selections persist across grid slot changes
+// localStorage backs the cache so filters survive page reloads
+const STORAGE_KEY = 'searchFilters_characters'
 let cachedRarityState: RarityState = emptyRarityState
 let cachedElementState: ElementState = emptyElementState
 let cachedProficiency1State: ProficiencyState = emptyProficiencyState
 let cachedProficiency2State: ProficiencyState = emptyProficiencyState
+
+if (typeof window !== 'undefined') {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      const data = JSON.parse(stored)
+      cachedRarityState = data.rarity ?? emptyRarityState
+      cachedElementState = data.element ?? emptyElementState
+      cachedProficiency1State = data.proficiency1 ?? emptyProficiencyState
+      cachedProficiency2State = data.proficiency2 ?? emptyProficiencyState
+    }
+  } catch {}
+}
 
 const CharacterSearchFilterBar = (props: Props) => {
   const t = useTranslations('common')
@@ -132,6 +147,14 @@ const CharacterSearchFilterBar = (props: Props) => {
     cachedElementState = elementState
     cachedProficiency1State = proficiency1State
     cachedProficiency2State = proficiency2State
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+        rarity: rarityState,
+        element: elementState,
+        proficiency1: proficiency1State,
+        proficiency2: proficiency2State,
+      }))
+    } catch {}
     sendFilters()
   }, [rarityState, elementState, proficiency1State, proficiency2State])
 

--- a/components/job/JobSkillSearchFilterBar/index.tsx
+++ b/components/job/JobSkillSearchFilterBar/index.tsx
@@ -11,7 +11,16 @@ interface Props {
 }
 
 // Module-level cache so filter selections persist across grid slot changes
+// localStorage backs the cache so filters survive page reloads
+const STORAGE_KEY = 'searchFilters_jobSkills'
 let cachedGroup = -1
+
+if (typeof window !== 'undefined') {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) cachedGroup = JSON.parse(stored)
+  } catch {}
+}
 
 const JobSkillSearchFilterBar = (props: Props) => {
   // Set up translation
@@ -39,6 +48,9 @@ const JobSkillSearchFilterBar = (props: Props) => {
 
   useEffect(() => {
     cachedGroup = currentGroup
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(currentGroup))
+    } catch {}
     sendFilters()
   }, [currentGroup])
 

--- a/components/summon/SummonSearchFilterBar/index.tsx
+++ b/components/summon/SummonSearchFilterBar/index.tsx
@@ -17,8 +17,21 @@ interface Props {
 }
 
 // Module-level cache so filter selections persist across grid slot changes
+// localStorage backs the cache so filters survive page reloads
+const STORAGE_KEY = 'searchFilters_summons'
 let cachedRarityState: RarityState = emptyRarityState
 let cachedElementState: ElementState = emptyElementState
+
+if (typeof window !== 'undefined') {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      const data = JSON.parse(stored)
+      cachedRarityState = data.rarity ?? emptyRarityState
+      cachedElementState = data.element ?? emptyElementState
+    }
+  } catch {}
+}
 
 const SummonSearchFilterBar = (props: Props) => {
   const t = useTranslations('common')
@@ -76,6 +89,12 @@ const SummonSearchFilterBar = (props: Props) => {
   useEffect(() => {
     cachedRarityState = rarityState
     cachedElementState = elementState
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+        rarity: rarityState,
+        element: elementState,
+      }))
+    } catch {}
     sendFilters()
   }, [rarityState, elementState])
 

--- a/components/weapon/WeaponSearchFilterBar/index.tsx
+++ b/components/weapon/WeaponSearchFilterBar/index.tsx
@@ -21,10 +21,25 @@ interface Props {
 }
 
 // Module-level cache so filter selections persist across grid slot changes
+// localStorage backs the cache so filters survive page reloads
+const STORAGE_KEY = 'searchFilters_weapons'
 let cachedRarityState: RarityState = emptyRarityState
 let cachedElementState: ElementState = emptyElementState
 let cachedProficiencyState: ProficiencyState = emptyProficiencyState
 let cachedSeriesState: WeaponSeriesState = emptyWeaponSeriesState
+
+if (typeof window !== 'undefined') {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      const data = JSON.parse(stored)
+      cachedRarityState = data.rarity ?? emptyRarityState
+      cachedElementState = data.element ?? emptyElementState
+      cachedProficiencyState = data.proficiency ?? emptyProficiencyState
+      cachedSeriesState = data.series ?? emptyWeaponSeriesState
+    }
+  } catch {}
+}
 
 const WeaponSearchFilterBar = (props: Props) => {
   const t = useTranslations('common')
@@ -49,6 +64,14 @@ const WeaponSearchFilterBar = (props: Props) => {
     cachedElementState = elementState
     cachedProficiencyState = proficiencyState
     cachedSeriesState = seriesState
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+        rarity: rarityState,
+        element: elementState,
+        proficiency: proficiencyState,
+        series: seriesState,
+      }))
+    } catch {}
     sendFilters()
   }, [rarityState, elementState, proficiencyState, seriesState])
 


### PR DESCRIPTION
## Summary
- Adds localStorage persistence to search filter bar caches so filter selections survive page reloads and browser restarts
- On module load, caches are initialized from localStorage (with SSR safety)
- On every filter change, selections are written to localStorage under keys: `searchFilters_weapons`, `searchFilters_characters`, `searchFilters_summons`, `searchFilters_jobSkills`
- Builds on #485

## Test plan
- [ ] Open a party editor and set some search filters on a weapon slot
- [ ] Reload the page, open a weapon slot's search modal
- [ ] Verify the previously selected filters are still applied
- [ ] Repeat for character, summon, and job skill filters
- [ ] Open DevTools → Application → Local Storage and verify the keys are present
- [ ] Clear localStorage and verify filters reset to defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)