### PR TITLE
Fix search result hover states and list spacing

### DIFF
--- a/src/lib/components/sidebar/GuidebookSearchContent.svelte
+++ b/src/lib/components/sidebar/GuidebookSearchContent.svelte
@@ -203,13 +203,12 @@
 	}
 
 	.results-list {
+		display: flex;
+		flex-direction: column;
+		gap: $unit-half;
 		list-style: none;
 		padding: 0;
 		margin: 0;
-	}
-
-	.result-item {
-		margin-bottom: $unit-half;
 	}
 
 	.result-button {
@@ -226,7 +225,7 @@
 		text-align: left;
 
 		&:hover {
-			background: var(--bg-tertiary);
+			background: var(--list-cell-bg-hover);
 
 			.result-image {
 				border-color: var(--accent-primary);

--- a/src/lib/components/sidebar/SearchContent.svelte
+++ b/src/lib/components/sidebar/SearchContent.svelte
@@ -620,6 +620,9 @@
 		}
 
 		.results-list {
+			display: flex;
+			flex-direction: column;
+			gap: $unit-half;
 			list-style: none;
 			padding: 0;
 			margin: 0;

--- a/src/lib/components/sidebar/search/SearchResultItem.svelte
+++ b/src/lib/components/sidebar/search/SearchResultItem.svelte
@@ -103,8 +103,6 @@
 	@use '$src/themes/layout' as *;
 
 	.result-item {
-		margin-bottom: $unit-half;
-
 		.result-button {
 			width: 100%;
 			display: flex;
@@ -119,7 +117,7 @@
 			text-align: left;
 
 			&:hover {
-				background: var(--bg-tertiary);
+				background: var(--list-cell-bg-hover);
 			}
 
 			&:active:not(:disabled) {


### PR DESCRIPTION
## Summary
- Replace `--bg-tertiary` (doesn't exist) with `--list-cell-bg-hover` across all search result components — works in both light and dark mode
- Switch `.results-list` from `margin-bottom` on items to flexbox `gap` on the container (SearchContent, GuidebookSearchContent, SearchResultItem)

## Test plan
- [ ] Open search sidebar for any entity type → hover over results → background highlights
- [ ] Verify hover works in dark mode
- [ ] Spacing between results is consistent (no doubled gaps, no missing gaps)