### PR TITLE
Only use alt summon art for specific IDs

### DIFF
--- a/src/lib/components/collection/CollectionSummonCard.svelte
+++ b/src/lib/components/collection/CollectionSummonCard.svelte
@@ -10,7 +10,7 @@
 
 	let { summon, onClick }: Props = $props()
 
-	const transformation = $derived(getSummonTransformation(summon.uncapLevel, summon.transcendenceStep))
+	const transformation = $derived(getSummonTransformation(summon.summon?.granblueId, summon.uncapLevel, summon.transcendenceStep))
 
 	const imageUrl = $derived(getSummonImage(summon.summon?.granblueId, 'wide', transformation))
 

--- a/src/lib/components/collection/CollectionSummonRow.svelte
+++ b/src/lib/components/collection/CollectionSummonRow.svelte
@@ -11,7 +11,7 @@
 
 	let { summon, onClick }: Props = $props()
 
-	const transformation = $derived(getSummonTransformation(summon.uncapLevel, summon.transcendenceStep))
+	const transformation = $derived(getSummonTransformation(summon.summon?.granblueId, summon.uncapLevel, summon.transcendenceStep))
 
 	const imageUrl = $derived(getSummonImage(summon.summon?.granblueId, 'wide', transformation))
 

--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -38,7 +38,7 @@
 
   let imageUrl = $derived.by(() => {
     const variant = isMainSized ? 'main' : 'grid'
-    const transformation = getSummonTransformation(item?.uncapLevel, item?.transcendenceStep)
+    const transformation = getSummonTransformation(item?.summon?.granblueId, item?.uncapLevel, item?.transcendenceStep)
     return getSummonImage(item?.summon?.granblueId, variant, transformation)
   })
 

--- a/src/lib/utils/images.ts
+++ b/src/lib/utils/images.ts
@@ -57,10 +57,33 @@ export function getGenericPlaceholder(): string {
 }
 
 /**
+ * Summon IDs that have alternate art at different uncap levels.
+ * Only these summons change their image based on uncap/transcendence.
+ */
+const SUMMONS_WITH_ALT_ART = new Set([
+	'2040094000',
+	'2040100000',
+	'2040080000',
+	'2040098000',
+	'2040090000',
+	'2040084000',
+	'2040003000',
+	'2040056000',
+	'2040020000',
+	'2040034000',
+	'2040028000',
+	'2040027000',
+	'2040046000',
+	'2040047000',
+])
+
+/**
  * Calculates the summon transformation suffix based on uncap level and transcendence
  * Returns undefined for base art, '02' for ULB, '03' for transcendence 1-4, '04' for transcendence 5+
+ * Only applies to summons in the SUMMONS_WITH_ALT_ART set.
  */
-export function getSummonTransformation(uncapLevel?: number, transcendenceStep?: number): string | undefined {
+export function getSummonTransformation(granblueId?: string | number | null, uncapLevel?: number, transcendenceStep?: number): string | undefined {
+	if (!granblueId || !SUMMONS_WITH_ALT_ART.has(String(granblueId))) return undefined
 	if (transcendenceStep && transcendenceStep >= 5) return '04'
 	if (transcendenceStep && transcendenceStep > 0) return '03'
 	if (uncapLevel && uncapLevel >= 5) return '02'


### PR DESCRIPTION
## Summary
- Gate `getSummonTransformation` behind a list of specific granblue IDs that actually have alternate art
- Previously all summons would try to load alt art based on uncap level, now only the 14 summons with actual alt art do

## Test plan
- [ ] Verify summons in the allow-list show correct art at different uncap levels (base, ULB, transcendence)
- [ ] Verify summons not in the list always show base art regardless of uncap level
- [ ] Check collection views (card + row) as well as party grid