### PR TITLE
Fix danger text color on context menu items

### DIFF
--- a/src/lib/components/ui/menu/menu-styles.scss
+++ b/src/lib/components/ui/menu/menu-styles.scss
@@ -84,6 +84,14 @@
 	@include menu-item;
 }
 
+:global(.context-menu-item.danger) {
+	color: var(--danger);
+
+	&:hover {
+		background: var(--danger-bg);
+	}
+}
+
 :global(.context-menu-separator) {
 	@include menu-separator;
 }
@@ -95,6 +103,14 @@
 
 :global(.dropdown-menu-item) {
 	@include menu-item;
+}
+
+:global(.dropdown-menu-item.danger) {
+	color: var(--danger);
+
+	&:hover {
+		background: var(--danger-bg);
+	}
 }
 
 :global(.dropdown-menu-separator) {


### PR DESCRIPTION
## Summary
- The `.danger` class (red text for "Remove from team") only worked in dropdown menus, not right-click context menus
- Root cause: the `.danger` selector from the `menu-item` mixin fell outside `:global()` and got locally scoped by Svelte
- Added explicit `:global(.context-menu-item.danger)` and `:global(.dropdown-menu-item.danger)` rules

## Test plan
- [ ] Right-click any unit → "Remove from team" text is red
- [ ] Click gear button → "Remove from team" text is still red
- [ ] Hover on danger item shows danger background in both menus