### PR TITLE
Fix favorites API endpoint

### DIFF
--- a/src/lib/api/adapters/party.adapter.ts
+++ b/src/lib/api/adapters/party.adapter.ts
@@ -451,9 +451,10 @@ export class PartyAdapter extends BaseAdapter {
 	/**
 	 * Favorite a party
 	 */
-	async favorite(shortcode: string): Promise<void> {
-		await this.request(`/parties/${shortcode}/favorite`, {
-			method: 'POST'
+	async favorite(partyId: string, shortcode: string): Promise<void> {
+		await this.request('/favorites', {
+			method: 'POST',
+			body: JSON.stringify({ favorite: { party_id: partyId } })
 		})
 		// Clear cache for the party to reflect updated state
 		this.clearCache(`/parties/${shortcode}`)
@@ -462,9 +463,10 @@ export class PartyAdapter extends BaseAdapter {
 	/**
 	 * Unfavorite a party
 	 */
-	async unfavorite(shortcode: string): Promise<void> {
-		await this.request(`/parties/${shortcode}/unfavorite`, {
-			method: 'DELETE'
+	async unfavorite(partyId: string, shortcode: string): Promise<void> {
+		await this.request('/favorites', {
+			method: 'DELETE',
+			body: JSON.stringify({ favorite: { party_id: partyId } })
 		})
 		// Clear cache for the party to reflect updated state
 		this.clearCache(`/parties/${shortcode}`)

--- a/src/lib/api/mutations/__tests__/party.mutations.test.ts
+++ b/src/lib/api/mutations/__tests__/party.mutations.test.ts
@@ -215,10 +215,12 @@ describe('remixPartyOptions', () => {
 // ============================================================================
 
 describe('favoritePartyOptions', () => {
+	const favoriteParams = { id: MOCK_PARTY.id, shortcode: MOCK_SHORTCODE }
+
 	it('optimistically sets favorited to true', async () => {
 		const opts = favoritePartyOptions(queryClient)
 
-		await opts.onMutate(MOCK_SHORTCODE)
+		await opts.onMutate(favoriteParams)
 
 		const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
 		expect(cached?.favorited).toBe(true)
@@ -227,7 +229,7 @@ describe('favoritePartyOptions', () => {
 	it('returns snapshot for rollback', async () => {
 		const opts = favoritePartyOptions(queryClient)
 
-		const context = await opts.onMutate(MOCK_SHORTCODE)
+		const context = await opts.onMutate(favoriteParams)
 
 		expect(context.previousParty?.favorited).toBe(false)
 	})
@@ -235,10 +237,10 @@ describe('favoritePartyOptions', () => {
 	it('rolls back on error', async () => {
 		const opts = favoritePartyOptions(queryClient)
 
-		const context = await opts.onMutate(MOCK_SHORTCODE)
+		const context = await opts.onMutate(favoriteParams)
 		expect(getCachedParty(queryClient, MOCK_SHORTCODE)?.favorited).toBe(true)
 
-		opts.onError(new Error('fail'), MOCK_SHORTCODE, context)
+		opts.onError(new Error('fail'), favoriteParams, context)
 
 		expect(getCachedParty(queryClient, MOCK_SHORTCODE)?.favorited).toBe(false)
 	})
@@ -247,7 +249,7 @@ describe('favoritePartyOptions', () => {
 		const spy = vi.spyOn(queryClient, 'invalidateQueries')
 		const opts = favoritePartyOptions(queryClient)
 
-		opts.onSettled(undefined, undefined, MOCK_SHORTCODE)
+		opts.onSettled(undefined, undefined, favoriteParams)
 
 		const keys = spy.mock.calls.map((c) => c[0].queryKey)
 		expect(keys).toContainEqual(['user', 'favorites'])
@@ -260,13 +262,15 @@ describe('favoritePartyOptions', () => {
 // ============================================================================
 
 describe('unfavoritePartyOptions', () => {
+	const favoriteParams = { id: MOCK_PARTY.id, shortcode: MOCK_SHORTCODE }
+
 	it('optimistically sets favorited to false', async () => {
 		// seed a favorited party
 		const favParty = { ...MOCK_PARTY, favorited: true }
 		seedPartyCache(queryClient, favParty)
 
 		const opts = unfavoritePartyOptions(queryClient)
-		await opts.onMutate(MOCK_SHORTCODE)
+		await opts.onMutate(favoriteParams)
 
 		const cached = getCachedParty(queryClient, MOCK_SHORTCODE)
 		expect(cached?.favorited).toBe(false)
@@ -277,7 +281,7 @@ describe('unfavoritePartyOptions', () => {
 		seedPartyCache(queryClient, favParty)
 
 		const opts = unfavoritePartyOptions(queryClient)
-		const context = await opts.onMutate(MOCK_SHORTCODE)
+		const context = await opts.onMutate(favoriteParams)
 
 		expect(context.previousParty?.favorited).toBe(true)
 	})
@@ -287,10 +291,10 @@ describe('unfavoritePartyOptions', () => {
 		seedPartyCache(queryClient, favParty)
 
 		const opts = unfavoritePartyOptions(queryClient)
-		const context = await opts.onMutate(MOCK_SHORTCODE)
+		const context = await opts.onMutate(favoriteParams)
 		expect(getCachedParty(queryClient, MOCK_SHORTCODE)?.favorited).toBe(false)
 
-		opts.onError(new Error('fail'), MOCK_SHORTCODE, context)
+		opts.onError(new Error('fail'), favoriteParams, context)
 
 		expect(getCachedParty(queryClient, MOCK_SHORTCODE)?.favorited).toBe(true)
 	})
@@ -299,7 +303,7 @@ describe('unfavoritePartyOptions', () => {
 		const spy = vi.spyOn(queryClient, 'invalidateQueries')
 		const opts = unfavoritePartyOptions(queryClient)
 
-		opts.onSettled(undefined, undefined, MOCK_SHORTCODE)
+		opts.onSettled(undefined, undefined, favoriteParams)
 
 		const keys = spy.mock.calls.map((c) => c[0].queryKey)
 		expect(keys).toContainEqual(['user', 'favorites'])

--- a/src/lib/api/mutations/party.mutations.ts
+++ b/src/lib/api/mutations/party.mutations.ts
@@ -96,10 +96,15 @@ export function remixPartyOptions(queryClient: QueryClient) {
 	}
 }
 
+export interface FavoriteParams {
+	id: string
+	shortcode: string
+}
+
 export function favoritePartyOptions(queryClient: QueryClient) {
 	return {
-		mutationFn: (shortcode: string) => partyAdapter.favorite(shortcode),
-		onMutate: async (shortcode: string) => {
+		mutationFn: ({ id, shortcode }: FavoriteParams) => partyAdapter.favorite(id, shortcode),
+		onMutate: async ({ shortcode }: FavoriteParams) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(shortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(shortcode))
@@ -113,12 +118,16 @@ export function favoritePartyOptions(queryClient: QueryClient) {
 
 			return { previousParty }
 		},
-		onError: (_err: unknown, shortcode: string, context: { previousParty?: Party } | undefined) => {
+		onError: (
+			_err: unknown,
+			{ shortcode }: FavoriteParams,
+			context: { previousParty?: Party } | undefined
+		) => {
 			if (context?.previousParty) {
 				queryClient.setQueryData(partyKeys.detail(shortcode), context.previousParty)
 			}
 		},
-		onSettled: (_data: unknown, _err: unknown, shortcode: string) => {
+		onSettled: (_data: unknown, _err: unknown, { shortcode }: FavoriteParams) => {
 			queryClient.invalidateQueries({ queryKey: userKeys.favorites() })
 			queryClient.invalidateQueries({ queryKey: partyKeys.detail(shortcode) })
 		}
@@ -127,8 +136,8 @@ export function favoritePartyOptions(queryClient: QueryClient) {
 
 export function unfavoritePartyOptions(queryClient: QueryClient) {
 	return {
-		mutationFn: (shortcode: string) => partyAdapter.unfavorite(shortcode),
-		onMutate: async (shortcode: string) => {
+		mutationFn: ({ id, shortcode }: FavoriteParams) => partyAdapter.unfavorite(id, shortcode),
+		onMutate: async ({ shortcode }: FavoriteParams) => {
 			await queryClient.cancelQueries({ queryKey: partyKeys.detail(shortcode) })
 
 			const previousParty = queryClient.getQueryData<Party>(partyKeys.detail(shortcode))
@@ -142,12 +151,16 @@ export function unfavoritePartyOptions(queryClient: QueryClient) {
 
 			return { previousParty }
 		},
-		onError: (_err: unknown, shortcode: string, context: { previousParty?: Party } | undefined) => {
+		onError: (
+			_err: unknown,
+			{ shortcode }: FavoriteParams,
+			context: { previousParty?: Party } | undefined
+		) => {
 			if (context?.previousParty) {
 				queryClient.setQueryData(partyKeys.detail(shortcode), context.previousParty)
 			}
 		},
-		onSettled: (_data: unknown, _err: unknown, shortcode: string) => {
+		onSettled: (_data: unknown, _err: unknown, { shortcode }: FavoriteParams) => {
 			queryClient.invalidateQueries({ queryKey: userKeys.favorites() })
 			queryClient.invalidateQueries({ queryKey: partyKeys.detail(shortcode) })
 		}

--- a/src/lib/composables/party-actions.svelte.ts
+++ b/src/lib/composables/party-actions.svelte.ts
@@ -58,10 +58,11 @@ export function usePartyActions(opts: PartyActionsOptions) {
 		error = null
 
 		try {
+			const params = { id: party.id, shortcode: party.shortcode }
 			if (party.favorited) {
-				await opts.mutations.party.unfavorite.mutateAsync(party.shortcode)
+				await opts.mutations.party.unfavorite.mutateAsync(params)
 			} else {
-				await opts.mutations.party.favorite.mutateAsync(party.shortcode)
+				await opts.mutations.party.favorite.mutateAsync(params)
 			}
 		} catch (err: any) {
 			error = err.message || m.toast_failed_update_favorite()


### PR DESCRIPTION
## Summary
- Frontend was calling `POST /parties/{shortcode}/favorite` which doesn't exist
- Changed to hit `POST /favorites` and `DELETE /favorites` with party UUID in request body, matching the Rails routes
- Updated mutations and composable to pass `{ id, shortcode }` instead of just shortcode

## Test plan
- [ ] Favorite a party you don't own
- [ ] Unfavorite a previously favorited party
- [ ] Verify optimistic UI updates and rollback on error