### PR TITLE
Fix collection weapon card transformation

### DIFF
--- a/src/lib/components/collection/CollectionWeaponCard.svelte
+++ b/src/lib/components/collection/CollectionWeaponCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { CollectionWeapon } from '$lib/types/api/collection'
-	import { getWeaponImage } from '$lib/utils/images'
+	import { getWeaponImage, getWeaponTransformation } from '$lib/utils/images'
 	import { getAwakeningImage } from '$lib/utils/modifiers'
 	import { localizedName } from '$lib/utils/locale'
 	import UncapIndicator from '$lib/components/uncap/UncapIndicator.svelte'
@@ -13,7 +13,9 @@
 	let { weapon, onClick }: Props = $props()
 
 	// Get transformation suffix for transcendence
-	const transformation = $derived(weapon.transcendenceStep > 0 ? '02' : undefined)
+	const transformation = $derived(
+		getWeaponTransformation(weapon.weapon?.uncap?.transcendence, weapon.uncapLevel, weapon.transcendenceStep)
+	)
 
 	// Use instance element for element-changeable weapons, default to 0 (no element image) if not set
 	const displayElement = $derived(weapon.weapon?.element === 0 ? (weapon.element ?? 0) : undefined)


### PR DESCRIPTION
## Summary
- CollectionWeaponCard had a naive transcendence check (`transcendenceStep > 0 ? '02'`) that didn't validate whether the weapon supports transcendence, the uncap level, or the step 5 `_03` variant
- Replaced with `getWeaponTransformation()` to match WeaponRep/WeaponUnit behavior

Followup to #576

## Test plan
- [ ] Check a transcended Dark Opus in the collection/gallery page — should show transformed art
- [ ] Step 5 transcendence should show `_03` variant
- [ ] Non-transcendable weapons should be unaffected