### PR TITLE
Preserve search filters across grid slot changes

### DIFF
--- a/src/lib/features/search/openSearchSidebar.svelte.ts
+++ b/src/lib/features/search/openSearchSidebar.svelte.ts
@@ -19,6 +19,22 @@ interface SearchSidebarOptions {
 export function openSearchSidebar(options: SearchSidebarOptions) {
 	const { type, onAddItems, canAddMore = true, authUserId, requiredProficiencies, userElement, onUnlinkCollection } = options
 
+	// If sidebar is already open with SearchContent for the same entity type,
+	// update props without remounting to preserve filter state
+	const currentPane = sidebar.paneStack.currentPane
+	if (
+		sidebar.isOpen &&
+		currentPane?.component === SearchContent &&
+		currentPane?.props?.type === type
+	) {
+		sidebar.paneStack.updateCurrentProps({
+			onAddItems,
+			canAddMore,
+			requiredProficiencies
+		})
+		return
+	}
+
 	// Open the sidebar with the search component
 	const title = `Search ${type.charAt(0).toUpperCase() + type.slice(1)}s`
 	sidebar.openWithComponent(title, SearchContent, {


### PR DESCRIPTION
When clicking different grid slots of the same type while the search sidebar is open, filters and filter visibility no longer reset. Instead of remounting SearchContent (which resets all $state), we now update props on the existing pane when the sidebar is already open with the same entity type.

Switching to a different entity type (e.g. weapon → character) still does a fresh open.