### PR TITLE
Remove extra suffixes from weapon key filenames

### DIFF
--- a/src/lib/components/sidebar/modifications/WeaponKeysList.svelte
+++ b/src/lib/components/sidebar/modifications/WeaponKeysList.svelte
@@ -19,15 +19,7 @@
 
 	let { weaponKeys, weaponData, layout = 'list' }: Props = $props()
 
-	let keyImages = $derived(
-		getWeaponKeyImages(
-			weaponKeys,
-			weaponData?.element,
-			Array.isArray(weaponData?.proficiency) ? weaponData?.proficiency[0] : weaponData?.proficiency,
-			weaponData?.series,
-			weaponData?.name
-		)
-	)
+	let keyImages = $derived(getWeaponKeyImages(weaponKeys))
 
 	function getKeyDescription(key: WeaponKey): string {
 		const name = localizedName(key.name)

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -49,15 +49,7 @@
 	let awakeningImage = $derived(getAwakeningImage(item?.awakening))
 
 	// Get weapon key images using utility
-	let weaponKeyImages = $derived(
-		getWeaponKeyImages(
-			item?.weaponKeys,
-			item?.weapon?.element,
-			item?.weapon?.proficiency,
-			item?.weapon?.series,
-			item?.weapon?.name
-		)
-	)
+	let weaponKeyImages = $derived(getWeaponKeyImages(item?.weaponKeys))
 
 	// Get AX skill images using utility
 	let axSkillImages = $derived(getAxSkillImages(item?.ax))

--- a/src/lib/utils/__tests__/images.test.ts
+++ b/src/lib/utils/__tests__/images.test.ts
@@ -447,23 +447,10 @@ describe('getAwakeningImage', () => {
 })
 
 describe('getWeaponKeyImage', () => {
-	it('returns key image without element', () => {
+	it('returns key image using slug directly', () => {
 		expect(getWeaponKeyImage('alpha')).toBe('/images/weapon-keys/alpha.png')
-	})
-
-	it('adds element suffix for elemental keys', () => {
-		expect(getWeaponKeyImage('pendulum', 3)).toBe('/images/weapon-keys/pendulum-3.png')
-		expect(getWeaponKeyImage('elemental-teluma', 1)).toBe(
-			'/images/weapon-keys/elemental-teluma-1.png'
-		)
-		expect(getWeaponKeyImage('chain-of-causality', 5)).toBe(
-			'/images/weapon-keys/chain-of-causality-5.png'
-		)
-		expect(getWeaponKeyImage('ultima', 2)).toBe('/images/weapon-keys/ultima-2.png')
-	})
-
-	it('does not add element for non-elemental keys', () => {
-		expect(getWeaponKeyImage('alpha', 3)).toBe('/images/weapon-keys/alpha.png')
+		expect(getWeaponKeyImage('pendulum')).toBe('/images/weapon-keys/pendulum.png')
+		expect(getWeaponKeyImage('elemental-teluma')).toBe('/images/weapon-keys/elemental-teluma.png')
 	})
 })
 

--- a/src/lib/utils/__tests__/modifiers.test.ts
+++ b/src/lib/utils/__tests__/modifiers.test.ts
@@ -4,10 +4,6 @@ vi.mock('$lib/utils/images', () => ({
 	getBasePath: vi.fn(() => '/images')
 }))
 
-vi.mock('$lib/types/api/weaponSeries', () => ({
-	isWeaponSeriesRef: vi.fn((s: any) => s !== null && typeof s === 'object' && 'slug' in s && 'id' in s && 'name' in s)
-}))
-
 import {
 	getAwakeningImage,
 	getWeaponKeyImage,
@@ -16,7 +12,6 @@ import {
 	getAxSkillImages
 } from '../modifiers'
 import type { WeaponKey } from '$lib/types/api/entities'
-import type { WeaponSeriesRef } from '$lib/types/api/weaponSeries'
 
 function makeKey(overrides: Partial<WeaponKey> = {}): WeaponKey {
 	return {
@@ -26,19 +21,6 @@ function makeKey(overrides: Partial<WeaponKey> = {}): WeaponKey {
 		name: { en: 'Alpha', ja: 'アルファ' },
 		...overrides
 	} as WeaponKey
-}
-
-function makeSeries(slug: string): WeaponSeriesRef {
-	return {
-		id: 's-1',
-		slug,
-		name: { en: slug, ja: slug },
-		hasWeaponKeys: true,
-		hasAwakening: false,
-		augmentType: 'no_augment',
-		extra: false,
-		elementChangeable: false
-	}
 }
 
 // ============================================================================
@@ -78,62 +60,13 @@ describe('getWeaponKeyImage', () => {
 		expect(getWeaponKeyImage(makeKey({ slug: '' }))).toBe('')
 	})
 
-	it('returns basic key image', () => {
+	it('returns key image using slug directly', () => {
 		expect(getWeaponKeyImage(makeKey())).toBe('/images/weapon-keys/alpha.png')
 	})
 
-	it('adds element suffix for elemental teluma keys', () => {
-		const key = makeKey({ slug: 'teluma', granblueId: 15008 })
-		expect(getWeaponKeyImage(key, 3)).toBe('/images/weapon-keys/teluma-3.png')
-	})
-
-	it('does not add element for non-teluma keys', () => {
-		const key = makeKey({ slug: 'alpha', granblueId: 10000 })
-		expect(getWeaponKeyImage(key, 3)).toBe('/images/weapon-keys/alpha.png')
-	})
-
-	it('adds proficiency suffix for ultima slot 0', () => {
-		const key = makeKey({ slug: 'strife', slot: 0 })
-		expect(getWeaponKeyImage(key, undefined, 1, makeSeries('ultima'))).toBe(
-			'/images/weapon-keys/strife-1.png'
-		)
-	})
-
-	it('does not add proficiency for non-ultima', () => {
-		const key = makeKey({ slug: 'strife', slot: 0 })
-		expect(getWeaponKeyImage(key, undefined, 1, makeSeries('dark-opus'))).toBe(
-			'/images/weapon-keys/strife.png'
-		)
-	})
-
-	it('adds mod and element suffix for dark-opus slot 1 pendulums', () => {
-		const key = makeKey({ slug: 'pendulum-strength', slot: 1 })
-		const url = getWeaponKeyImage(
-			key,
-			2,
-			undefined,
-			makeSeries('dark-opus'),
-			{ en: 'Repudiation' }
-		)
-		expect(url).toBe('/images/weapon-keys/pendulum-strength-primal-2.png')
-	})
-
-	it('uses magna for non-Repudiation opus weapons', () => {
-		const key = makeKey({ slug: 'pendulum-zeal', slot: 1 })
-		const url = getWeaponKeyImage(
-			key,
-			4,
-			undefined,
-			makeSeries('dark-opus'),
-			{ en: 'Renunciation' }
-		)
-		expect(url).toBe('/images/weapon-keys/pendulum-zeal-magna-4.png')
-	})
-
-	it('does not add opus suffix for non-matching slugs', () => {
-		const key = makeKey({ slug: 'alpha', slot: 1 })
-		const url = getWeaponKeyImage(key, 2, undefined, makeSeries('dark-opus'), { en: 'Repudiation' })
-		expect(url).toBe('/images/weapon-keys/alpha.png')
+	it('does not add any suffixes', () => {
+		const key = makeKey({ slug: 'pendulum-strength', slot: 1, granblueId: 15008 })
+		expect(getWeaponKeyImage(key)).toBe('/images/weapon-keys/pendulum-strength.png')
 	})
 })
 
@@ -161,10 +94,10 @@ describe('getWeaponKeyImages', () => {
 		expect(getWeaponKeyImages(keys)).toHaveLength(1)
 	})
 
-	it('handles array proficiency (takes first)', () => {
+	it('uses slug directly without suffixes', () => {
 		const keys = [makeKey({ slug: 'strife', slot: 0 })]
-		const result = getWeaponKeyImages(keys, undefined, [1, 2], makeSeries('ultima'))
-		expect(result[0]!.url).toContain('strife-1')
+		const result = getWeaponKeyImages(keys)
+		expect(result[0]!.url).toBe('/images/weapon-keys/strife.png')
 	})
 })
 

--- a/src/lib/utils/images.ts
+++ b/src/lib/utils/images.ts
@@ -356,27 +356,8 @@ export function getAwakeningImage(slug: string | undefined, extension: 'png' | '
 /**
  * Get weapon key image URL
  */
-export function getWeaponKeyImage(slug: string, element?: number): string {
-	const basePath = `${getBasePath()}/weapon-keys`
-
-	// Check if this key type needs element suffix
-	if (element && isElementalWeaponKey(slug)) {
-		return `${basePath}/${slug}-${element}.png`
-	}
-	return `${basePath}/${slug}.png`
-}
-
-/**
- * Check if weapon key slug requires element suffix
- */
-function isElementalWeaponKey(slug: string): boolean {
-	const elementalKeys = [
-		'elemental-teluma',
-		'pendulum',
-		'chain-of-causality',
-		'ultima'
-	]
-	return elementalKeys.some((key) => slug.includes(key))
+export function getWeaponKeyImage(slug: string): string {
+	return `${getBasePath()}/weapon-keys/${slug}.png`
 }
 
 /**

--- a/src/lib/utils/modifiers.ts
+++ b/src/lib/utils/modifiers.ts
@@ -4,7 +4,6 @@
 
 import type { Awakening, WeaponKey } from '$lib/types/api/entities'
 import type { AugmentSkill } from '$lib/types/api/weaponStatModifier'
-import { isWeaponSeriesRef, type WeaponSeriesRef } from '$lib/types/api/weaponSeries'
 import { getBasePath } from '$lib/utils/images'
 import { localizedName } from '$lib/utils/locale'
 
@@ -27,85 +26,25 @@ export function getAwakeningImage(awakening?: { type?: Awakening; level?: number
 }
 
 /**
- * Helper to get series slug from WeaponSeriesRef
+ * Get the image URL for a weapon key
  */
-function getSeriesSlug(series?: WeaponSeriesRef | null): string | undefined {
-	if (!isWeaponSeriesRef(series)) {
-		return undefined
-	}
-	return series.slug
-}
-
-/**
- * Get the image URL for a weapon key with proper element/proficiency/mod variants
- */
-export function getWeaponKeyImage(
-	key: WeaponKey,
-	weaponElement?: number,
-	weaponProficiency?: number,
-	weaponSeries?: WeaponSeriesRef | null,
-	weaponName?: { en?: string }
-): string {
+export function getWeaponKeyImage(key: WeaponKey): string {
 	if (!key.slug) return ''
-
-	const baseUrl = `${getBasePath()}/weapon-keys/`
-	let filename = key.slug
-
-	// Get series slug for comparison
-	const seriesSlug = getSeriesSlug(weaponSeries)
-
-	// Handle element-specific telumas (Draconic weapons)
-	const elementalTelumas = [15008, 16001, 16002]
-	const granblueId = key.granblueId ?? 0
-
-	if (elementalTelumas.includes(granblueId) && weaponElement) {
-		filename += `-${weaponElement}`
-	}
-
-	// Handle proficiency-specific ultima keys (slot 0)
-	if (key.slot === 0 && seriesSlug === 'ultima' && weaponProficiency) {
-		filename += `-${weaponProficiency}`
-	}
-
-	// Handle element-specific opus pendulums (slot 1)
-	if (seriesSlug === 'dark-opus' && key.slot === 1 && weaponElement) {
-		const mod = weaponName?.en?.includes('Repudiation') ? 'primal' : 'magna'
-		const suffixes = [
-			'pendulum-strength',
-			'pendulum-zeal',
-			'pendulum-strife',
-			'chain-temperament',
-			'chain-restoration',
-			'chain-glorification'
-		]
-
-		if (suffixes.includes(key.slug)) {
-			filename += `-${mod}-${weaponElement}`
-		}
-	}
-
-	return `${baseUrl}${filename}.png`
+	return `${getBasePath()}/weapon-keys/${key.slug}.png`
 }
 
 /**
  * Get all weapon key images for a weapon
  */
 export function getWeaponKeyImages(
-	keys?: WeaponKey[],
-	weaponElement?: number,
-	weaponProficiency?: number | number[],
-	weaponSeries?: WeaponSeriesRef | null,
-	weaponName?: { en?: string }
+	keys?: WeaponKey[]
 ): Array<{ url: string; alt: string }> {
 	if (!keys || keys.length === 0) return []
-
-	// Handle proficiency being an array (take first element)
-	const proficiency = Array.isArray(weaponProficiency) ? weaponProficiency[0] : weaponProficiency
 
 	return keys
 		.filter(key => key.slug)
 		.map(key => ({
-			url: getWeaponKeyImage(key, weaponElement, proficiency, weaponSeries, weaponName),
+			url: getWeaponKeyImage(key),
 			alt: key.name ? localizedName(key.name) : (key.slug || 'Weapon Key')
 		}))
 }


### PR DESCRIPTION
## Summary
- Weapon key images now always use the base slug without appending element, proficiency, or magna/primal suffixes
- Simplified `getWeaponKeyImage` and `getWeaponKeyImages` in both `modifiers.ts` and `images.ts`
- Removed unused helpers (`getSeriesSlug`, `isElementalWeaponKey`)
- Updated callers in `WeaponUnit` and `WeaponKeysList` to drop extra args
- Updated tests to match