### PR TITLE
Always show perpetuity ring and quick summon badges

### DIFF
--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -503,7 +503,7 @@
 		cursor: pointer;
 		transition: transform 0.2s ease;
 
-		&:not(.active) {
+		&:not(.active):not(.static) {
 			display: none;
 		}
 

--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -473,7 +473,7 @@
     cursor: pointer;
     transition: transform 0.2s ease;
 
-    &:not(.active) {
+    &:not(.active):not(.static) {
       display: none;
     }
 


### PR DESCRIPTION
## Summary
- Perpetuity ring and quick summon badges were hidden in non-edit mode even when active, because the static `<img>` elements lacked the `.active` class
- Excluded `.static` elements from the hide rule so badges are always visible when their value is true

## Test plan
- View a party in non-edit mode with a character that has perpetuity ring — badge should be visible
- View a party in non-edit mode with a summon marked as quick summon — badge should be visible
- Edit mode hover-to-toggle behavior should be unchanged