### PR TITLE
Fix navigation auth flash on page load

### DIFF
--- a/src/lib/components/Navigation.svelte
+++ b/src/lib/components/Navigation.svelte
@@ -39,7 +39,7 @@
 
 	const username = $derived(account?.username ?? '')
 	// Use reactive authStore instead of static server prop for real-time auth state
-	const isAuth = $derived(authStore.isAuthenticated)
+	const isAuth = $derived(authStore.isAuthenticated || (isAuthProp ?? false))
 	const role = $derived(account?.role ?? null)
 	// Element from UserCookie is already a string like "fire", "water", etc.
 	const userElement = $derived(


### PR DESCRIPTION
## Summary
- Navigation was flashing logged-out state before switching to logged-in on every page load
- Root cause: `isAuth` only used the client-side auth store, which starts empty during SSR/hydration
- Now falls back to the server-provided `isAuthProp` (from cookies) when the store hasn't initialized yet