### PR TITLE
Add None option to weapon element dropdown

### DIFF
--- a/src/lib/components/sidebar/EditWeaponSidebar.svelte
+++ b/src/lib/components/sidebar/EditWeaponSidebar.svelte
@@ -102,7 +102,7 @@
 
 	// Element options
 	const elementOptions = [
-		{ value: 0, label: 'None' },
+		{ value: 0, label: 'No element' },
 		{ value: 1, label: 'Wind', image: getElementIcon(1) },
 		{ value: 2, label: 'Fire', image: getElementIcon(2) },
 		{ value: 3, label: 'Water', image: getElementIcon(3) },


### PR DESCRIPTION
## Summary
- Adds a "None" (value 0) option to the element select in the weapon edit sidebar so users can clear a weapon's element back to unset

## Test plan
- [ ] Open edit sidebar for an element-changeable weapon
- [ ] Verify "None" appears as the first option in the element dropdown
- [ ] Select "None", save, confirm element is cleared