### PR TITLE
Style guidebooks like additional weapons section

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -45,6 +45,7 @@
 	"skill_selection_search_placeholder": "Search skills...",
 
 	"extra_weapons": "Additional Weapons",
+	"guidebooks": "Guidebooks",
 
 	"context_edit": "Edit {type}",
 	"context_view_details": "View details",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -45,6 +45,7 @@
 	"skill_selection_search_placeholder": "スキルを検索...",
 
 	"extra_weapons": "追加武器",
+	"guidebooks": "教本",
 
 	"context_edit": "{type}を編集",
 	"context_view_details": "詳細を見る",

--- a/src/lib/components/extra/GuidebookUnit.svelte
+++ b/src/lib/components/extra/GuidebookUnit.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from '$lib/components/Icon.svelte'
   import { getGuidebookImage } from '$lib/utils/images'
   import { localizedName } from '$lib/utils/locale'
   import type { Guidebook } from '$lib/types/api/entities'
@@ -23,29 +24,45 @@
   }
 </script>
 
-{#if canEdit}
-  <button
-    class="unit"
-    class:empty={!item}
-    onclick={() => onclick?.()}
-    oncontextmenu={handleContextMenu}
-    type="button"
-  >
-    <img class="image" alt={name} src={imageUrl} />
-    <div class="name">{name}</div>
-  </button>
-{:else}
-  <div class="unit" class:empty={!item}>
-    <img class="image" alt={name} src={imageUrl} />
-    <div class="name">{name}</div>
-  </div>
-{/if}
+<div class="unit" class:empty={!item}>
+  {#if item}
+    <div
+      class="frame"
+      class:editable={canEdit}
+      role={canEdit ? 'button' : undefined}
+      tabindex={canEdit ? 0 : undefined}
+      onclick={() => canEdit && onclick?.()}
+      oncontextmenu={handleContextMenu}
+      onkeydown={(e) => { if (canEdit && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); onclick?.() }}}
+    >
+      <img class="image" alt={name} src={imageUrl} />
+    </div>
+  {:else}
+    <div
+      class="frame"
+      class:editable={canEdit}
+      role={canEdit ? 'button' : undefined}
+      tabindex={canEdit ? 0 : undefined}
+      onclick={() => canEdit && onclick?.()}
+      onkeydown={(e) => { if (canEdit && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); onclick?.() }}}
+    >
+      {#if canEdit}
+        <span class="icon">
+          <Icon name="plus" size={24} />
+        </span>
+      {/if}
+    </div>
+  {/if}
+  <div class="name">{item ? name : ''}</div>
+</div>
 
 <style lang="scss">
-  @use '$src/themes/colors' as *;
-  @use '$src/themes/typography' as *;
-  @use '$src/themes/spacing' as *;
+  @use '$src/themes/colors' as colors;
+  @use '$src/themes/typography' as typography;
+  @use '$src/themes/spacing' as spacing;
   @use '$src/themes/layout' as layout;
+  @use '$src/themes/rep' as rep;
+  @use '$src/themes/effects' as effects;
 
   .unit {
     position: relative;
@@ -53,45 +70,59 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: $unit;
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: default;
+    gap: spacing.$unit;
+
+    &.empty .name {
+      display: none;
+    }
   }
 
-  button.unit {
-    cursor: pointer;
+  .frame {
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+    border-radius: layout.$input-corner;
+    background: var(--extra-purple-card-bg);
+    transition: opacity 0.2s ease-in-out;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    @include rep.aspect(rep.$weapon-cell-w, rep.$weapon-cell-h);
 
-    &:hover .image {
-      border-color: var(--accent-primary);
-    }
+    &.editable {
+      cursor: pointer;
 
-    &.empty {
-      .image {
-        opacity: 0.5;
-      }
-
-      &:hover .image {
-        opacity: 0.75;
-        border-color: var(--accent-primary);
+      &:hover {
+        opacity: 0.95;
+        box-shadow: var(--shadow-sm);
       }
     }
   }
 
   .image {
+    position: relative;
     width: 100%;
-    height: auto;
-    border: 1px solid $grey-75;
-    border-radius: layout.$input-corner;
+    height: 100%;
+    object-fit: cover;
     display: block;
-    background: var(--extra-purple-card-bg);
-    transition: border-color 0.15s ease-out, opacity 0.15s ease-out;
+    z-index: effects.$z-badge;
+  }
+
+  .icon {
+    position: absolute;
+    z-index: effects.$z-raised;
+    color: var(--extra-purple-secondary);
+    transition: color 0.2s ease-in-out;
+  }
+
+  .frame.editable:hover .icon {
+    color: var(--extra-purple-primary);
   }
 
   .name {
-    font-size: $font-small;
+    font-size: typography.$font-small;
+    font-weight: typography.$medium;
     text-align: center;
-    color: var(--text-secondary);
+    color: var(--extra-purple-text);
   }
 </style>

--- a/src/lib/components/extra/GuidebooksGrid.svelte
+++ b/src/lib/components/extra/GuidebooksGrid.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import GuidebookUnit from '$lib/components/extra/GuidebookUnit.svelte'
+  import ExtraContainerItem from './ExtraContainerItem.svelte'
   import type { GuidebookList } from '$lib/types/api/party'
+  import * as m from '$lib/paraglide/messages'
 
   interface Props {
     guidebooks?: GuidebookList
@@ -12,7 +14,7 @@
   let { guidebooks, canEdit = false, onClickSlot, onRemove }: Props = $props()
 </script>
 
-<div class="guidebooks">
+<ExtraContainerItem title={m.guidebooks()}>
   <ul class="grid">
     {#each [1, 2, 3] as pos (pos)}
       <li>
@@ -26,22 +28,20 @@
       </li>
     {/each}
   </ul>
-</div>
+</ExtraContainerItem>
 
 <style lang="scss">
   @use '$src/themes/spacing' as *;
   @use '$src/themes/mixins' as *;
 
-  .guidebooks {
-    .grid {
-      display: grid;
-      gap: $unit-3x;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+  .grid {
+    display: grid;
+    gap: $unit-3x;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
 
-      @include breakpoint(tablet) { gap: $unit-2x; }
-      @include breakpoint(phone) { gap: $unit; }
+    @include breakpoint(tablet) { gap: $unit-2x; }
+    @include breakpoint(phone) { gap: $unit; }
 
-      & > li { list-style: none; }
-    }
+    & > li { list-style: none; }
   }
 </style>


### PR DESCRIPTION
## Summary
- Wrap GuidebooksGrid in ExtraContainerItem with "Guidebooks" label
- Restyle GuidebookUnit to match WeaponUnit in extra mode (frame, aspect ratio, purple bg, plus icon)
- Add i18n keys for "Guidebooks" (en/ja)

## Test plan
- [ ] Guidebooks section shows "Guidebooks" label matching "Additional Weapons" style
- [ ] Filled guidebook slots show image in weapon-cell-sized frame
- [ ] Empty editable slots show plus icon with purple styling