### PR TITLE
Redirect old /p/ party URLs to /teams/

### DIFF
--- a/src/routes/(app)/p/[shortcode]/+server.ts
+++ b/src/routes/(app)/p/[shortcode]/+server.ts
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = ({ params }) => {
+	redirect(301, `/teams/${params.shortcode}`)
+}


### PR DESCRIPTION
## Summary
- Adds a 301 redirect from `/p/:shortcode` to `/teams/:shortcode` so old party links still work

## Test plan
- [ ] Visit `/p/<valid-shortcode>` and confirm redirect to `/teams/<shortcode>`
- [ ] Verify the redirect is a 301 (permanent)