### PR TITLE
Show job icon and abbreviate raid names in grid rep cards

### DIFF
--- a/src/lib/components/reps/GridRep.svelte
+++ b/src/lib/components/reps/GridRep.svelte
@@ -7,9 +7,14 @@
 	import Icon from '$lib/components/Icon.svelte'
 	import Tooltip from '$lib/components/ui/Tooltip.svelte'
 	import { localizeHref } from '$lib/paraglide/runtime'
-	import { localizedName } from '$lib/utils/locale'
+	import { localizedName, appLocale } from '$lib/utils/locale'
 	import { getJobIconUrl } from '$lib/utils/jobUtils'
 	import * as m from '$lib/paraglide/messages'
+
+	const RAID_ABBREVIATIONS: Record<string, Record<string, string>> = {
+		'Ultimate Bahamut': { en: 'UBHL', ja: 'アルバハ' },
+		'Proto Bahamut': { en: 'PBHL', ja: 'PBHL' }
+	}
 
 	interface Props {
 		party: Party
@@ -38,8 +43,14 @@
 	function displayName(input: any): string {
 		if (!input) return '—'
 		const maybe = input.name ?? input
-		if (typeof maybe === 'string') return maybe
-		return localizedName(maybe)
+		const name = typeof maybe === 'string' ? maybe : localizedName(maybe)
+
+		const enName = typeof maybe === 'string' ? maybe : maybe.en ?? ''
+		for (const [key, abbr] of Object.entries(RAID_ABBREVIATIONS)) {
+			if (enName.startsWith(key)) return abbr[appLocale()] ?? abbr.en
+		}
+
+		return name
 	}
 </script>
 


### PR DESCRIPTION
## Summary
- Show job icon to the left of raid name in grid rep cards
- Abbreviate long raid names: Ultimate Bahamut (Impossible) → UBHL, Proto Bahamut (Impossible) → PBHL
- Support JP abbreviations (アルバハ for UBHL)
- Show transformed weapon images in grid rep

## Test plan
- [ ] Verify job icon appears next to raid name on explore page
- [ ] Verify UBHL and PBHL abbreviations show correctly
- [ ] Verify JP locale shows アルバハ for Ultimate Bahamut
- [ ] Verify transformed weapon images display correctly