### PR TITLE
Use raid-level extra for party extra slots

### DIFF
--- a/src/lib/components/party/Party.svelte
+++ b/src/lib/components/party/Party.svelte
@@ -409,7 +409,7 @@
 				{#if activeTab === GridType.Weapon}
 					<WeaponGrid
 						weapons={party.weapons}
-						raidExtra={(party as any)?.raid?.group?.extra}
+						raidExtra={(party as any)?.raid?.extra}
 						showGuidebooks={(party as any)?.raid?.group?.guidebooks}
 						guidebooks={(party as any)?.guidebooks}
 						{collectionWeaponItems}

--- a/src/lib/components/reps/GridRep.svelte
+++ b/src/lib/components/reps/GridRep.svelte
@@ -64,7 +64,7 @@
 							{/snippet}
 						</Tooltip>
 					{/if}
-					{#if party.raid?.group?.extra}
+					{#if party.raid?.extra}
 						<Tooltip content="Extra">
 							{#snippet children()}
 								<span class="pill extra">


### PR DESCRIPTION
## Summary
- Party.svelte: reads `raid.extra` (resolved by API) instead of `raid.group.extra` for extra weapon slots
- GridRep.svelte: same change for the extra badge on party cards

Depends on API PR #259 which adds `effective_extra` to the raid response.