### PR TITLE
Add tooltip on job icon in grid rep cards

### DIFF
--- a/src/lib/components/reps/GridRep.svelte
+++ b/src/lib/components/reps/GridRep.svelte
@@ -66,7 +66,11 @@
 			<div class="details">
 				<div class="details-text">
 					{#if party.job}
-						<img class="job-icon" src={getJobIconUrl(party.job.granblueId)} alt="" loading="lazy" />
+						<Tooltip content={displayName(party.job)}>
+							{#snippet children()}
+								<img class="job-icon" src={getJobIconUrl(party.job.granblueId)} alt="" loading="lazy" />
+							{/snippet}
+						</Tooltip>
 					{/if}
 					<span class={`raid ${!party.raid ? 'empty' : ''}`}
 						>{party.raid ? displayName(party.raid) : m.grid_no_raid()}</span


### PR DESCRIPTION
## Summary
- Wrap job icon in a Tooltip that shows the job name on hover
- Companion API PR: https://github.com/jedmund/hensei-api/pull/330

## Test plan
- [ ] Hover job icon on explore page shows job name tooltip