### PR TITLE
Show all element variants for element-changeable weapons

### DIFF
--- a/src/lib/utils/images.ts
+++ b/src/lib/utils/images.ts
@@ -197,7 +197,7 @@ export function getWeaponImage(
 	const basePath = `${getBasePath()}/${directory}`
 
 	// Handle element-specific weapons (including element 0 for null-element weapons)
-	if ((variant === 'grid' || variant === 'main' || variant === 'square') && element !== undefined && element >= 0) {
+	if (element !== undefined && element >= 0) {
 		return `${basePath}/${id}_${element}${extension}`
 	}
 

--- a/src/routes/(app)/database/weapons/[granblueId]/+page.svelte
+++ b/src/routes/(app)/database/weapons/[granblueId]/+page.svelte
@@ -31,7 +31,7 @@
 	import DetailsContainer from '$lib/components/ui/DetailsContainer.svelte'
 	import DetailItem from '$lib/components/ui/DetailItem.svelte'
 	import { getWeaponGridImage, getWeaponImage as getWeaponImageUrl } from '$lib/utils/images'
-	import { getElementLabel } from '$lib/utils/element'
+	import { getElementLabel, ELEMENT_DISPLAY_ORDER } from '$lib/utils/element'
 	import {
 		buildWikiEnUrl,
 		buildWikiJaUrl,
@@ -109,33 +109,51 @@
 
 	// Generate image items for weapon (base, grid, main, square variants)
 	// Weapons have transformations: Base (no suffix), Transcendence Stage 1 (_02), Transcendence Stage 5 (_03)
+	// Element-changeable weapons (element === 0) show all elements at all sizes
 	const weaponImages = $derived.by((): ImageItem[] => {
 		if (!weapon?.granblueId) return []
 
 		const variants = ['base', 'grid', 'main', 'square'] as const
 		const images: ImageItem[] = []
 
-		// Only include transformations that are available
-		const transformations: { id: string; label: string; suffix?: string }[] = [
-			{ id: '01', label: 'Base', suffix: undefined }
-		]
+		if (weapon.element === 0) {
+			// Element-changeable: show all elements (including base _0) at all sizes
+			const elements = [0, ...ELEMENT_DISPLAY_ORDER]
+			for (const element of elements) {
+				const elementLabel = getElementLabel(element)
+				for (const variant of variants) {
+					images.push({
+						url: getWeaponImageUrl(weapon.granblueId, variant, element),
+						label: `${variant} (${elementLabel})`,
+						variant,
+						pose: `element-${element}`,
+						poseLabel: elementLabel
+					})
+				}
+			}
+		} else {
+			// Only include transformations that are available
+			const transformations: { id: string; label: string; suffix?: string }[] = [
+				{ id: '01', label: 'Base', suffix: undefined }
+			]
 
-		if (weapon.uncap?.transcendence) {
-			transformations.push(
-				{ id: '02', label: 'Transcendence (1)', suffix: '02' },
-				{ id: '03', label: 'Transcendence (5)', suffix: '03' }
-			)
-		}
+			if (weapon.uncap?.transcendence) {
+				transformations.push(
+					{ id: '02', label: 'Transcendence (1)', suffix: '02' },
+					{ id: '03', label: 'Transcendence (5)', suffix: '03' }
+				)
+			}
 
-		for (const transformation of transformations) {
-			for (const variant of variants) {
-				images.push({
-					url: getWeaponImageUrl(weapon.granblueId, variant, undefined, transformation.suffix),
-					label: `${variant} (${transformation.label})`,
-					variant,
-					pose: transformation.id,
-					poseLabel: transformation.label
-				})
+			for (const transformation of transformations) {
+				for (const variant of variants) {
+					images.push({
+						url: getWeaponImageUrl(weapon.granblueId, variant, undefined, transformation.suffix),
+						label: `${variant} (${transformation.label})`,
+						variant,
+						pose: transformation.id,
+						poseLabel: transformation.label
+					})
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Element-changeable weapons (element = 0) now show all 7 element variants (Null + 6 elements) at all image sizes (base, grid, main, square) in the database detail images tab
- Removed variant restriction on element suffix in `getWeaponImage` so it applies to all sizes, not just grid/main/square
- Each element gets its own section header, ordered as Null first then standard display order

## Test plan
- [ ] View a element-changeable weapon (element = 0) in the database and check the Images tab
- [ ] Verify all 7 elements show with all 4 size variants each
- [ ] Verify non-element-changeable weapons still show normally with transformation groups