### PR TITLE
Fix tile header padding when empty

### DIFF
--- a/src/lib/components/party/info/InfoTile.svelte
+++ b/src/lib/components/party/info/InfoTile.svelte
@@ -28,7 +28,7 @@
 	onkeydown={clickable ? (e) => e.key === 'Enter' && onclick?.() : undefined}
 >
 	{#if label}
-		<div class="tile-header" class:has-action={headerAction || (showAdd && onAdd)}>
+		<div class="tile-header" class:has-action={headerAction || (showAdd && onAdd)} class:show-add={showAdd && onAdd}>
 			{#if showAdd && onAdd}
 				<button type="button" class="tile-header-button" onclick={onAdd}>
 					<h3 class="tile-label">{label}</h3>
@@ -80,7 +80,10 @@
 			display: flex;
 			align-items: center;
 			min-height: 30px;
-			margin-right: -$unit;
+
+			&:not(.show-add) {
+				margin-right: -$unit;
+			}
 
 			&.has-action {
 				justify-content: space-between;


### PR DESCRIPTION
## Summary
- Only apply negative right margin on InfoTile header when the tile has content
- Empty tiles (showing + icon) now get full `$unit-2x` padding-right on the header instead of the reduced `$unit`