### PR TITLE
Fix transcendence stars for Eternals

### DIFF
--- a/src/lib/components/collection/CollectionCharacterCard.svelte
+++ b/src/lib/components/collection/CollectionCharacterCard.svelte
@@ -48,7 +48,7 @@
 		special={character.character?.special}
 		flb={character.character?.uncap?.flb}
 		ulb={character.character?.uncap?.ulb}
-		transcendence={!character.character?.special && character.character?.uncap?.ulb}
+		transcendence={character.character?.uncap?.transcendence}
 	/>
 	<span class="character-name">{displayName}</span>
 	{#if character.character}

--- a/src/lib/components/collection/CollectionCharacterRow.svelte
+++ b/src/lib/components/collection/CollectionCharacterRow.svelte
@@ -69,7 +69,7 @@
 			special={character.character?.special}
 			flb={character.character?.uncap?.flb}
 			ulb={character.character?.uncap?.ulb}
-			transcendence={!character.character?.special && character.character?.uncap?.ulb}
+			transcendence={character.character?.uncap?.transcendence}
 		/>
 	</div>
 

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -322,7 +322,7 @@
 			special={item.character?.special}
 			flb={item.character?.uncap?.flb}
 			ulb={item.character?.uncap?.ulb}
-			transcendence={!item.character?.special && item.character?.uncap?.ulb}
+			transcendence={item.character?.uncap?.transcendence}
 			editable={ctx?.canEdit()}
 			updateUncap={async (level) => {
 				if (!item?.id || !ctx) return


### PR DESCRIPTION
## Summary
- Transcendence stars weren't showing for Eternals in collection pages
- The `transcendence` prop was derived from `!special && ulb` which is true for any non-special ULB character, not just those with transcendence
- Changed to use the actual `uncap.transcendence` flag from the API in CollectionCharacterCard, CollectionCharacterRow, and CharacterUnit