### PR TITLE
Fix roster page reactivity

### DIFF
--- a/src/lib/api/queries/crew.queries.ts
+++ b/src/lib/api/queries/crew.queries.ts
@@ -177,6 +177,19 @@ export const crewQueries = {
    *
    * @param gamertag - Gamertag to check availability for
    */
+  /**
+   * Crew roster query options
+   * Returns ownership info for specified items across all active crew members
+   */
+  roster: (characterIds: string[], weaponIds: string[], summonIds: string[]) =>
+    queryOptions({
+      queryKey: ['crew', 'roster', { characterIds, weaponIds, summonIds }] as const,
+      queryFn: () => crewAdapter.getRoster({ characterIds, weaponIds, summonIds }),
+      enabled: characterIds.length + weaponIds.length + summonIds.length > 0,
+      staleTime: 1000 * 60 * 2,
+      gcTime: 1000 * 60 * 15
+    }),
+
   checkGamertag: (gamertag: string) =>
     queryOptions({
       queryKey: ['crew', 'check', 'gamertag', gamertag] as const,
@@ -212,6 +225,8 @@ export const crewKeys = {
   crewInvitations: (crewId: string) => [...crewKeys.all, crewId, 'invitations'] as const,
   sharedParties: () => [...crewKeys.all, 'shared_parties'] as const,
   accessibleCollectionMembers: () => [...crewKeys.all, 'members', 'accessible-collections'] as const,
+  roster: (characterIds: string[], weaponIds: string[], summonIds: string[]) =>
+    [...crewKeys.all, 'roster', { characterIds, weaponIds, summonIds }] as const,
   checkGamertag: (gamertag: string) => [...crewKeys.all, 'check', 'gamertag', gamertag] as const,
   invitations: {
     all: ['invitations'] as const,

--- a/src/routes/(app)/crew/roster/+page.svelte
+++ b/src/routes/(app)/crew/roster/+page.svelte
@@ -1,9 +1,10 @@
 
 <script lang="ts">
 	import { goto } from '$app/navigation'
+	import { createQuery } from '@tanstack/svelte-query'
+	import { crewQueries } from '$lib/api/queries/crew.queries'
 	import { localizeHref } from '$lib/paraglide/runtime'
 	import { crewStore } from '$lib/stores/crew.store.svelte'
-	import { crewAdapter } from '$lib/api/adapters/crew.adapter'
 	import { type UnifiedSearchSeriesRef } from '$lib/api/adapters/search.adapter'
 	import { getCharacterImage, getWeaponImage, getSummonImage } from '$lib/utils/images'
 	import Icon from '$lib/components/Icon.svelte'
@@ -14,7 +15,6 @@
 	import RosterRow from '$lib/components/crew/RosterRow.svelte'
 	import RosterSearch from '$lib/components/crew/RosterSearch.svelte'
 	import type { RosterSearchResult } from '$lib/components/crew/RosterSearch.svelte'
-	import type { RosterMember } from '$lib/types/api/crew'
 	import * as m from '$lib/paraglide/messages'
 	import type { PageData } from './$types'
 	import { toast } from 'svelte-sonner'
@@ -42,21 +42,38 @@
 
 	// State
 	let selectedItems = $state<SelectedItem[]>([])
-	let rosterData = $state<RosterMember[]>([])
-	let isLoadingRoster = $state(false)
+	let hasCheckedOfficer = $state(false)
 
-	// Check if user is an officer
+	// Check if user is an officer (one-time after initial load)
 	$effect(() => {
-		if (!crewStore.isLoading && !crewStore.isOfficer) {
+		if (crewStore.isLoading) return
+		if (hasCheckedOfficer) return
+		hasCheckedOfficer = true
+		if (!crewStore.isOfficer) {
 			goto(localizeHref('/crew'))
 		}
 	})
 
-	// Fetch roster on mount and when items change
+	// Derived ID arrays for the roster query key
+	const characterIds = $derived(
+		selectedItems.filter((i) => i.type === 'Character').map((i) => i.id)
+	)
+	const weaponIds = $derived(selectedItems.filter((i) => i.type === 'Weapon').map((i) => i.id))
+	const summonIds = $derived(selectedItems.filter((i) => i.type === 'Summon').map((i) => i.id))
+
+	// TanStack Query handles deduplication, cancellation, caching
+	const rosterQuery = createQuery(() => ({
+		...crewQueries.roster(characterIds, weaponIds, summonIds)
+	}))
+
+	const rosterData = $derived(rosterQuery.data?.members ?? [])
+	const isLoadingRoster = $derived(rosterQuery.isLoading && selectedItems.length > 0)
+
+	// Show error toast on query failure
 	$effect(() => {
-		// Track selectedItems to trigger refetch
-		const _ = selectedItems.length
-		fetchRoster()
+		if (rosterQuery.isError) {
+			toast.error(extractErrorMessage(rosterQuery.error, 'Failed to load roster'))
+		}
 	})
 
 	function handleSelect(result: RosterSearchResult) {
@@ -78,26 +95,6 @@
 
 	function removeItem(id: string, type: ItemType) {
 		selectedItems = selectedItems.filter((item) => !(item.id === id && item.type === type))
-	}
-
-	async function fetchRoster() {
-		isLoadingRoster = true
-		try {
-			const query = {
-				characterIds: selectedItems.filter((i) => i.type === 'Character').map((i) => i.id),
-				weaponIds: selectedItems.filter((i) => i.type === 'Weapon').map((i) => i.id),
-				summonIds: selectedItems.filter((i) => i.type === 'Summon').map((i) => i.id)
-			}
-
-			const response = await crewAdapter.getRoster(query)
-			rosterData = response.members
-		} catch (error) {
-			console.error('Failed to fetch roster:', error)
-			toast.error(extractErrorMessage(error, 'Failed to load roster'))
-			rosterData = []
-		} finally {
-			isLoadingRoster = false
-		}
 	}
 
 	function getItemImage(item: SelectedItem): string {


### PR DESCRIPTION
## Summary
- Replace manual `$effect` + `fetchRoster()` with TanStack Query (`createQuery`) so request deduplication, cancellation, and caching are handled automatically
- Add `roster()` query factory to `crew.queries.ts`
- Guard the officer check effect to only fire once after initial crew data load, preventing spurious redirects during background refetches

## Test plan
- [ ] Navigate to `/crew/roster` as an officer
- [ ] Search and add items via typeahead — no flicker or reload
- [ ] Add 2-3 items rapidly — typeahead remains functional
- [ ] Remove items — roster updates reactively
- [ ] Verify non-officers still redirect to `/crew`