### PR TITLE
Add import settings UI

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1035,6 +1035,10 @@
 	"settings_privacy_crew_desc": "Only crew members can view",
 	"settings_privacy_private": "Private",
 	"settings_privacy_private_desc": "Only you can view your collection",
+	"settings_import_weapons": "Import weapons to collection",
+	"settings_import_weapons_subtitle": "Automatically add weapons from imported parties to your collection",
+	"settings_default_import_visibility": "Default import visibility",
+	"settings_default_import_visibility_subtitle": "Privacy setting for parties imported from the extension",
 
 	"collection_tab_characters": "Characters",
 	"collection_tab_weapons": "Weapons",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1035,6 +1035,10 @@
 	"settings_privacy_crew_desc": "騎空団員のみ閲覧可能",
 	"settings_privacy_private": "非公開",
 	"settings_privacy_private_desc": "自分だけがコレクションを閲覧できます",
+	"settings_import_weapons": "武器をコレクションにインポート",
+	"settings_import_weapons_subtitle": "インポートした編成の武器を自動的にコレクションに追加します",
+	"settings_default_import_visibility": "インポート時のデフォルト公開設定",
+	"settings_default_import_visibility_subtitle": "拡張機能からインポートした編成の公開設定",
 
 	"collection_tab_characters": "キャラクター",
 	"collection_tab_weapons": "武器",

--- a/src/lib/api/adapters/user.adapter.ts
+++ b/src/lib/api/adapters/user.adapter.ts
@@ -22,6 +22,8 @@ interface ApiUserResponse {
   wikiProfile?: string | null  // transformed from wiki_profile
   showWikiProfile?: boolean  // transformed from show_wiki_profile
   collectionPrivacy?: number  // transformed from collection_privacy (0=everyone, 1=crew_only, 2=private)
+  importWeapons?: boolean  // transformed from import_weapons
+  defaultImportVisibility?: number  // transformed from default_import_visibility
   gamertag?: string
   email?: string  // Only included in settings view
   emailVerified?: boolean  // Only included in settings view
@@ -49,6 +51,8 @@ export interface UserInfo {
   wikiProfile?: string
   showWikiProfile?: boolean
   collectionPrivacy?: number
+  importWeapons?: boolean
+  defaultImportVisibility?: number
   crewGamertag?: string
   avatar: {
     picture: string
@@ -100,6 +104,8 @@ function transformUserResponse(apiUser: ApiUserResponse): UserInfo {
     wikiProfile: apiUser.wikiProfile ?? undefined,
     showWikiProfile: apiUser.showWikiProfile,
     collectionPrivacy: apiUser.collectionPrivacy,
+    importWeapons: apiUser.importWeapons,
+    defaultImportVisibility: apiUser.defaultImportVisibility,
     // Rename gamertag to crewGamertag
     crewGamertag: apiUser.gamertag,
     avatar: apiUser.avatar

--- a/src/lib/api/resources/users.ts
+++ b/src/lib/api/resources/users.ts
@@ -12,6 +12,8 @@ export interface UserUpdateParams {
 	wikiProfile?: string | undefined
 	showWikiProfile?: boolean | undefined
 	collectionPrivacy?: number | undefined
+	importWeapons?: boolean | undefined
+	defaultImportVisibility?: number | undefined
 }
 
 export interface UserResponse {
@@ -31,6 +33,8 @@ export interface UserResponse {
 	wikiProfile?: string
 	showWikiProfile?: boolean
 	collectionPrivacy?: number
+	importWeapons?: boolean
+	defaultImportVisibility?: number
 }
 
 export const users = {
@@ -51,6 +55,8 @@ export const users = {
 			wiki_profile?: string | undefined
 			show_wiki_profile?: boolean | undefined
 			collection_privacy?: number | undefined
+			import_weapons?: boolean | undefined
+			default_import_visibility?: number | undefined
 		} = {}
 
 		if (params.picture !== undefined) updates.picture = params.picture
@@ -64,6 +70,8 @@ export const users = {
 		if (params.wikiProfile !== undefined) updates.wiki_profile = params.wikiProfile
 		if (params.showWikiProfile !== undefined) updates.show_wiki_profile = params.showWikiProfile
 		if (params.collectionPrivacy !== undefined) updates.collection_privacy = params.collectionPrivacy
+		if (params.importWeapons !== undefined) updates.import_weapons = params.importWeapons
+		if (params.defaultImportVisibility !== undefined) updates.default_import_visibility = params.defaultImportVisibility
 
 		const result = await userAdapter.updateProfile(updates)
 		return {
@@ -79,7 +87,9 @@ export const users = {
 			showGranblueId: result.showGranblueId,
 			wikiProfile: result.wikiProfile,
 			showWikiProfile: result.showWikiProfile,
-			collectionPrivacy: result.collectionPrivacy
+			collectionPrivacy: result.collectionPrivacy,
+			importWeapons: result.importWeapons,
+			defaultImportVisibility: result.defaultImportVisibility
 		}
 	}
 }

--- a/src/lib/components/UserSettingsModal.svelte
+++ b/src/lib/components/UserSettingsModal.svelte
@@ -56,6 +56,8 @@
 	let showWikiProfile = $state(false)
 	let collectionPrivacy = $state(1) // 1 = Everyone (1-based to avoid JS falsy 0)
 	let showCrewGamertag = $state(false)
+	let importWeapons = $state(true)
+	let defaultImportVisibility = $state(1)
 
 	// Track whether form has been initialized from API
 	let formInitialized = $state(false)
@@ -107,6 +109,8 @@
 			showWikiProfile = data.showWikiProfile ?? false
 			collectionPrivacy = data.collectionPrivacy ?? 1
 			showCrewGamertag = data.showCrewGamertag ?? false
+			importWeapons = data.importWeapons ?? true
+			defaultImportVisibility = data.defaultImportVisibility ?? 1
 			// Store original values for comparison
 			originalLanguage = data.language ?? 'en'
 			originalTheme = data.theme ?? 'system'
@@ -171,7 +175,9 @@
 				showCrewGamertag,
 				showGranblueId,
 				showWikiProfile,
-				collectionPrivacy
+				collectionPrivacy,
+				importWeapons,
+				defaultImportVisibility
 			}
 
 			// Call API to update user settings
@@ -190,7 +196,9 @@
 				showCrewGamertag: response.showCrewGamertag,
 				showGranblueId: response.showGranblueId,
 				showWikiProfile: response.showWikiProfile,
-				collectionPrivacy: response.collectionPrivacy
+				collectionPrivacy: response.collectionPrivacy,
+				importWeapons: response.importWeapons,
+				defaultImportVisibility: response.defaultImportVisibility
 			}
 
 			// Make a request to update the cookie server-side
@@ -218,7 +226,9 @@
 								showGranblueId,
 								showWikiProfile,
 								collectionPrivacy,
-								showCrewGamertag
+								showCrewGamertag,
+								importWeapons,
+								defaultImportVisibility
 							}
 						: oldData
 			)
@@ -318,6 +328,8 @@
 							{showWikiProfile}
 							{collectionPrivacy}
 							{showCrewGamertag}
+							{importWeapons}
+							{defaultImportVisibility}
 							{isInCrew}
 							{crewGamertag}
 							{element}
@@ -325,6 +337,8 @@
 							onShowWikiProfileChange={(v) => (showWikiProfile = v)}
 							onCollectionPrivacyChange={(v) => (collectionPrivacy = v)}
 							onShowCrewGamertagChange={(v) => (showCrewGamertag = v)}
+							onImportWeaponsChange={(v) => (importWeapons = v)}
+							onDefaultImportVisibilityChange={(v) => (defaultImportVisibility = v)}
 						/>
 					{/if}
 				</main>

--- a/src/lib/components/settings/PrivacySettings.svelte
+++ b/src/lib/components/settings/PrivacySettings.svelte
@@ -11,6 +11,8 @@
 		showWikiProfile: boolean
 		collectionPrivacy: number
 		showCrewGamertag: boolean
+		importWeapons: boolean
+		defaultImportVisibility: number
 		isInCrew: boolean
 		crewGamertag?: string
 		element: ElementType
@@ -18,6 +20,8 @@
 		onShowWikiProfileChange: (value: boolean) => void
 		onCollectionPrivacyChange: (value: number) => void
 		onShowCrewGamertagChange: (value: boolean) => void
+		onImportWeaponsChange: (value: boolean) => void
+		onDefaultImportVisibilityChange: (value: number) => void
 	}
 
 	let {
@@ -25,13 +29,17 @@
 		showWikiProfile,
 		collectionPrivacy,
 		showCrewGamertag,
+		importWeapons,
+		defaultImportVisibility,
 		isInCrew,
 		crewGamertag,
 		element,
 		onShowGranblueIdChange,
 		onShowWikiProfileChange,
 		onCollectionPrivacyChange,
-		onShowCrewGamertagChange
+		onShowCrewGamertagChange,
+		onImportWeaponsChange,
+		onDefaultImportVisibilityChange
 	}: Props = $props()
 
 	// Collection privacy options (1-based to avoid JavaScript falsy 0 issues)
@@ -39,6 +47,13 @@
 		{ value: 1, label: m.settings_privacy_everyone(), description: m.settings_privacy_everyone_desc() },
 		{ value: 2, label: m.settings_privacy_crew(), description: m.settings_privacy_crew_desc() },
 		{ value: 3, label: m.settings_privacy_private(), description: m.settings_privacy_private_desc() }
+	]
+
+	// Default import visibility options (mirrors party visibility, not collection privacy)
+	const importVisibilityOptions = [
+		{ value: 1, label: m.visibility_public() },
+		{ value: 2, label: m.visibility_unlisted() },
+		{ value: 3, label: m.visibility_private() }
 	]
 
 </script>
@@ -105,6 +120,39 @@
 					onValueChange={onCollectionPrivacyChange}
 					options={collectionPrivacyOptions}
 					placeholder={m.settings_collection_visibility_placeholder()}
+					contained
+					portal
+				/>
+			{/snippet}
+		</SettingsRow>
+
+		<hr class="separator" />
+
+		<!-- Import Weapons -->
+		<SettingsRow
+			title={m.settings_import_weapons()}
+			subtitle={m.settings_import_weapons_subtitle()}
+		>
+			{#snippet control()}
+				<Switch
+					checked={importWeapons}
+					name="import-weapons"
+					{element}
+					onCheckedChange={onImportWeaponsChange}
+				/>
+			{/snippet}
+		</SettingsRow>
+
+		<!-- Default Import Visibility -->
+		<SettingsRow
+			title={m.settings_default_import_visibility()}
+			subtitle={m.settings_default_import_visibility_subtitle()}
+		>
+			{#snippet control()}
+				<Select
+					value={defaultImportVisibility}
+					onValueChange={onDefaultImportVisibilityChange}
+					options={importVisibilityOptions}
 					contained
 					portal
 				/>

--- a/src/lib/types/UserCookie.d.ts
+++ b/src/lib/types/UserCookie.d.ts
@@ -11,4 +11,6 @@ export interface UserCookie {
 	wikiProfile?: string
 	showWikiProfile?: boolean
 	collectionPrivacy?: number
+	importWeapons?: boolean
+	defaultImportVisibility?: number
 }


### PR DESCRIPTION
## Summary
- Add import weapons toggle and default import visibility select to privacy settings
- Wire up API adapter, resources, cookie, and i18n (EN/JA) for both new fields
- Visibility options mirror party visibility (Public/Unlisted/Private)

## Test plan
- [ ] Open settings > privacy, verify new controls appear below collection privacy
- [ ] Toggle import weapons, save, reload, verify it persists
- [ ] Change default import visibility, save, reload, verify it persists
- [ ] Check Japanese locale renders correctly