### PR TITLE
Fix element-changeable weapon image downloads

### DIFF
--- a/src/routes/(app)/database/weapons/[granblueId]/+page.svelte
+++ b/src/routes/(app)/database/weapons/[granblueId]/+page.svelte
@@ -167,17 +167,29 @@
 		force: boolean
 	) {
 		if (!weapon?.id) return
-		// For weapons, '01' means base (no transformation suffix)
-		const trans = transformation === '01' ? undefined : transformation
-		await entityAdapter.downloadWeaponImage(weapon.id, size, trans, force)
+
+		if (weapon.element === 0) {
+			// Element-changeable weapons: use batch endpoint which handles element variants
+			await entityAdapter.downloadWeaponImages(weapon.id, { force, size })
+		} else {
+			// For weapons, '01' means base (no transformation suffix)
+			const trans = transformation === '01' ? undefined : transformation
+			await entityAdapter.downloadWeaponImage(weapon.id, size, trans, force)
+		}
 	}
 
 	async function handleDownloadAllPose(pose: string, force: boolean) {
 		if (!weapon?.id) return
-		const trans = pose === '01' ? undefined : pose
-		// Download all sizes for this pose
-		for (const size of weaponSizes) {
-			await entityAdapter.downloadWeaponImage(weapon.id, size, trans, force)
+
+		if (weapon.element === 0) {
+			// Element-changeable weapons: use batch endpoint which handles element variants
+			await entityAdapter.downloadWeaponImages(weapon.id, { force })
+		} else {
+			const trans = pose === '01' ? undefined : pose
+			// Download all sizes for this pose
+			for (const size of weaponSizes) {
+				await entityAdapter.downloadWeaponImage(weapon.id, size, trans, force)
+			}
 		}
 	}
 
@@ -188,14 +200,20 @@
 
 	async function handleDownloadSize(size: string) {
 		if (!weapon?.id) return
-		// Download this size for all available transformations
-		const transformations: (string | undefined)[] = [undefined]
-		if (weapon.uncap?.transcendence) {
-			transformations.push('02', '03')
-		}
 
-		for (const trans of transformations) {
-			await entityAdapter.downloadWeaponImage(weapon.id, size, trans, false)
+		if (weapon.element === 0) {
+			// Element-changeable weapons: use batch endpoint which handles element variants
+			await entityAdapter.downloadWeaponImages(weapon.id, { force: false, size })
+		} else {
+			// Download this size for all available transformations
+			const transformations: (string | undefined)[] = [undefined]
+			if (weapon.uncap?.transcendence) {
+				transformations.push('02', '03')
+			}
+
+			for (const trans of transformations) {
+				await entityAdapter.downloadWeaponImage(weapon.id, size, trans, false)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Element-changeable weapon downloads were silently failing because the single `download_image` endpoint only accepts transformation values (`02`, `03`), not element IDs (`element-0`, `element-2`, etc.)
- Route download handlers through the batch `download_images` endpoint for element-changeable weapons, which already handles element variants correctly

## Test plan
- [ ] Open an element-changeable weapon in the database (element = 0)
- [ ] Go to Images tab, right-click an image and download — should work now
- [ ] Verify non-element-changeable weapon downloads still work