### PR TITLE
Update Discord invite link

### DIFF
--- a/src/routes/(app)/about/+page.svelte
+++ b/src/routes/(app)/about/+page.svelte
@@ -11,7 +11,7 @@
 	<h2>{m.about_feedback_title()}</h2>
 	<p>{m.about_feedback_explanation()}</p>
 	<p>{m.about_feedback_solicit()}</p>
-	<LinkItem title="granblue-tools" link="https://discord.gg/qyZ5hGdPC8" icon="discord" class="discord" />
+	<LinkItem title="granblue-tools" link="https://discord.gg/pSjUAYNDzN" icon="discord" class="discord" />
 </div>
 
 <div class="about-card">


### PR DESCRIPTION
## Summary
- Updated the Discord invite URL on the about page to the new permanent link

## Test plan
- [ ] Visit /about and verify the Discord link works