### PR TITLE
Fix dark mode text on extension page

### DIFF
--- a/src/routes/(app)/extension/+page.svelte
+++ b/src/routes/(app)/extension/+page.svelte
@@ -95,6 +95,7 @@
 
 	.card {
 		background: var(--card-bg);
+		color: var(--text-primary);
 		border: $card-border;
 		border-radius: $page-corner;
 		box-shadow: $page-elevation;


### PR DESCRIPTION
## Summary
- Added `color: var(--text-primary)` to `.card` class on the extension page so text responds to dark mode

## Test plan
- [ ] Visit `/extension` in dark mode and verify all text is readable