### PR TITLE
Fix dark mode text on database pages

### DIFF
--- a/src/routes/(app)/database/jobs/+page.svelte
+++ b/src/routes/(app)/database/jobs/+page.svelte
@@ -361,6 +361,7 @@
 	:global(.database-grid-theme) {
 		font-size: typography.$font-small;
 		width: 100%;
+		color: var(--text-primary);
 	}
 
 	:global(.wx-grid .wx-header) {
@@ -401,6 +402,7 @@
 		display: flex;
 		align-items: center;
 		border: none;
+		color: var(--text-primary);
 		--wx-table-cell-border: none;
 	}
 

--- a/src/routes/(app)/database/raids/+page.svelte
+++ b/src/routes/(app)/database/raids/+page.svelte
@@ -637,6 +637,7 @@
 	:global(.database-grid-theme) {
 		font-size: typography.$font-small;
 		width: 100%;
+		color: var(--text-primary);
 	}
 
 	:global(.wx-grid .wx-header) {
@@ -668,6 +669,7 @@
 		display: flex;
 		align-items: center;
 		border: none;
+		color: var(--text-primary);
 		--wx-table-cell-border: none;
 	}
 


### PR DESCRIPTION
## Summary
- Database grid pages (raids, jobs) sometimes showed black text in dark mode due to missing `color` declarations
- Added `color: var(--text-primary)` to `.database-grid-theme` and `.wx-grid .wx-cell` on both pages
- The intermittent behavior was caused by CSS load order — wx-svelte-grid defaults to black text, and without an explicit override, it would sometimes win

## Test plan
- [ ] Open /database/raids in dark mode, verify text is readable
- [ ] Open /database/jobs in dark mode, verify text is readable
- [ ] Hard refresh several times to confirm it's consistent