### PR TITLE
Show equipped bullets in weapon detail sidebar

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -586,6 +586,7 @@
 	"details_artifact": "Artifact",
 	"details_ax_skills": "AX Skills",
 	"details_befoulment": "Befoulment",
+	"details_bullets": "Bullets",
 	"details_exorcism_level": "Exorcism Level",
 	"details_element_override": "Element Override",
 	"details_weapon_element": "Weapon Element",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -586,6 +586,7 @@
 	"details_artifact": "アーティファクト",
 	"details_ax_skills": "EXスキル",
 	"details_befoulment": "魔蝕",
+	"details_bullets": "バレット",
 	"details_exorcism_level": "退魔Lv",
 	"details_element_override": "属性変更",
 	"details_weapon_element": "武器属性",

--- a/src/lib/components/sidebar/details/TeamView.svelte
+++ b/src/lib/components/sidebar/details/TeamView.svelte
@@ -9,6 +9,9 @@
 	import { formatAxSkill, getWeaponKeyTitle } from '$lib/utils/modificationFormatters'
 	import ElementLabel from '$lib/components/labels/ElementLabel.svelte'
 	import UncapIndicator from '$lib/components/uncap/UncapIndicator.svelte'
+	import { BULLET_TYPES } from '$lib/types/api/entities'
+	import { getBulletImage } from '$lib/utils/images'
+	import { localizedName } from '$lib/utils/locale'
 	import * as m from '$lib/paraglide/messages'
 
 	interface Props {
@@ -139,6 +142,19 @@
 				</DetailRow>
 			</DetailsSection>
 		{/if}
+
+		{#if modificationStatus.hasBullets && weapon.bullets?.length}
+			<DetailsSection title={m.details_bullets()}>
+				{#each weapon.bullets as loadout}
+					<DetailRow label={BULLET_TYPES[loadout.bullet.bulletType] ?? 'Unknown'}>
+						<span class="bullet-value">
+							<img src={getBulletImage(loadout.bullet.granblueId)} alt="" class="bullet-icon" />
+							{localizedName(loadout.bullet.name)}
+						</span>
+					</DetailRow>
+				{/each}
+			</DetailsSection>
+		{/if}
 	{:else if type === 'summon'}
 		{@const summon = item as GridSummon}
 
@@ -162,5 +178,17 @@
 		display: flex;
 		flex-direction: column;
 		gap: spacing.$unit-3x;
+	}
+
+	.bullet-value {
+		display: flex;
+		align-items: center;
+		gap: spacing.$unit;
+	}
+
+	.bullet-icon {
+		width: 24px;
+		height: 24px;
+		object-fit: contain;
 	}
 </style>

--- a/src/lib/utils/modificationDetector.ts
+++ b/src/lib/utils/modificationDetector.ts
@@ -13,6 +13,7 @@ export interface ModificationStatus {
 	hasTranscendence: boolean
 	hasUncapLevel: boolean
 	hasElement: boolean
+	hasBullets: boolean
 	hasQuickSummon: boolean
 	hasFriendSummon: boolean
 }
@@ -27,6 +28,7 @@ export function detectModifications(
 		hasWeaponKeys: false,
 		hasAxSkills: false,
 		hasBefoulment: false,
+		hasBullets: false,
 		hasRings: false,
 		hasEarring: false,
 		hasPerpetuity: false,
@@ -63,6 +65,7 @@ export function detectModifications(
 		status.hasWeaponKeys = !!(weapon.weaponKeys && weapon.weaponKeys.length > 0)
 		status.hasAxSkills = !!(weapon.ax && weapon.ax.length > 0)
 		status.hasBefoulment = !!weapon.befoulment?.modifier
+		status.hasBullets = !!(weapon.bullets && weapon.bullets.length > 0)
 		status.hasTranscendence = !!(weapon.transcendenceStep && weapon.transcendenceStep > 0)
 		status.hasUncapLevel = weapon.uncapLevel !== undefined && weapon.uncapLevel !== null
 		status.hasElement = !!(weapon.element && weapon.weapon?.element === 0)
@@ -72,6 +75,7 @@ export function detectModifications(
 			status.hasWeaponKeys ||
 			status.hasAxSkills ||
 			status.hasBefoulment ||
+			status.hasBullets ||
 			status.hasTranscendence ||
 			status.hasUncapLevel ||
 			status.hasElement


### PR DESCRIPTION
## Summary
- Add `hasBullets` to modification detection so bullets show in "This team" section
- Display each equipped bullet with type label, icon, and name in the detail sidebar
- EN/JA localization for "Bullets" section title

## Test plan
- [ ] Equip bullets on a mainhand gun, view detail sidebar — bullets section appears
- [ ] Non-gun weapons don't show bullets section
- [ ] Guns without equipped bullets don't show bullets section