### PR TITLE
Fix weapon accessory icons fading with collection

### DIFF
--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -538,7 +538,7 @@
 		position: absolute;
 		width: 100%;
 		height: 100%;
-		z-index: effects.$z-badge;
+		z-index: effects.$z-sticky;
 		pointer-events: none;
 
 		.orphaned-badge {
@@ -581,8 +581,11 @@
 	// Orphaned state
 	.unit.orphaned {
 		.frame {
-			opacity: 0.7;
 			border: 2px solid colors.$error;
+		}
+
+		.frame .image {
+			opacity: 0.7;
 		}
 
 		.name {


### PR DESCRIPTION
## Summary
- Weapon accessory icons (AX skills, keys, awakenings) were getting faded along with the weapon image when not in collection or orphaned
- Moved opacity from `.frame` to `.image` for orphaned state so accessories aren't affected
- Bumped `.modifiers` z-index above `.image` so the semi-transparent image doesn't paint over the icons

## Test plan
- [ ] Check weapon with keys/AX that's not in collection — icons should be fully opaque
- [ ] Check orphaned weapon — icons should be fully opaque, image faded
- [ ] Verify red border still shows on not-in-collection weapons