### PR TITLE
Show solo first in battle settings and pills

### DIFF
--- a/src/lib/components/party/edit/BattleSettingsSection.svelte
+++ b/src/lib/components/party/edit/BattleSettingsSection.svelte
@@ -49,6 +49,18 @@
 </script>
 
 <DetailsSection title={m.section_battle_settings()}>
+	<DetailRow label={m.battle_solo()} noHover compact>
+		{#snippet children()}
+			<Switch
+				checked={solo}
+				size="small"
+				{element}
+				{disabled}
+				onCheckedChange={(v) => handleChange('solo', v)}
+			/>
+		{/snippet}
+	</DetailRow>
+
 	<DetailRow label={m.battle_charge_attack()} noHover compact>
 		{#snippet children()}
 			<Switch

--- a/src/lib/components/party/info/DescriptionTile.svelte
+++ b/src/lib/components/party/info/DescriptionTile.svelte
@@ -244,6 +244,11 @@
 	<!-- Battle settings & performance -->
 	<div class="battle-section">
 		<div class="settings-tokens">
+			{#if solo}
+				<Tooltip content={m.battle_solo()}>
+					<span class="token solo on">{m.battle_solo()}</span>
+				</Tooltip>
+			{/if}
 			{#each settings as setting (setting.key)}
 				<Tooltip content={setting.tooltip}>
 					<span class="token {setting.key}" class:on={setting.active} class:off={!setting.active}>


### PR DESCRIPTION
## Summary
- Solo toggle is now the first option in BattleSettingsSection
- Solo pill renders first in DescriptionTile before CA/FA/AS/AG tokens