### PR TITLE
Fix theme not applying after login

### DIFF
--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -20,9 +20,17 @@ class ThemeStore {
 	 * This should be called once on app startup from the root layout
 	 */
 	init(initial: ThemePreference = 'system') {
-		if (this.#initialized || typeof window === 'undefined') return
-		this.#initialized = true
+		if (typeof window === 'undefined') return
 
+		if (this.#initialized) {
+			// Re-apply if preference changed (e.g. after login)
+			if (initial !== this.#preference) {
+				this.setTheme(initial)
+			}
+			return
+		}
+
+		this.#initialized = true
 		this.#preference = initial
 		this.#resolved = this.#resolveTheme(initial)
 		this.#applyTheme(this.#resolved)


### PR DESCRIPTION
## Summary
- ThemeStore.init() was bailing out on subsequent calls after login redirect because `#initialized` was already true from the initial page load
- Now re-applies theme when the preference changes between init calls (e.g. going from unauthenticated 'system' default to user's saved 'dark' preference)