### PR TITLE
Add summon series filter to collection

### DIFF
--- a/src/lib/components/collection/CollectionFilters.svelte
+++ b/src/lib/components/collection/CollectionFilters.svelte
@@ -94,7 +94,7 @@
 			element: true,
 			rarity: true,
 			season: false,
-			series: false,
+			series: true,
 			race: false,
 			proficiency: false,
 			gender: false
@@ -181,6 +181,17 @@
 		})
 	)
 
+	// Fetch summon series from API (only when entityType is summon)
+	const summonSeriesQuery = createQuery(() =>
+		queryOptions({
+			queryKey: ['summonSeries', 'list'] as const,
+			queryFn: () => entityAdapter.getSummonSeriesList(),
+			enabled: entityType === 'summon',
+			staleTime: 1000 * 60 * 60,
+			gcTime: 1000 * 60 * 60 * 24
+		})
+	)
+
 	// Convert record maps to arrays for iteration
 	const seasons = Object.entries(CHARACTER_SEASON_NAMES).map(([value, label]) => ({
 		value: Number(value),
@@ -194,11 +205,19 @@
 	}))
 
 	// Build series options based on entity type
-	// For weapons: use API-fetched series with string IDs
+	// For weapons/summons: use API-fetched series with string IDs
 	// For characters: use hardcoded enum with number values
 	const seriesOptions = $derived.by(() => {
 		if (entityType === 'weapon' && weaponSeriesQuery.data) {
 			return weaponSeriesQuery.data
+				.sort((a, b) => a.order - b.order)
+				.map((s) => ({
+					value: s.id,
+					label: localizedName(s.name)
+				}))
+		}
+		if (entityType === 'summon' && summonSeriesQuery.data) {
+			return summonSeriesQuery.data
 				.sort((a, b) => a.order - b.order)
 				.map((s) => ({
 					value: s.id,

--- a/src/lib/stores/collectionFilters.svelte.ts
+++ b/src/lib/stores/collectionFilters.svelte.ts
@@ -22,6 +22,7 @@ interface WeaponFilters {
 interface SummonFilters {
 	element: number[]
 	rarity: number[]
+	series: (number | string)[]
 	sort: CollectionSortKey
 }
 
@@ -53,7 +54,7 @@ const DEFAULTS: EntityFilters = {
 		sort: 'name_asc'
 	},
 	weapons: { element: [], rarity: [], proficiency: [], series: [], sort: 'name_asc' },
-	summons: { element: [], rarity: [], sort: 'name_asc' },
+	summons: { element: [], rarity: [], series: [], sort: 'name_asc' },
 	artifacts: {
 		element: [],
 		proficiency: [],

--- a/src/routes/(app)/[username]/collection/summons/+page.svelte
+++ b/src/routes/(app)/[username]/collection/summons/+page.svelte
@@ -34,6 +34,7 @@
 	// Filter state (initialized from localStorage)
 	let elementFilters = $state<number[]>(collectionFilters.summons.element)
 	let rarityFilters = $state<number[]>(collectionFilters.summons.rarity)
+	let seriesFilters = $state<(number | string)[]>(collectionFilters.summons.series ?? [])
 	let searchQuery = $state('')
 
 	// Sort state (initialized from localStorage)
@@ -46,6 +47,7 @@
 	const queryFilters = $derived({
 		element: elementFilters.length > 0 ? elementFilters : undefined,
 		rarity: rarityFilters.length > 0 ? rarityFilters : undefined,
+		series: seriesFilters.length > 0 ? seriesFilters : undefined,
 		search: searchQuery.length > 0 ? searchQuery : undefined,
 		sort: sortBy
 	})
@@ -93,6 +95,7 @@
 	function handleFiltersChange(filters: CollectionFilterState) {
 		elementFilters = filters.element
 		rarityFilters = filters.rarity
+		seriesFilters = filters.series
 	}
 
 	// Persist all filter and sort state to localStorage
@@ -100,6 +103,7 @@
 		const filters = {
 			element: elementFilters,
 			rarity: rarityFilters,
+			series: seriesFilters,
 			sort: sortBy
 		}
 		untrack(() => collectionFilters.setSummons(filters))
@@ -127,6 +131,7 @@
 			entityType="summon"
 			bind:elementFilters
 			bind:rarityFilters
+			bind:seriesFilters
 			bind:searchQuery
 			bind:sortBy
 			onFiltersChange={handleFiltersChange}


### PR DESCRIPTION
## Summary
- Enable series filter for summon collection pages
- Fetch summon series list from API with caching
- Wire series filter state, persistence, and query params on the summons page
- Add `series` to `SummonFilters` interface in the collection filters store

## Test plan
- [ ] Series dropdown appears on summon collection page
- [ ] Selecting a series filters summons correctly
- [ ] Series filter persists across page navigation via localStorage
- [ ] Clearing filters resets series selection