### PR TITLE
Fix DetailRow value alignment for child content

### DIFF
--- a/src/lib/components/sidebar/details/DetailRow.svelte
+++ b/src/lib/components/sidebar/details/DetailRow.svelte
@@ -60,6 +60,9 @@
 			font-size: typography.$font-regular;
 			color: var(--text-primary);
 			min-width: 180px;
+			display: flex;
+			justify-content: flex-end;
+			align-items: center;
 		}
 
 		// Static value display (no children snippet)


### PR DESCRIPTION
## Summary
- DetailRow values with children snippets (Element, Proficiency, Max Uncap) were not right-aligned
- Add flexbox alignment to `.value` so child content aligns to the right consistently