### PR TITLE
Add unit type to duplicate context menu label

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -51,7 +51,7 @@
 	"context_view_in_database": "View in Database",
 	"context_replace": "Replace {type}",
 	"context_remove": "Remove from team",
-	"context_duplicate": "Duplicate",
+	"context_duplicate": "Duplicate {type}",
 
 	"duplicate_collection_title": "Duplicate collection item?",
 	"duplicate_collection_body": "The duplicate will not be linked to your collection. Changes to the original in your collection won't sync to the copy.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -51,7 +51,7 @@
 	"context_view_in_database": "データベースで見る",
 	"context_replace": "{type}を交換",
 	"context_remove": "編成から外す",
-	"context_duplicate": "複製する",
+	"context_duplicate": "{type}を複製する",
 
 	"duplicate_collection_title": "コレクションのアイテムを複製しますか？",
 	"duplicate_collection_body": "複製はコレクションとリンクされません。コレクションでの変更は複製に反映されません。",

--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -187,7 +187,7 @@
           viewDetailsLabel={m.context_view_details()}
           viewInDatabaseLabel={m.context_view_in_database()}
           replaceLabel={m.context_replace({ type: m.type_summon() })}
-          duplicateLabel={m.context_duplicate()}
+          duplicateLabel={m.context_duplicate({ type: m.type_summon() })}
           removeLabel={m.context_remove()}
         />
       {/snippet}
@@ -205,7 +205,7 @@
           viewDetailsLabel={m.context_view_details()}
           viewInDatabaseLabel={m.context_view_in_database()}
           replaceLabel={m.context_replace({ type: m.type_summon() })}
-          duplicateLabel={m.context_duplicate()}
+          duplicateLabel={m.context_duplicate({ type: m.type_summon() })}
           removeLabel={m.context_remove()}
         />
       {/snippet}

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -265,7 +265,7 @@
 					viewDetailsLabel={m.context_view_details()}
 					viewInDatabaseLabel={m.context_view_in_database()}
 					replaceLabel={m.context_replace({ type: m.type_weapon() })}
-					duplicateLabel={m.context_duplicate()}
+					duplicateLabel={m.context_duplicate({ type: m.type_weapon() })}
 					removeLabel={m.context_remove()}
 				/>
 			{/snippet}
@@ -285,7 +285,7 @@
 					viewDetailsLabel={m.context_view_details()}
 					viewInDatabaseLabel={m.context_view_in_database()}
 					replaceLabel={m.context_replace({ type: m.type_weapon() })}
-					duplicateLabel={m.context_duplicate()}
+					duplicateLabel={m.context_duplicate({ type: m.type_weapon() })}
 					removeLabel={m.context_remove()}
 				/>
 			{/snippet}


### PR DESCRIPTION
## Summary
- Context menu "Duplicate" now reads "Duplicate weapon" or "Duplicate summon" depending on the unit type, matching how "Replace weapon"/"Replace summon" already works
- Updated i18n messages (en + ja) to accept a `{type}` param