### PR TITLE
Fix infinite effect loop in collection filters

### DIFF
--- a/src/routes/(app)/[username]/collection/artifacts/+page.svelte
+++ b/src/routes/(app)/[username]/collection/artifacts/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types'
 	import type { CollectionArtifact } from '$lib/types/api/artifact'
-	import { getContext, onDestroy } from 'svelte'
+	import { getContext, onDestroy, untrack } from 'svelte'
 	import { createInfiniteQuery, createQuery } from '@tanstack/svelte-query'
 	import { artifactQueries } from '$lib/api/queries/artifact.queries'
 	import CollectionArtifactDetailPane from '$lib/components/collection/CollectionArtifactDetailPane.svelte'
@@ -112,7 +112,7 @@
 
 	// Persist all filter state to localStorage
 	$effect(() => {
-		collectionFilters.setArtifacts({
+		const filters = {
 			element: elementFilters,
 			proficiency: proficiencyFilters,
 			rarity: rarityFilter,
@@ -120,7 +120,8 @@
 			slot2: slot2Filters,
 			slot3: slot3Filters,
 			slot4: slot4Filters
-		})
+		}
+		untrack(() => collectionFilters.setArtifacts(filters))
 	})
 
 	// Sentinel for infinite scroll

--- a/src/routes/(app)/[username]/collection/characters/+page.svelte
+++ b/src/routes/(app)/[username]/collection/characters/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types'
 	import type { CollectionCharacter, CollectionSortKey } from '$lib/types/api/collection'
-	import { getContext, onDestroy } from 'svelte'
+	import { getContext, onDestroy, untrack } from 'svelte'
 	import { createInfiniteQuery } from '@tanstack/svelte-query'
 	import { collectionQueries } from '$lib/api/queries/collection.queries'
 	import CollectionFilters, {
@@ -102,14 +102,15 @@
 
 	// Persist all filter and sort state to localStorage
 	$effect(() => {
-		collectionFilters.setCharacters({
+		const filters = {
 			element: elementFilters,
 			rarity: rarityFilters,
 			race: raceFilters,
 			proficiency: proficiencyFilters,
 			gender: genderFilters,
 			sort: sortBy
-		})
+		}
+		untrack(() => collectionFilters.setCharacters(filters))
 	})
 
 	function handleViewModeChange(mode: ViewMode) {

--- a/src/routes/(app)/[username]/collection/summons/+page.svelte
+++ b/src/routes/(app)/[username]/collection/summons/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types'
 	import type { CollectionSummon, CollectionSortKey } from '$lib/types/api/collection'
-	import { getContext, onDestroy } from 'svelte'
+	import { getContext, onDestroy, untrack } from 'svelte'
 	import { createInfiniteQuery } from '@tanstack/svelte-query'
 	import { collectionQueries } from '$lib/api/queries/collection.queries'
 	import CollectionFilters, {
@@ -93,11 +93,12 @@
 
 	// Persist all filter and sort state to localStorage
 	$effect(() => {
-		collectionFilters.setSummons({
+		const filters = {
 			element: elementFilters,
 			rarity: rarityFilters,
 			sort: sortBy
-		})
+		}
+		untrack(() => collectionFilters.setSummons(filters))
 	})
 
 	function handleViewModeChange(mode: ViewMode) {

--- a/src/routes/(app)/[username]/collection/weapons/+page.svelte
+++ b/src/routes/(app)/[username]/collection/weapons/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types'
 	import type { CollectionWeapon, CollectionSortKey } from '$lib/types/api/collection'
-	import { getContext, onDestroy } from 'svelte'
+	import { getContext, onDestroy, untrack } from 'svelte'
 	import { createInfiniteQuery } from '@tanstack/svelte-query'
 	import { collectionQueries } from '$lib/api/queries/collection.queries'
 	import CollectionFilters, {
@@ -99,13 +99,14 @@
 
 	// Persist all filter and sort state to localStorage
 	$effect(() => {
-		collectionFilters.setWeapons({
+		const filters = {
 			element: elementFilters,
 			rarity: rarityFilters,
 			proficiency: proficiencyFilters,
 			series: seriesFilters,
 			sort: sortBy
-		})
+		}
+		untrack(() => collectionFilters.setWeapons(filters))
 	})
 
 	function handleViewModeChange(mode: ViewMode) {


### PR DESCRIPTION
Wrap store writes in `untrack()` to prevent the `$effect` from tracking the store's internal `$state` reads, which caused `effect_update_depth_exceeded`.