### PR TITLE
Persist theme and language toggle settings

### DIFF
--- a/src/lib/components/LanguageToggle.svelte
+++ b/src/lib/components/LanguageToggle.svelte
@@ -3,6 +3,8 @@
 	import { invalidateAll } from '$app/navigation'
 	import { Switch as SwitchPrimitive } from 'bits-ui'
 	import * as m from '$lib/paraglide/messages'
+	import { authStore } from '$lib/stores/auth.store.svelte'
+	import { users } from '$lib/api/resources/users'
 	import type { AppLocale } from '$lib/utils/locale'
 
 	const locale = $derived(getLocale() as AppLocale)
@@ -13,6 +15,11 @@
 		if (newLocale === locale) return
 
 		document.cookie = `PARAGLIDE_LOCALE=${newLocale};path=/;max-age=${60 * 60 * 24 * 365};SameSite=Lax`
+
+		if (authStore.isAuthenticated && authStore.user) {
+			users.update(authStore.user.id, { language: newLocale })
+		}
+
 		await invalidateAll()
 		window.location.reload()
 	}

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -2,6 +2,8 @@
 	import { Switch as SwitchPrimitive } from 'bits-ui'
 	import * as m from '$lib/paraglide/messages'
 	import { themeStore } from '$lib/stores/theme.svelte'
+	import { authStore } from '$lib/stores/auth.store.svelte'
+	import { users } from '$lib/api/resources/users'
 	import SunIcon from '$src/assets/icons/sun.svg?raw'
 	import MoonIcon from '$src/assets/icons/moon.svg?raw'
 
@@ -10,8 +12,11 @@
 	function handleToggle(checked: boolean) {
 		const newTheme = checked ? 'dark' : 'light'
 		themeStore.setTheme(newTheme)
-		// Persist for logged-out users via cookie
 		document.cookie = `theme=${newTheme};path=/;max-age=${60 * 60 * 24 * 365};SameSite=Lax`
+
+		if (authStore.isAuthenticated && authStore.user) {
+			users.update(authStore.user.id, { theme: newTheme })
+		}
 	}
 </script>
 


### PR DESCRIPTION
## Summary
- Theme and language toggles now save to the database via the users API when logged in
- Logged-out users still get cookie-only persistence as before