### PR TITLE
Support party last_updated

### DIFF
--- a/src/lib/api/adapters/__tests__/party.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/party.adapter.test.ts
@@ -54,7 +54,8 @@ describe('PartyAdapter', () => {
 		summons: [],
 		characters: [],
 		createdAt: '2024-01-01T00:00:00Z',
-		updatedAt: '2024-01-01T00:00:00Z'
+		updatedAt: '2024-01-01T00:00:00Z',
+		lastUpdated: '2024-01-01T00:00:00Z'
 	}
 
 	beforeEach(() => {

--- a/src/lib/api/schemas/party.ts
+++ b/src/lib/api/schemas/party.ts
@@ -470,7 +470,8 @@ export const PartySchemaRaw = z.object({
   
   // Timestamps
   created_at: z.string().nullish(),
-  updated_at: z.string().nullish()
+  updated_at: z.string().nullish(),
+  last_updated: z.string().nullish()
 })
 
 // Apply transform after parsing (do NOT nest this schema inside other schemas)

--- a/src/lib/components/party/info/PartyInfoGrid.svelte
+++ b/src/lib/components/party/info/PartyInfoGrid.svelte
@@ -72,7 +72,7 @@
 		<DescriptionTile
 			name={party.name}
 			description={party.description}
-			updatedAt={party.updatedAt}
+			updatedAt={party.lastUpdated ?? party.updatedAt}
 			visibility={party.visibility}
 			user={party.user}
 			collectionSourceUser={party.collectionSourceUser}

--- a/src/lib/components/playlist/PlaylistHeader.svelte
+++ b/src/lib/components/playlist/PlaylistHeader.svelte
@@ -37,7 +37,7 @@
 		title={playlist.title}
 		description={playlist.description}
 		user={playlist.user}
-		updatedAt={playlist.updatedAt}
+		updatedAt={playlist.lastUpdated ?? playlist.updatedAt}
 	>
 		{#snippet menu()}
 			{#if isOwner}

--- a/src/lib/types/api/party.ts
+++ b/src/lib/types/api/party.ts
@@ -182,6 +182,7 @@ export interface Party {
   // Timestamps
   createdAt?: string
   updatedAt?: string
+  lastUpdated?: string
 }
 
 // Minimal party for list views
@@ -233,4 +234,5 @@ export interface PartyPreview {
   }
   createdAt?: string
   updatedAt?: string
+  lastUpdated?: string
 }

--- a/src/lib/types/api/playlist.ts
+++ b/src/lib/types/api/playlist.ts
@@ -15,4 +15,5 @@ export interface Playlist {
 	raidSlugs?: string[]
 	createdAt: string
 	updatedAt: string
+	lastUpdated?: string
 }


### PR DESCRIPTION
## Summary
- Add `lastUpdated` field to Party, PartyPreview, and Playlist types
- Add `last_updated` to party Zod schema (auto-transformed to camelCase)
- Use `lastUpdated` for "last updated" display in party and playlist views, falling back to `updatedAt`

Companion to jedmund/hensei-api#343.