### PR TITLE
Fix job skill detail endpoint path

### DIFF
--- a/src/lib/api/adapters/job.adapter.ts
+++ b/src/lib/api/adapters/job.adapter.ts
@@ -215,7 +215,7 @@ export class JobAdapter extends BaseAdapter {
 	 * Gets a single job skill by ID
 	 */
 	async getSkillById(id: string): Promise<JobSkill> {
-		return this.request<JobSkill>(`/jobs/skills/${id}`)
+		return this.request<JobSkill>(`/job_skills/${id}`)
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Changes `getSkillById` to call `/job_skills/:id` instead of `/jobs/skills/:id`
- The old path didn't have a matching API route, causing 404s that surfaced as 500s on the database job skill pages

Depends on jedmund/hensei-api#295

## Test plan
- [ ] Visit a job skill detail page in the database section