### PR TITLE
Default class weapon mainhand images to fire element

### DIFF
--- a/src/lib/components/reps/WeaponRep.svelte
+++ b/src/lib/components/reps/WeaponRep.svelte
@@ -23,8 +23,9 @@
 
 	function weaponImageUrl(w?: GridWeapon, isMain = false): string {
 		const variant = isMain ? 'main' : 'grid'
-		// For weapons with null element that have an instance element, use it
-		const element = (w?.weapon?.element === 0 && w?.element) ? w.element : undefined
+		// For weapons with null element that have an instance element, use it.
+		// Mainhand images don't have a null-element variant, so default to fire (2).
+		const element = w?.weapon?.element === 0 ? (w?.element || (isMain ? 2 : undefined)) : undefined
 		const transformation = getWeaponTransformation(w?.weapon?.uncap?.transcendence, w?.uncapLevel, w?.transcendenceStep)
 		return getWeaponImage(w?.weapon?.granblueId, variant, element, transformation)
 	}

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -38,8 +38,9 @@
 		const isMain = position === -1 || item?.mainhand
 		const variant = isMain ? 'main' : 'grid'
 
-		// For element-changeable weapons (element === 0), use instance element or default to 0 (no element image)
-		const element = item?.weapon?.element === 0 ? (item?.element ?? 0) : undefined
+		// For element-changeable weapons (element === 0), use instance element.
+		// Mainhand images don't have a null-element variant, so default to fire (2).
+		const element = item?.weapon?.element === 0 ? (item?.element ?? (isMain ? 2 : 0)) : undefined
 		const transformation = getWeaponTransformation(item?.weapon?.uncap?.transcendence, item?.uncapLevel, item?.transcendenceStep)
 
 		return getWeaponImage(item?.weapon?.granblueId, variant, element, transformation)


### PR DESCRIPTION
## Summary
- Class champion weapons have null element (0), but mainhand images don't have a null-element variant
- Default to fire element (2) for mainhand slot when no instance element is set
- Fixes in both WeaponUnit and WeaponRep

## Test plan
- [ ] Equip a class champion weapon as mainhand with no element set — should show fire variant image
- [ ] Equip a class champion weapon with an element set — should show that element's image
- [ ] Grid slot class weapons with no element should still show null-element variant