### PR TITLE
Use S3 bucket for extension page video

### DIFF
--- a/src/routes/(app)/extension/+page.svelte
+++ b/src/routes/(app)/extension/+page.svelte
@@ -5,6 +5,7 @@
 	import PageMeta from '$lib/components/PageMeta.svelte'
 	import Button from '$lib/components/ui/Button.svelte'
 	import * as m from '$lib/paraglide/messages'
+	import { getImageBaseUrl } from '$lib/api/adapters/config'
 	import type { UserCookie } from '$lib/types/UserCookie'
 
 	const faqItems = [
@@ -26,7 +27,7 @@
 <div class="extension-page">
 	<div class="hero card">
 		<video class="hero-video" autoplay loop muted playsinline>
-			<source src="/images/media/extension.mp4" type="video/mp4" />
+			<source src="{getImageBaseUrl()}/images/media/extension.mp4" type="video/mp4" />
 		</video>
 		<p>{m.ext_description()}</p>
 		<a


### PR DESCRIPTION
## Summary
- Extension page video was serving from local static files instead of the S3 bucket
- Now uses `getImageBaseUrl()` to construct the video URL, consistent with how images are served elsewhere