### PR TITLE
Add farming tab to raid picker

### DIFF
--- a/src/lib/components/raid/RaidSectionTabs.svelte
+++ b/src/lib/components/raid/RaidSectionTabs.svelte
@@ -30,6 +30,7 @@
 	}
 
 	const sections = [
+		{ value: RaidSection.Farming, label: getRaidSectionLabel(RaidSection.Farming) },
 		{ value: RaidSection.Raid, label: getRaidSectionLabel(RaidSection.Raid) },
 		{ value: RaidSection.Event, label: getRaidSectionLabel(RaidSection.Event) },
 		{ value: RaidSection.Solo, label: getRaidSectionLabel(RaidSection.Solo) }


### PR DESCRIPTION
## Summary
- Adds the Farming section tab to the raid picker's segmented control
- Was previously only showing Raids/Events/Solo, now matches the extension's 4-tab layout

## Test plan
- [ ] Open raid picker, verify Farming tab appears first
- [ ] Verify farming raids load when selecting the tab