### PR TITLE
Fix bullet image padding in database list

### DIFF
--- a/src/lib/components/database/cells/BulletImageCell.svelte
+++ b/src/lib/components/database/cells/BulletImageCell.svelte
@@ -24,7 +24,7 @@
 
 	.database-image {
 		max-width: 100%;
-		max-height: 48px;
+		max-height: 36px;
 		width: auto;
 		height: auto;
 		object-fit: contain;


### PR DESCRIPTION
## Summary
- Reduce bullet image max-height from 48px to 36px so they don't touch each other in the grid rows