### PR TITLE
Add /auth/verify-email route

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -211,6 +211,11 @@
 	"auth_resetPassword_errors_passwordMismatch": "Passwords don't match",
 	"auth_resetPassword_errors_failed": "Password reset failed",
 
+	"auth_verifyEmail_title": "Verify email",
+	"auth_verifyEmail_success": "Your email has been verified.",
+	"auth_verifyEmail_invalidToken": "This verification link is invalid or has expired.",
+	"auth_verifyEmail_signIn": "Sign in",
+
 	"auth_register_title": "Sign up",
 	"auth_register_username": "Username",
 	"auth_register_usernameNote": "You can change this later",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -211,6 +211,11 @@
 	"auth_resetPassword_errors_passwordMismatch": "パスワードが一致しません",
 	"auth_resetPassword_errors_failed": "パスワードのリセットに失敗しました",
 
+	"auth_verifyEmail_title": "メール認証",
+	"auth_verifyEmail_success": "メールアドレスが認証されました。",
+	"auth_verifyEmail_invalidToken": "この認証リンクは無効または期限切れです。",
+	"auth_verifyEmail_signIn": "ログイン",
+
 	"auth_register_title": "アカウント作成",
 	"auth_register_username": "ユーザー名",
 	"auth_register_usernameNote": "後から変更できます",

--- a/src/routes/auth/verify-email/+page.server.ts
+++ b/src/routes/auth/verify-email/+page.server.ts
@@ -1,0 +1,23 @@
+import type { PageServerLoad } from './$types'
+import { getApiBaseUrl } from '$lib/api/adapters/config'
+
+export const load: PageServerLoad = async ({ url, fetch }) => {
+	const email = url.searchParams.get('email') ?? ''
+	const token = url.searchParams.get('token') ?? ''
+
+	if (!email || !token) {
+		return { invalidToken: true }
+	}
+
+	const res = await fetch(`${getApiBaseUrl()}/email_verifications`, {
+		method: 'PUT',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ email, token })
+	})
+
+	if (res.ok) {
+		return { success: true }
+	}
+
+	return { invalidToken: true }
+}

--- a/src/routes/auth/verify-email/+page.svelte
+++ b/src/routes/auth/verify-email/+page.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import AuthCard from '$lib/components/auth/AuthCard.svelte'
+	import PageMeta from '$lib/components/PageMeta.svelte'
+	import * as m from '$lib/paraglide/messages'
+	import { localizeHref } from '$lib/paraglide/runtime'
+
+	interface Props {
+		data: { success?: boolean; invalidToken?: boolean }
+	}
+
+	let { data }: Props = $props()
+</script>
+
+<PageMeta title={m.auth_verifyEmail_title()} description={m.page_desc_home()} />
+
+<AuthCard title={m.auth_verifyEmail_title()}>
+	{#if data.success}
+		<p class="success">{m.auth_verifyEmail_success()}</p>
+		<a href={localizeHref('/auth/login')} class="action-link">
+			{m.auth_verifyEmail_signIn()}
+		</a>
+	{:else}
+		<p class="error">{m.auth_verifyEmail_invalidToken()}</p>
+		<a href={localizeHref('/auth/login')} class="action-link">
+			{m.auth_verifyEmail_signIn()}
+		</a>
+	{/if}
+
+	{#snippet footer()}
+		<p>
+			<a href={localizeHref('/auth/login')}>{m.auth_forgotPassword_backToLogin()}</a>
+		</p>
+	{/snippet}
+</AuthCard>
+
+<style lang="scss">
+	@use '$src/themes/spacing' as *;
+	@use '$src/themes/colors' as *;
+	@use '$src/themes/typography' as *;
+
+	.success {
+		color: var(--text-primary);
+		font-size: $font-small;
+		text-align: center;
+		margin: 0;
+		padding: $unit-2x;
+	}
+
+	.error {
+		color: $error;
+		font-size: $font-small;
+		text-align: center;
+		margin: 0;
+		padding: $unit $unit-2x;
+		background: var(--danger-bg);
+		border-radius: $unit;
+	}
+
+	.action-link {
+		display: block;
+		text-align: center;
+		color: var(--accent-blue);
+		text-decoration: none;
+		font-size: $font-small;
+		margin-top: $unit;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary
- Adds the missing `/auth/verify-email` route that handles email verification links
- On page load, sends the token to the API to verify the email and shows success or error
- Follows the same pattern as `/auth/reset-password` (AuthCard, i18n, etc.)