### PR TITLE
Befoulment icons 42x42 on weapon units

### DIFF
--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -233,7 +233,7 @@
 										<img class="skill" src={skill.url} alt={skill.alt} />
 									{/each}
 									{#each befoulmentImages as skill}
-										<img class="skill" src={skill.url} alt={skill.alt} />
+										<img class="skill befoulment" src={skill.url} alt={skill.alt} />
 									{/each}
 									{#each weaponKeyImages as skill}
 										<Tooltip content={skill.alt}>
@@ -581,6 +581,11 @@
 			.skill {
 				width: 30px;
 				height: 30px;
+
+				&.befoulment {
+					width: 42px;
+					height: 42px;
+				}
 			}
 		}
 	}
@@ -631,6 +636,11 @@
 			.skill {
 				width: 38px;
 				height: 38px;
+
+				&.befoulment {
+					width: 42px;
+					height: 42px;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Befoulment skill icons on WeaponUnit are now 42x42 instead of matching the default AX skill size (30px grid / 38px main)
- Added `.befoulment` class to befoulment `<img>` elements for independent sizing

## Test plan
- [ ] Check befoulment icons render at 42x42 on grid weapons
- [ ] Check befoulment icons render at 42x42 on mainhand weapons
- [ ] AX skill and weapon key icons remain at their original sizes