### PR TITLE
Persist collection filters to localStorage

### DIFF
--- a/src/lib/stores/collectionFilters.svelte.ts
+++ b/src/lib/stores/collectionFilters.svelte.ts
@@ -1,0 +1,155 @@
+import type { CollectionSortKey } from '$lib/types/api/collection'
+
+const STORAGE_KEY_PREFIX = 'collection-filters'
+
+interface CharacterFilters {
+	element: number[]
+	rarity: number[]
+	race: number[]
+	proficiency: number[]
+	gender: number[]
+	sort: CollectionSortKey
+}
+
+interface WeaponFilters {
+	element: number[]
+	rarity: number[]
+	proficiency: number[]
+	series: (number | string)[]
+	sort: CollectionSortKey
+}
+
+interface SummonFilters {
+	element: number[]
+	rarity: number[]
+	sort: CollectionSortKey
+}
+
+interface ArtifactFilters {
+	element: number[]
+	proficiency: number[]
+	rarity: 'all' | 'standard' | 'quirk'
+	slot1: number[]
+	slot2: number[]
+	slot3: number[]
+	slot4: number[]
+}
+
+type EntityFilters = {
+	characters: CharacterFilters
+	weapons: WeaponFilters
+	summons: SummonFilters
+	artifacts: ArtifactFilters
+}
+
+const DEFAULTS: EntityFilters = {
+	characters: {
+		element: [],
+		rarity: [],
+		race: [],
+		proficiency: [],
+		gender: [],
+		sort: 'name_asc'
+	},
+	weapons: { element: [], rarity: [], proficiency: [], series: [], sort: 'name_asc' },
+	summons: { element: [], rarity: [], sort: 'name_asc' },
+	artifacts: {
+		element: [],
+		proficiency: [],
+		rarity: 'all',
+		slot1: [],
+		slot2: [],
+		slot3: [],
+		slot4: []
+	}
+}
+
+class CollectionFiltersStore {
+	#characters = $state<CharacterFilters>({ ...DEFAULTS.characters })
+	#weapons = $state<WeaponFilters>({ ...DEFAULTS.weapons })
+	#summons = $state<SummonFilters>({ ...DEFAULTS.summons })
+	#artifacts = $state<ArtifactFilters>({ ...DEFAULTS.artifacts })
+	#initialized = false
+
+	constructor() {
+		if (typeof window !== 'undefined') {
+			this.#loadFromStorage()
+		}
+	}
+
+	#loadFromStorage() {
+		if (this.#initialized) return
+		this.#initialized = true
+
+		this.#characters = this.#load('characters', DEFAULTS.characters)
+		this.#weapons = this.#load('weapons', DEFAULTS.weapons)
+		this.#summons = this.#load('summons', DEFAULTS.summons)
+		this.#artifacts = this.#load('artifacts', DEFAULTS.artifacts)
+	}
+
+	#load<K extends keyof EntityFilters>(key: K, defaults: EntityFilters[K]): EntityFilters[K] {
+		try {
+			const stored = localStorage.getItem(`${STORAGE_KEY_PREFIX}-${key}`)
+			if (!stored) return { ...defaults }
+			const parsed = JSON.parse(stored)
+			// Merge with defaults to handle missing keys from schema changes
+			return { ...defaults, ...parsed }
+		} catch {
+			return { ...defaults }
+		}
+	}
+
+	#save<K extends keyof EntityFilters>(key: K, value: EntityFilters[K]) {
+		if (typeof window !== 'undefined') {
+			localStorage.setItem(`${STORAGE_KEY_PREFIX}-${key}`, JSON.stringify(value))
+		}
+	}
+
+	#ensureInit() {
+		if (typeof window !== 'undefined' && !this.#initialized) {
+			this.#loadFromStorage()
+		}
+	}
+
+	get characters(): CharacterFilters {
+		this.#ensureInit()
+		return this.#characters
+	}
+
+	get weapons(): WeaponFilters {
+		this.#ensureInit()
+		return this.#weapons
+	}
+
+	get summons(): SummonFilters {
+		this.#ensureInit()
+		return this.#summons
+	}
+
+	get artifacts(): ArtifactFilters {
+		this.#ensureInit()
+		return this.#artifacts
+	}
+
+	setCharacters(filters: Partial<CharacterFilters>) {
+		this.#characters = { ...this.#characters, ...filters }
+		this.#save('characters', this.#characters)
+	}
+
+	setWeapons(filters: Partial<WeaponFilters>) {
+		this.#weapons = { ...this.#weapons, ...filters }
+		this.#save('weapons', this.#weapons)
+	}
+
+	setSummons(filters: Partial<SummonFilters>) {
+		this.#summons = { ...this.#summons, ...filters }
+		this.#save('summons', this.#summons)
+	}
+
+	setArtifacts(filters: Partial<ArtifactFilters>) {
+		this.#artifacts = { ...this.#artifacts, ...filters }
+		this.#save('artifacts', this.#artifacts)
+	}
+}
+
+export const collectionFilters = new CollectionFiltersStore()

--- a/src/routes/(app)/[username]/collection/artifacts/+page.svelte
+++ b/src/routes/(app)/[username]/collection/artifacts/+page.svelte
@@ -13,6 +13,7 @@
 	import ViewModeToggle from '$lib/components/ui/ViewModeToggle.svelte'
 	import MultiSelect from '$lib/components/ui/MultiSelect.svelte'
 	import { sidebar } from '$lib/stores/sidebar.svelte'
+	import { collectionFilters } from '$lib/stores/collectionFilters.svelte'
 	import { viewMode, type ViewMode } from '$lib/stores/viewMode.svelte'
 	import Select from '$lib/components/ui/Select.svelte'
 	import { getArtifactImage } from '$lib/utils/images'
@@ -29,16 +30,16 @@
 		data.user?.avatar?.element as 'wind' | 'fire' | 'water' | 'earth' | 'dark' | 'light' | undefined
 	)
 
-	// Filter state
-	let elementFilters = $state<number[]>([])
-	let proficiencyFilters = $state<number[]>([])
-	let rarityFilter = $state<'all' | 'standard' | 'quirk'>('all')
+	// Filter state (initialized from localStorage)
+	let elementFilters = $state<number[]>(collectionFilters.artifacts.element)
+	let proficiencyFilters = $state<number[]>(collectionFilters.artifacts.proficiency)
+	let rarityFilter = $state<'all' | 'standard' | 'quirk'>(collectionFilters.artifacts.rarity)
 
-	// Skill filter state - array of modifier IDs per slot
-	let slot1Filters = $state<number[]>([])
-	let slot2Filters = $state<number[]>([])
-	let slot3Filters = $state<number[]>([])
-	let slot4Filters = $state<number[]>([])
+	// Skill filter state - array of modifier IDs per slot (initialized from localStorage)
+	let slot1Filters = $state<number[]>(collectionFilters.artifacts.slot1)
+	let slot2Filters = $state<number[]>(collectionFilters.artifacts.slot2)
+	let slot3Filters = $state<number[]>(collectionFilters.artifacts.slot3)
+	let slot4Filters = $state<number[]>(collectionFilters.artifacts.slot4)
 
 	// Element options for MultiSelect
 	const elementOptions = [
@@ -108,6 +109,19 @@
 		slot3Filters = []
 		slot4Filters = []
 	}
+
+	// Persist all filter state to localStorage
+	$effect(() => {
+		collectionFilters.setArtifacts({
+			element: elementFilters,
+			proficiency: proficiencyFilters,
+			rarity: rarityFilter,
+			slot1: slot1Filters,
+			slot2: slot2Filters,
+			slot3: slot3Filters,
+			slot4: slot4Filters
+		})
+	})
 
 	// Sentinel for infinite scroll
 	let sentinelEl = $state<HTMLElement>()

--- a/src/routes/(app)/[username]/collection/characters/+page.svelte
+++ b/src/routes/(app)/[username]/collection/characters/+page.svelte
@@ -14,6 +14,7 @@
 	import SelectableCollectionRow from '$lib/components/collection/SelectableCollectionRow.svelte'
 	import Icon from '$lib/components/Icon.svelte'
 	import { sidebar } from '$lib/stores/sidebar.svelte'
+	import { collectionFilters } from '$lib/stores/collectionFilters.svelte'
 	import { viewMode, type ViewMode } from '$lib/stores/viewMode.svelte'
 	import { LOADED_IDS_KEY, type LoadedIdsContext } from '$lib/stores/selectionMode.svelte'
 	import { useInfiniteLoader } from '$lib/stores/loaderState.svelte'
@@ -28,15 +29,15 @@
 		data.user?.avatar?.element as 'wind' | 'fire' | 'water' | 'earth' | 'dark' | 'light' | undefined
 	)
 
-	// Filter state
-	let elementFilters = $state<number[]>([])
-	let rarityFilters = $state<number[]>([])
-	let raceFilters = $state<number[]>([])
-	let proficiencyFilters = $state<number[]>([])
-	let genderFilters = $state<number[]>([])
+	// Filter state (initialized from localStorage)
+	let elementFilters = $state<number[]>(collectionFilters.characters.element)
+	let rarityFilters = $state<number[]>(collectionFilters.characters.rarity)
+	let raceFilters = $state<number[]>(collectionFilters.characters.race)
+	let proficiencyFilters = $state<number[]>(collectionFilters.characters.proficiency)
+	let genderFilters = $state<number[]>(collectionFilters.characters.gender)
 
-	// Sort state
-	let sortBy = $state<CollectionSortKey>('name_asc')
+	// Sort state (initialized from localStorage)
+	let sortBy = $state<CollectionSortKey>(collectionFilters.characters.sort)
 
 	// Sentinel for infinite scroll
 	let sentinelEl = $state<HTMLElement>()
@@ -98,6 +99,18 @@
 		proficiencyFilters = filters.proficiency
 		genderFilters = filters.gender
 	}
+
+	// Persist all filter and sort state to localStorage
+	$effect(() => {
+		collectionFilters.setCharacters({
+			element: elementFilters,
+			rarity: rarityFilters,
+			race: raceFilters,
+			proficiency: proficiencyFilters,
+			gender: genderFilters,
+			sort: sortBy
+		})
+	})
 
 	function handleViewModeChange(mode: ViewMode) {
 		viewMode.setCollectionView(mode)

--- a/src/routes/(app)/[username]/collection/summons/+page.svelte
+++ b/src/routes/(app)/[username]/collection/summons/+page.svelte
@@ -14,6 +14,7 @@
 	import SelectableCollectionRow from '$lib/components/collection/SelectableCollectionRow.svelte'
 	import Icon from '$lib/components/Icon.svelte'
 	import { sidebar } from '$lib/stores/sidebar.svelte'
+	import { collectionFilters } from '$lib/stores/collectionFilters.svelte'
 	import { viewMode, type ViewMode } from '$lib/stores/viewMode.svelte'
 	import { LOADED_IDS_KEY, type LoadedIdsContext } from '$lib/stores/selectionMode.svelte'
 	import { useInfiniteLoader } from '$lib/stores/loaderState.svelte'
@@ -28,12 +29,12 @@
 		data.user?.avatar?.element as 'wind' | 'fire' | 'water' | 'earth' | 'dark' | 'light' | undefined
 	)
 
-	// Filter state
-	let elementFilters = $state<number[]>([])
-	let rarityFilters = $state<number[]>([])
+	// Filter state (initialized from localStorage)
+	let elementFilters = $state<number[]>(collectionFilters.summons.element)
+	let rarityFilters = $state<number[]>(collectionFilters.summons.rarity)
 
-	// Sort state
-	let sortBy = $state<CollectionSortKey>('name_asc')
+	// Sort state (initialized from localStorage)
+	let sortBy = $state<CollectionSortKey>(collectionFilters.summons.sort)
 
 	// Sentinel for infinite scroll
 	let sentinelEl = $state<HTMLElement>()
@@ -89,6 +90,15 @@
 		elementFilters = filters.element
 		rarityFilters = filters.rarity
 	}
+
+	// Persist all filter and sort state to localStorage
+	$effect(() => {
+		collectionFilters.setSummons({
+			element: elementFilters,
+			rarity: rarityFilters,
+			sort: sortBy
+		})
+	})
 
 	function handleViewModeChange(mode: ViewMode) {
 		viewMode.setCollectionView(mode)

--- a/src/routes/(app)/[username]/collection/weapons/+page.svelte
+++ b/src/routes/(app)/[username]/collection/weapons/+page.svelte
@@ -14,6 +14,7 @@
 	import SelectableCollectionRow from '$lib/components/collection/SelectableCollectionRow.svelte'
 	import Icon from '$lib/components/Icon.svelte'
 	import { sidebar } from '$lib/stores/sidebar.svelte'
+	import { collectionFilters } from '$lib/stores/collectionFilters.svelte'
 	import { viewMode, type ViewMode } from '$lib/stores/viewMode.svelte'
 	import { LOADED_IDS_KEY, type LoadedIdsContext } from '$lib/stores/selectionMode.svelte'
 	import { useInfiniteLoader } from '$lib/stores/loaderState.svelte'
@@ -28,14 +29,14 @@
 		data.user?.avatar?.element as 'wind' | 'fire' | 'water' | 'earth' | 'dark' | 'light' | undefined
 	)
 
-	// Filter state
-	let elementFilters = $state<number[]>([])
-	let rarityFilters = $state<number[]>([])
-	let proficiencyFilters = $state<number[]>([])
-	let seriesFilters = $state<(number | string)[]>([])
+	// Filter state (initialized from localStorage)
+	let elementFilters = $state<number[]>(collectionFilters.weapons.element)
+	let rarityFilters = $state<number[]>(collectionFilters.weapons.rarity)
+	let proficiencyFilters = $state<number[]>(collectionFilters.weapons.proficiency)
+	let seriesFilters = $state<(number | string)[]>(collectionFilters.weapons.series)
 
-	// Sort state
-	let sortBy = $state<CollectionSortKey>('name_asc')
+	// Sort state (initialized from localStorage)
+	let sortBy = $state<CollectionSortKey>(collectionFilters.weapons.sort)
 
 	// Sentinel for infinite scroll
 	let sentinelEl = $state<HTMLElement>()
@@ -95,6 +96,17 @@
 		proficiencyFilters = filters.proficiency
 		seriesFilters = filters.series
 	}
+
+	// Persist all filter and sort state to localStorage
+	$effect(() => {
+		collectionFilters.setWeapons({
+			element: elementFilters,
+			rarity: rarityFilters,
+			proficiency: proficiencyFilters,
+			series: seriesFilters,
+			sort: sortBy
+		})
+	})
 
 	function handleViewModeChange(mode: ViewMode) {
 		viewMode.setCollectionView(mode)


### PR DESCRIPTION
Collection page filters (element, rarity, proficiency, sort, etc.) now persist to localStorage per entity type. Filters are restored on page load so they survive reloads and navigation.

New store at `collectionFilters.svelte.ts` follows the existing `viewMode.svelte.ts` pattern. All four collection pages (characters, weapons, summons, artifacts) load initial state from the store and sync changes back via `$effect`.