### PR TITLE
Wire up save button for weapon/character edit panes

### DIFF
--- a/src/lib/components/sidebar/EditCharacterSidebar.svelte
+++ b/src/lib/components/sidebar/EditCharacterSidebar.svelte
@@ -14,14 +14,20 @@
 	} from './CharacterEditPane.svelte'
 	import { useSyncGridCharacter, useSwitchCharacterStyle } from '$lib/api/mutations/grid.mutations'
 	import Icon from '$lib/components/Icon.svelte'
+	import { sidebar } from '$lib/stores/sidebar.svelte'
+	import { getElementKey } from '$lib/utils/element'
+	import { untrack } from 'svelte'
 
 	interface Props {
+		paneId?: string
 		character: GridCharacter
 		onSave?: (updates: Partial<GridCharacter>) => void
 		onCancel?: () => void
 	}
 
-	let { character, onSave, onCancel }: Props = $props()
+	let { paneId, character, onSave, onCancel }: Props = $props()
+
+	let editPaneRef: ReturnType<typeof CharacterEditPane> | undefined = $state()
 
 	// Sync mutation
 	const syncMutation = useSyncGridCharacter()
@@ -86,6 +92,22 @@
 		perpetuity: character.perpetuity ?? false
 	})
 
+	// Element name for action button theming
+	const elementId = $derived(characterData?.element)
+	const elementName = $derived(
+		elementId ? (getElementKey(elementId) as 'wind' | 'fire' | 'water' | 'earth' | 'dark' | 'light') : undefined
+	)
+
+	// Register save action in the pane header
+	$effect(() => {
+		const el = elementName
+		untrack(() => {
+			if (paneId) {
+				sidebar.setActionForPane(paneId, () => editPaneRef?.save(), m.action_save(), el)
+			}
+		})
+	})
+
 	function handleSave(updates: CharacterEditUpdates) {
 		// Transform CharacterEditUpdates to GridCharacter API format
 		// The CharacterEditPane already formats awakening with id/level
@@ -134,6 +156,7 @@
 	{/if}
 
 	<CharacterEditPane
+		bind:this={editPaneRef}
 		{characterData}
 		{currentValues}
 		showPerpetuity={canHavePerpetuity}

--- a/src/lib/components/sidebar/EditWeaponPane.svelte
+++ b/src/lib/components/sidebar/EditWeaponPane.svelte
@@ -14,14 +14,20 @@
 	} from './WeaponEditPane.svelte'
 	import { useSyncGridWeapon } from '$lib/api/mutations/grid.mutations'
 	import Icon from '$lib/components/Icon.svelte'
+	import { sidebar } from '$lib/stores/sidebar.svelte'
+	import { getElementKey } from '$lib/utils/element'
+	import { untrack } from 'svelte'
 
 	interface Props {
+		paneId?: string
 		weapon: GridWeapon
 		onSave?: (updates: Partial<GridWeapon>) => void
 		onCancel?: () => void
 	}
 
-	let { weapon, onSave, onCancel }: Props = $props()
+	let { paneId, weapon, onSave, onCancel }: Props = $props()
+
+	let editPaneRef: ReturnType<typeof WeaponEditPane> | undefined = $state()
 
 	// Sync mutation
 	const syncMutation = useSyncGridWeapon()
@@ -61,6 +67,23 @@
 		befoulment: weapon.befoulment ?? null
 	})
 
+	// Element name for action button theming
+	const elementId = $derived(weapon.element || weaponData?.element)
+	const elementName = $derived(
+		elementId ? (getElementKey(elementId) as 'wind' | 'fire' | 'water' | 'earth' | 'dark' | 'light') : undefined
+	)
+
+	// Register save action in the pane header
+	$effect(() => {
+		// Read elementName to track it
+		const el = elementName
+		untrack(() => {
+			if (paneId) {
+				sidebar.setActionForPane(paneId, () => editPaneRef?.save(), m.action_save(), el)
+			}
+		})
+	})
+
 	function handleSave(updates: WeaponEditUpdates) {
 		onSave?.(updates as Partial<GridWeapon>)
 	}
@@ -92,6 +115,7 @@
 	{/if}
 
 	<WeaponEditPane
+		bind:this={editPaneRef}
 		{weaponData}
 		{currentValues}
 		onSave={handleSave}


### PR DESCRIPTION
## Summary
- `EditWeaponPane` and `EditCharacterSidebar` were missing the `sidebar.setActionForPane()` call, so no save button appeared in the pane header when editing weapons or characters in a party
- Added `paneId` prop, `bind:this` ref to the inner edit pane, and a `$effect` that registers the save action — matching the pattern used by `EditPartyPane` and collection panes