### PR TITLE
GridRep preview chips navigate to correct tab

### DIFF
--- a/src/lib/components/reps/GridRep.svelte
+++ b/src/lib/components/reps/GridRep.svelte
@@ -15,9 +15,18 @@
 		loading?: boolean
 	}
 
-	let { party, href = localizeHref(`/teams/${party.shortcode}`), loading = false }: Props = $props()
+	let { party, href: hrefProp, loading = false }: Props = $props()
 
 	let currentView: 'weapons' | 'summons' | 'characters' = $state('weapons')
+
+	let href = $derived(
+		hrefProp ??
+			localizeHref(
+				currentView === 'weapons'
+					? `/teams/${party.shortcode}`
+					: `/teams/${party.shortcode}/${currentView}`
+			)
+	)
 
 	function displayName(input: any): string {
 		if (!input) return '—'


### PR DESCRIPTION
## Summary
- Clicking a GridRep while hovering the characters or summons preview chip now navigates directly to that tab on the party page (e.g. `/teams/{id}/characters`)
- Weapons view still navigates to the default `/teams/{id}` URL
- Explicit `href` prop still takes precedence