### PR TITLE
Use raid-level extra in database display

### DIFF
--- a/src/lib/types/api/entities.ts
+++ b/src/lib/types/api/entities.ts
@@ -225,6 +225,7 @@ export interface Raid {
   name: LocalizedName
   level: number
   element: number
+  extra: boolean
   enemy_id?: number
   summon_id?: number
   quest_id?: number

--- a/src/lib/types/api/raid.ts
+++ b/src/lib/types/api/raid.ts
@@ -16,6 +16,7 @@ export interface RaidFull {
   name: LocalizedName
   level: number
   element: number
+  extra: boolean
   enemy_id?: number
   summon_id?: number
   quest_id?: number

--- a/src/routes/(app)/database/raids/+page.svelte
+++ b/src/routes/(app)/database/raids/+page.svelte
@@ -118,7 +118,7 @@
 		// Apply Extra filter (1 = yes, 0 = no)
 		if (extraFilter !== undefined) {
 			const extraBool = extraFilter === 1
-			raids = raids.filter((r) => r.group?.extra === extraBool)
+			raids = raids.filter((r) => r.extra === extraBool)
 		}
 
 		// Sort by group section, then group order, then element

--- a/src/routes/(app)/database/raids/[slug]/+page.svelte
+++ b/src/routes/(app)/database/raids/[slug]/+page.svelte
@@ -200,7 +200,7 @@
 								<span class="badge" class:active={raid.group.hl}>{raid.group.hl ? 'Yes' : 'No'}</span>
 							</DetailItem>
 							<DetailItem label="Extra">
-								<span class="badge" class:active={raid.group.extra}>{raid.group.extra ? 'Yes' : 'No'}</span>
+								<span class="badge" class:active={raid.extra}>{raid.extra ? 'Yes' : 'No'}</span>
 							</DetailItem>
 							<DetailItem label="Guidebooks">
 								<span class="badge" class:active={raid.group.guidebooks}>{raid.group.guidebooks ? 'Yes' : 'No'}</span>


### PR DESCRIPTION
## Summary
- Added `extra` field to `Raid` and `RaidFull` types (resolved by API via `effective_extra`)
- Raid detail page reads `raid.extra` instead of `raid.group.extra`
- Raid list extra filter uses `r.extra` instead of `r.group?.extra`

Companion API PR: https://github.com/jedmund/hensei-api/pull/259