### PR TITLE
Fix 404 page browse link contrast and copy

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -77,9 +77,9 @@
 
 	"error_something_went_wrong": "Something went wrong",
 	"error_404_title": "Are you in the right skydom?",
-	"error_random_team_or_browse": "Here's a random team.",
-	"error_or": "Or,",
-	"error_browse_teams": "Browse teams",
+	"error_random_team_label": "Here's a random team.",
+	"error_or_browse_gallery": "Or browse teams in the ",
+	"error_gallery": "Gallery",
 
 	"party_segmented_control_characters": "Characters",
 	"party_segmented_control_weapons": "Weapons",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -77,9 +77,9 @@
 
 	"error_something_went_wrong": "エラーが発生しました",
 	"error_404_title": "正しい空域にいますか？",
-	"error_random_team_or_browse": "ランダムな編成をどうぞ。",
-	"error_or": "または、",
-	"error_browse_teams": "ギャラリーで編成を探す",
+	"error_random_team_label": "ランダムな編成をどうぞ。",
+	"error_or_browse_gallery": "または",
+	"error_gallery": "ギャラリーで編成を探す",
 
 	"party_segmented_control_characters": "キャラ",
 	"party_segmented_control_weapons": "武器",

--- a/src/routes/(app)/+error.svelte
+++ b/src/routes/(app)/+error.svelte
@@ -42,15 +42,15 @@
 
 	{#if is404 && randomParty}
 		<div class="random-team">
-			<p class="random-label" class:ja={isJa}>{m.error_random_team_or_browse()}<br>{m.error_or()} <a href={localizeHref('/teams/explore')} style:color={linkColor}>{m.error_browse_teams()}</a></p>
+			<p class="random-label" class:ja={isJa}>{m.error_random_team_label()}<br>{m.error_or_browse_gallery()} <a href={localizeHref('/teams/explore')} style:color={linkColor}>{m.error_gallery()}</a></p>
 			<div class="random-team-card">
 				<GridRep party={randomParty} />
 			</div>
 		</div>
 	{:else if is404}
-		<a class="browse-link" href={localizeHref('/teams/explore')} style:color={linkColor}>{m.error_browse_teams()}</a>
+		<p class="browse-link">{m.error_or_browse_gallery()} <a href={localizeHref('/teams/explore')} style:color={linkColor}>{m.error_gallery()}</a></p>
 	{:else}
-		<a class="browse-link" href={localizeHref('/teams/explore')}>{m.error_browse_teams()}</a>
+		<a class="browse-link" href={localizeHref('/teams/explore')}>{m.error_gallery()}</a>
 	{/if}
 </div>
 
@@ -88,14 +88,18 @@
 	}
 
 	.browse-link {
-		color: var(--link);
-		text-decoration: none;
-		font-weight: typography.$medium;
+		color: var(--text-secondary);
 		font-size: typography.$font-body;
 		margin-top: spacing.$unit-3x;
 
-		&:hover {
-			text-decoration: underline;
+		a {
+			color: var(--link);
+			text-decoration: none;
+			font-weight: typography.$medium;
+
+			&:hover {
+				text-decoration: underline;
+			}
 		}
 	}
 

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -10,7 +10,7 @@
 		<h1>{m.error_something_went_wrong()}</h1>
 	</div>
 
-	<a class="browse-link" href={localizeHref('/teams/explore')}>{m.error_browse_teams()}</a>
+	<p class="browse-link">{m.error_or_browse_gallery()} <a href={localizeHref('/teams/explore')}>{m.error_gallery()}</a></p>
 </div>
 
 <style lang="scss">
@@ -47,14 +47,18 @@
 	}
 
 	.browse-link {
-		color: var(--link);
-		text-decoration: none;
-		font-weight: typography.$medium;
+		color: var(--text-secondary);
 		font-size: typography.$font-body;
 		margin-top: spacing.$unit-3x;
 
-		&:hover {
-			text-decoration: underline;
+		a {
+			color: var(--link);
+			text-decoration: none;
+			font-weight: typography.$medium;
+
+			&:hover {
+				text-decoration: underline;
+			}
 		}
 	}
 </style>


### PR DESCRIPTION
## Summary
- Fix element-colored link on 404 page using `--element-text` instead of `--element-bg` so it's actually readable
- Change "Browse teams" to "Or browse teams in the Gallery" with only "Gallery" as the link
- Update EN/JA i18n strings accordingly

## Test plan
- [ ] Visit a non-existent URL while logged in with an element set
- [ ] Verify the "Gallery" link is legible in both light and dark mode
- [ ] Check both EN and JA locales