### PR TITLE
Optimistic delete for team/playlist cards

### DIFF
--- a/src/lib/api/mutations/party.mutations.ts
+++ b/src/lib/api/mutations/party.mutations.ts
@@ -77,10 +77,40 @@ export function updatePartyOptions(queryClient: QueryClient) {
 export function deletePartyOptions(queryClient: QueryClient) {
 	return {
 		mutationFn: (params: { id: string; shortcode: string }) => partyAdapter.delete(params.id),
+		onMutate: async (params: { id: string; shortcode: string }) => {
+			await queryClient.cancelQueries({ queryKey: partyKeys.userLists() })
+
+			const previousQueries = queryClient.getQueriesData({ queryKey: partyKeys.userLists() })
+
+			queryClient.setQueriesData(
+				{ queryKey: partyKeys.userLists() },
+				(old: { pages: Array<{ results: Party[]; [k: string]: unknown }>; pageParams: number[] } | undefined) => {
+					if (!old) return old
+					return {
+						...old,
+						pages: old.pages.map((page) => ({
+							...page,
+							results: page.results.filter((p) => p.id !== params.id)
+						}))
+					}
+				}
+			)
+
+			return { previousQueries }
+		},
 		onSuccess: (_data: unknown, params: { id: string; shortcode: string }) => {
 			queryClient.removeQueries({ queryKey: partyKeys.detail(params.shortcode) })
 			queryClient.invalidateQueries({ queryKey: partyKeys.lists() })
 			queryClient.invalidateQueries({ queryKey: userKeys.all })
+		},
+		onError: (
+			_err: unknown,
+			_params: { id: string; shortcode: string },
+			context: { previousQueries?: Array<[unknown, unknown]> } | undefined
+		) => {
+			context?.previousQueries?.forEach(([queryKey, data]) => {
+				queryClient.setQueryData(queryKey as readonly unknown[], data)
+			})
 		}
 	}
 }

--- a/src/lib/api/mutations/playlist.mutations.ts
+++ b/src/lib/api/mutations/playlist.mutations.ts
@@ -78,10 +78,40 @@ export function updatePlaylistOptions(queryClient: QueryClient) {
 export function deletePlaylistOptions(queryClient: QueryClient) {
 	return {
 		mutationFn: (id: string) => playlistAdapter.destroy(id),
+		onMutate: async (id: string) => {
+			await queryClient.cancelQueries({ queryKey: playlistKeys.userLists() })
+
+			const previousQueries = queryClient.getQueriesData({ queryKey: playlistKeys.userLists() })
+
+			queryClient.setQueriesData(
+				{ queryKey: playlistKeys.userLists() },
+				(old: { pages: Array<{ results: Playlist[]; [k: string]: unknown }>; pageParams: number[] } | undefined) => {
+					if (!old) return old
+					return {
+						...old,
+						pages: old.pages.map((page) => ({
+							...page,
+							results: page.results.filter((p) => p.id !== id)
+						}))
+					}
+				}
+			)
+
+			return { previousQueries }
+		},
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: playlistKeys.details() })
 			queryClient.invalidateQueries({ queryKey: playlistKeys.userLists() })
 			queryClient.invalidateQueries({ queryKey: playlistKeys.all })
+		},
+		onError: (
+			_err: unknown,
+			_id: string,
+			context: { previousQueries?: Array<[unknown, unknown]> } | undefined
+		) => {
+			context?.previousQueries?.forEach(([queryKey, data]) => {
+				queryClient.setQueryData(queryKey as readonly unknown[], data)
+			})
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Cards now disappear immediately from the grid when deleted via right-click context menu on profile teams/playlists pages
- Rolls back if the API call fails
- Server-side cache invalidation still runs on success for consistency

## Test plan
- [ ] Right-click delete a team on profile page — card should vanish instantly
- [ ] Right-click delete a playlist on playlists page — same behavior
- [ ] Disable network and try deleting — card should reappear after error