### PR TITLE
Fix variant ID inputs + image download UX

### DIFF
--- a/src/routes/(app)/database/weapons/[granblueId]/edit/+page.svelte
+++ b/src/routes/(app)/database/weapons/[granblueId]/edit/+page.svelte
@@ -28,7 +28,7 @@
 		buildGamewithUrl,
 		buildKamigameUrl
 	} from '$lib/utils/external-links'
-	import { getElementLabel, getElementIcon, ELEMENT_DISPLAY_ORDER } from '$lib/utils/element'
+	import { getElementLabel, getElementImage, ELEMENT_DISPLAY_ORDER } from '$lib/utils/element'
 	import DatabasePageHeader from '$lib/components/database/DatabasePageHeader.svelte'
 	import NotFoundPlaceholder from '$lib/components/database/NotFoundPlaceholder.svelte'
 	import Button from '$lib/components/ui/Button.svelte'
@@ -281,24 +281,26 @@
 					<DetailsContainer title="Element Variant IDs">
 						{#each ELEMENT_DISPLAY_ORDER as elementNum}
 							{@const key = String(elementNum)}
-							<div class="variant-id-row">
-								<img class="element-icon" src={getElementIcon(elementNum)} alt={getElementLabel(elementNum)} />
-								<input
-									class="variant-input"
-									type="text"
-									placeholder="Variant ID"
-									value={editData.elementVariantIds[key] || ''}
-									oninput={(e) => {
-										const val = e.currentTarget.value
-										if (val) {
-											editData.elementVariantIds = { ...editData.elementVariantIds, [key]: val }
-										} else {
-											const { [key]: _, ...rest } = editData.elementVariantIds
-											editData.elementVariantIds = rest
-										}
-									}}
-								/>
-							</div>
+							<DetailItem label={getElementLabel(elementNum)} editable={true}>
+								<div class="variant-id-input">
+									<img class="element-icon" src={getElementImage(elementNum)} alt={getElementLabel(elementNum)} />
+									<input
+										class="variant-input contained"
+										type="text"
+										placeholder="Variant ID"
+										value={editData.elementVariantIds[key] || ''}
+										oninput={(e) => {
+											const val = e.currentTarget.value
+											if (val) {
+												editData.elementVariantIds = { ...editData.elementVariantIds, [key]: val }
+											} else {
+												const { [key]: _, ...rest } = editData.elementVariantIds
+												editData.elementVariantIds = rest
+											}
+										}}
+									/>
+								</div>
+							</DetailItem>
 						{/each}
 					</DetailsContainer>
 				{/if}
@@ -413,6 +415,8 @@
 <style lang="scss">
 	@use '$src/themes/database' as database;
 	@use '$src/themes/layout' as layout;
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
 
 	.page {
 		background: var(--card-bg);
@@ -424,11 +428,10 @@
 		@include database.details;
 	}
 
-	.variant-id-row {
+	.variant-id-input {
 		display: flex;
 		align-items: center;
-		gap: 8px;
-		padding: 4px 0;
+		gap: spacing.$unit;
 
 		.element-icon {
 			width: 24px;
@@ -438,20 +441,23 @@
 
 		.variant-input {
 			flex: 1;
-			background: var(--input-bg, var(--background));
-			border: 1px solid var(--border-color);
+			background-color: var(--input-bound-bg);
+			border: none;
 			border-radius: layout.$input-corner;
 			color: var(--text-primary);
-			font-size: 14px;
-			padding: 6px 10px;
+			font-size: typography.$font-regular;
+			font-family: var(--font-family);
+			padding: spacing.$unit calc(spacing.$unit * 1.5);
+			min-height: spacing.$unit-4x;
 			outline: none;
+			transition: background-color 0.15s;
 
 			&::placeholder {
 				color: var(--text-tertiary);
 			}
 
-			&:focus {
-				border-color: var(--accent-color, #3366ff);
+			&:hover {
+				background-color: var(--input-bound-bg-hover);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Use element images (`elements/{name}.png`) instead of label icons for variant ID inputs
- Wrap inputs in DetailItem rows with element name as label, contained style
- Add "Download All Images" option to right-click context menu in images tab
- Cache-bust image URLs after download so updated images display immediately without refresh