### PR TITLE
Fix weapon skill modifier icon sizes

### DIFF
--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -564,8 +564,8 @@
 			padding: calc(spacing.$unit / 2);
 
 			.skill {
-				width: 20%;
-				height: auto;
+				width: 30px;
+				height: 30px;
 			}
 		}
 	}
@@ -614,7 +614,8 @@
 			justify-content: flex-end;
 
 			.skill {
-				height: 25%;
+				width: 38px;
+				height: 38px;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Skill modifier icons on weapon units now use fixed sizes instead of relative percentages
- Grid weapons: 30x30px, mainhand weapons: 38x38px