### PR TITLE
Disable auto guard/summon when full auto is off

### DIFF
--- a/src/lib/components/party/edit/BattleSettingsSection.svelte
+++ b/src/lib/components/party/edit/BattleSettingsSection.svelte
@@ -41,8 +41,15 @@
 		field: 'fullAuto' | 'solo' | 'autoGuard' | 'autoSummon' | 'chargeAttack',
 		value: boolean
 	) {
-		if (field === 'fullAuto') fullAuto = value
-		else if (field === 'solo') solo = value
+		if (field === 'fullAuto') {
+			fullAuto = value
+			if (!value) {
+				autoGuard = false
+				autoSummon = false
+				onchange?.('autoGuard', false)
+				onchange?.('autoSummon', false)
+			}
+		} else if (field === 'solo') solo = value
 		else if (field === 'autoGuard') autoGuard = value
 		else if (field === 'autoSummon') autoSummon = value
 		else chargeAttack = value
@@ -94,7 +101,7 @@
 				checked={autoSummon}
 				size="small"
 				{element}
-				{disabled}
+				disabled={disabled || !fullAuto}
 				onCheckedChange={(v) => handleChange('autoSummon', v)}
 			/>
 		{/snippet}
@@ -106,7 +113,7 @@
 				checked={autoGuard}
 				size="small"
 				{element}
-				{disabled}
+				disabled={disabled || !fullAuto}
 				onCheckedChange={(v) => handleChange('autoGuard', v)}
 			/>
 		{/snippet}


### PR DESCRIPTION
## Summary
- Auto Guard and Auto Summon switches are now disabled when Full Auto is toggled off
- Turning off Full Auto also resets both to unchecked so they don't retain stale state