### PR TITLE
Change job button: swap icon + tooltip

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -88,6 +88,7 @@
 	"job_selection_title": "Select Job",
 	"job_selection_search_placeholder": "Search jobs...",
 	"job_choose": "Choose a job",
+	"job_change": "Change job",
 
 	"skill_selection_title": "Select Skill",
 	"skill_selection_search_placeholder": "Search skills...",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -88,6 +88,7 @@
 	"job_selection_title": "ジョブ選択",
 	"job_selection_search_placeholder": "ジョブを検索...",
 	"job_choose": "ジョブを選択",
+	"job_change": "ジョブを変更する",
 
 	"skill_selection_title": "アビリティ選択",
 	"skill_selection_search_placeholder": "アビリティを検索...",

--- a/src/lib/components/job/JobSection.svelte
+++ b/src/lib/components/job/JobSection.svelte
@@ -12,6 +12,7 @@
 	} from '$lib/utils/jobUtils'
 	import { getAccessoryImage, getBasePath } from '$lib/utils/images'
 	import Icon from '$lib/components/Icon.svelte'
+	import Tooltip from '$lib/components/ui/Tooltip.svelte'
 	import Button from '$lib/components/ui/Button.svelte'
 	import * as m from '$lib/paraglide/messages'
 	import { localizedName } from '$lib/utils/locale'
@@ -70,9 +71,11 @@
 		{/if}
 
 		{#if canEdit && job}
-			<button class="change-job-button" onclick={onSelectJob} aria-label="Change job">
-				<Icon name="arrow-left" size={16} />
-			</button>
+			<Tooltip content={m.job_change()}>
+				<button class="change-job-button" onclick={onSelectJob} aria-label={m.job_change()}>
+					<Icon name="swap" size={16} />
+				</button>
+			</Tooltip>
 		{/if}
 	</div>
 


### PR DESCRIPTION
## Summary
- Replace arrow-left icon with swap icon on the change job button
- Add hover tooltip ("Change job" / "ジョブを変更する")
- Localize aria-label

## Test plan
- [ ] Hover over change job button, verify tooltip appears
- [ ] Check JP locale shows correct tooltip text