### PR TITLE
Show 'no skill selected' on readonly skill slots

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1164,6 +1164,7 @@
 	"skill_slot_locked": "This slot cannot be changed",
 	"skill_slot_already_equipped": "This skill is already equipped in another slot",
 	"skill_slot_select": "Select a skill",
+	"skill_slot_empty": "No skill selected",
 
 	"job_no_job": "No Job",
 

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1164,6 +1164,7 @@
 	"skill_slot_locked": "この枠は変更できません",
 	"skill_slot_already_equipped": "このアビリティは別の枠に装備済みです",
 	"skill_slot_select": "アビリティを選択",
+	"skill_slot_empty": "未選択",
 
 	"job_no_job": "ジョブなし",
 

--- a/src/lib/components/job/JobSkillSlot.svelte
+++ b/src/lib/components/job/JobSkillSlot.svelte
@@ -115,10 +115,15 @@
 
 {#snippet EmptyState({ slot }: { slot: number })}
 	<div class="empty-content">
-		<div class="placeholder-icon">
-			<Icon name="plus" size={16} />
-		</div>
-		<span class="placeholder-text">{m.skill_slot_select()}</span>
+		{#if editable}
+			<div class="placeholder-icon">
+				<Icon name="plus" size={16} />
+			</div>
+			<span class="placeholder-text">{m.skill_slot_select()}</span>
+		{:else}
+			<div class="placeholder-icon readonly"></div>
+			<span class="placeholder-text">{m.skill_slot_empty()}</span>
+		{/if}
 	</div>
 {/snippet}
 
@@ -253,6 +258,10 @@
 			flex-shrink: 0;
 			color: var(--icon-secondary);
 			transition: all 0.15s ease;
+
+			&.readonly {
+				background: var(--card-bg-disabled);
+			}
 		}
 
 		.placeholder-text {


### PR DESCRIPTION
## Summary
- Empty skill slots on parties you don't own now say "No skill selected" instead of "Select a skill"
- Removed the + icon for readonly empty slots, replaced with a subtle background indicator

## Test plan
- [ ] View a party you don't own with empty skill slots
- [ ] Verify it shows "No skill selected" with no + icon
- [ ] Verify editing your own party still shows "Select a skill" with + icon