### PR TITLE
Improve download toast feedback

### DIFF
--- a/src/lib/features/database/detail/tabs/EntityImagesTab.svelte
+++ b/src/lib/features/database/detail/tabs/EntityImagesTab.svelte
@@ -9,6 +9,7 @@
 		variant: string
 		pose?: string
 		poseLabel?: string // Custom label for the pose group (e.g., "ULB" for summons)
+		placeholder?: boolean
 	}
 
 	interface Props {
@@ -129,7 +130,12 @@
 				{@const imageKey = getImageKey(image)}
 				{@const isDownloading = downloadingImages.has(imageKey)}
 
-				{#if canEdit && onDownloadImage}
+				{#if image.placeholder}
+					<div class="image-item placeholder">
+						<div class="image-container empty"></div>
+						<span class="image-label">{image.variant}</span>
+					</div>
+				{:else if canEdit && onDownloadImage}
 					<ContextMenuWrapper>
 						{#snippet trigger()}
 							<div class="image-item" class:downloading={isDownloading}>
@@ -254,6 +260,14 @@
 
 		&:hover {
 			transform: scale(1.02);
+		}
+
+		&.empty {
+			opacity: 0.3;
+
+			&:hover {
+				transform: none;
+			}
 		}
 
 		img {

--- a/src/routes/(app)/database/weapons/[granblueId]/+page.svelte
+++ b/src/routes/(app)/database/weapons/[granblueId]/+page.svelte
@@ -118,18 +118,30 @@
 		const images: ImageItem[] = []
 
 		if (weapon.element === 0) {
-			// Element-changeable: show all elements (including base _0) at all sizes
+			// Element-changeable: show all elements at all sizes
+			// Element 0 (Null) has no base art, so show a placeholder there
 			const elements = [0, ...ELEMENT_DISPLAY_ORDER]
 			for (const element of elements) {
 				const elementLabel = getElementLabel(element)
 				for (const variant of variants) {
-					images.push({
-						url: getWeaponImageUrl(weapon.granblueId, variant, element),
-						label: `${variant} (${elementLabel})`,
-						variant,
-						pose: `element-${element}`,
-						poseLabel: elementLabel
-					})
+					if (element === 0 && variant === 'base') {
+						images.push({
+							url: '',
+							label: `${variant} (${elementLabel})`,
+							variant,
+							pose: `element-${element}`,
+							poseLabel: elementLabel,
+							placeholder: true
+						})
+					} else {
+						images.push({
+							url: getWeaponImageUrl(weapon.granblueId, variant, element),
+							label: `${variant} (${elementLabel})`,
+							variant,
+							pose: `element-${element}`,
+							poseLabel: elementLabel
+						})
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
## Summary
- Use persistent loading toasts for batch image downloads instead of static info toasts
- Toast updates through lifecycle: "Queuing download…" → "Downloading images… X/Y" → success/error
- Errors and timeouts replace the loading toast instead of stacking separate ones

## Test plan
- [ ] Download images for an element-changeable weapon and verify toast progression
- [ ] Verify error states replace the loading toast cleanly