### PR TITLE
Fix forge chain display styling

### DIFF
--- a/src/lib/features/database/weapons/sections/WeaponForgeSection.svelte
+++ b/src/lib/features/database/weapons/sections/WeaponForgeSection.svelte
@@ -118,22 +118,22 @@
 
 		&.current {
 			&.wind {
-				background: color-mix(in srgb, var(--wind-button-bg) 15%, transparent);
+				background: var(--wind-nav-hover-bg);
 			}
 			&.fire {
-				background: color-mix(in srgb, var(--fire-button-bg) 15%, transparent);
+				background: var(--fire-nav-hover-bg);
 			}
 			&.water {
-				background: color-mix(in srgb, var(--water-button-bg) 15%, transparent);
+				background: var(--water-nav-hover-bg);
 			}
 			&.earth {
-				background: color-mix(in srgb, var(--earth-button-bg) 15%, transparent);
+				background: var(--earth-nav-hover-bg);
 			}
 			&.light {
-				background: color-mix(in srgb, var(--light-button-bg) 15%, transparent);
+				background: var(--light-nav-hover-bg);
 			}
 			&.dark {
-				background: color-mix(in srgb, var(--dark-button-bg) 15%, transparent);
+				background: var(--dark-nav-hover-bg);
 			}
 			&.null {
 				background: var(--card-bg-hover);


### PR DESCRIPTION
## Summary
- Use subtle element-tinted backgrounds (15% opacity) instead of nav-selected colors that were illegible in dark mode
- Remove outlines from current weapon highlight
- Use square weapon images at 32x32
- Arrows are now sibling elements with proper gap spacing between all items