### PR TITLE
Use element-null icon for No element option

### DIFF
--- a/src/lib/components/sidebar/EditWeaponSidebar.svelte
+++ b/src/lib/components/sidebar/EditWeaponSidebar.svelte
@@ -102,7 +102,7 @@
 
 	// Element options
 	const elementOptions = [
-		{ value: 0, label: 'No element' },
+		{ value: 0, label: 'No element', image: getElementIcon(0) },
 		{ value: 1, label: 'Wind', image: getElementIcon(1) },
 		{ value: 2, label: 'Fire', image: getElementIcon(2) },
 		{ value: 3, label: 'Water', image: getElementIcon(3) },

--- a/src/lib/utils/images.ts
+++ b/src/lib/utils/images.ts
@@ -385,6 +385,7 @@ export function getGenderLabelImage(genderLabel: string): string {
  */
 export function getElementIcon(element: number): string {
 	const elementNames: Record<number, string> = {
+		0: 'null',
 		1: 'wind',
 		2: 'fire',
 		3: 'water',


### PR DESCRIPTION
## Summary
- Maps element 0 to `element-null` in `getElementIcon()` so the "No element" dropdown option shows the null element icon instead of nothing

## Test plan
- [ ] Edit a weapon with changeable element, verify "No element" shows the null element icon in the dropdown