### PR TITLE
Fix typeahead dropdown not showing results

### DIFF
--- a/src/lib/components/ui/CharacterTypeahead.svelte
+++ b/src/lib/components/ui/CharacterTypeahead.svelte
@@ -193,29 +193,27 @@
 			{/if}
 		</div>
 
-		<Combobox.Portal>
-			<Combobox.Content class="combobox-content">
-				<Combobox.Viewport>
-					{#each searchResults as character (character.granblueId)}
-						<Combobox.Item value={character.granblueId} label={character.label} class="combobox-item">
-							{#snippet children({ selected })}
-								<img
-									src={getCharacterImage(character.granblueId, 'square', '01')}
-									alt=""
-									class="item-image"
-								/>
-								<span class="item-label">{character.label}</span>
-								{#if selected}
-									<span class="item-check">
-										<Icon name="check" size={14} />
-									</span>
-								{/if}
-							{/snippet}
-						</Combobox.Item>
-					{/each}
-				</Combobox.Viewport>
-			</Combobox.Content>
-		</Combobox.Portal>
+		<Combobox.Content class="combobox-content">
+			<Combobox.Viewport>
+				{#each searchResults as character (character.granblueId)}
+					<Combobox.Item value={character.granblueId} label={character.label} class="combobox-item">
+						{#snippet children({ selected })}
+							<img
+								src={getCharacterImage(character.granblueId, 'square', '01')}
+								alt=""
+								class="item-image"
+							/>
+							<span class="item-label">{character.label}</span>
+							{#if selected}
+								<span class="item-check">
+									<Icon name="check" size={14} />
+								</span>
+							{/if}
+						{/snippet}
+					</Combobox.Item>
+				{/each}
+			</Combobox.Viewport>
+		</Combobox.Content>
 	</Combobox.Root>
 </div>
 

--- a/src/lib/components/ui/WeaponTypeahead.svelte
+++ b/src/lib/components/ui/WeaponTypeahead.svelte
@@ -193,29 +193,27 @@
 			{/if}
 		</div>
 
-		<Combobox.Portal>
-			<Combobox.Content class="combobox-content">
-				<Combobox.Viewport>
-					{#each searchResults as weapon (weapon.granblueId)}
-						<Combobox.Item value={weapon.granblueId} label={weapon.label} class="combobox-item">
-							{#snippet children({ selected })}
-								<img
-									src={getWeaponGridImage(weapon.granblueId, weapon.element)}
-									alt=""
-									class="item-image"
-								/>
-								<span class="item-label">{weapon.label}</span>
-								{#if selected}
-									<span class="item-check">
-										<Icon name="check" size={14} />
-									</span>
-								{/if}
-							{/snippet}
-						</Combobox.Item>
-					{/each}
-				</Combobox.Viewport>
-			</Combobox.Content>
-		</Combobox.Portal>
+		<Combobox.Content class="combobox-content">
+			<Combobox.Viewport>
+				{#each searchResults as weapon (weapon.granblueId)}
+					<Combobox.Item value={weapon.granblueId} label={weapon.label} class="combobox-item">
+						{#snippet children({ selected })}
+							<img
+								src={getWeaponGridImage(weapon.granblueId, weapon.element)}
+								alt=""
+								class="item-image"
+							/>
+							<span class="item-label">{weapon.label}</span>
+							{#if selected}
+								<span class="item-check">
+									<Icon name="check" size={14} />
+								</span>
+							{/if}
+						{/snippet}
+					</Combobox.Item>
+				{/each}
+			</Combobox.Viewport>
+		</Combobox.Content>
 	</Combobox.Root>
 </div>
 


### PR DESCRIPTION
## Summary
- Removed `Combobox.Portal` from WeaponTypeahead and CharacterTypeahead
- Portal was teleporting the dropdown to `document.body`, breaking the scoped `:global()` styles that depend on the parent wrapper class
- Without the portal the dropdown stays in the component DOM tree and styles apply correctly

## Test plan
- [ ] Search for a weapon/character in database edit page
- [ ] Verify dropdown menu appears with results
- [ ] Verify styling in both light and dark mode