### PR TITLE
Fix infinite scroll stalling on large viewports

### DIFF
--- a/src/lib/stores/loaderState.svelte.ts
+++ b/src/lib/stores/loaderState.svelte.ts
@@ -298,6 +298,15 @@ export function useInfiniteLoader<TData, TError>(
 							`[InfiniteLoader] ${new Date().toISOString()} Ready for next page (waiting for sentinel exit)`
 						)
 					state.loaded()
+
+					// If sentinel is still visible after DOM updates (large viewport where
+					// content doesn't fill the scroll area), clear the gate so the $effect
+					// can trigger another load. LoopTracker guards against runaway fetches.
+					requestAnimationFrame(() => {
+						if (inViewport.current && state.status === STATUS.READY) {
+							waitingForSentinelExit = false
+						}
+					})
 				}
 			}
 		} catch (error) {


### PR DESCRIPTION
## Summary
- On large viewports (tablet portrait, tall windows), the modal's results area is tall enough that a single page of results doesn't fill it — no scrollbar appears
- The infinite loader's `waitingForSentinelExit` flag blocks further page loads until the sentinel leaves the viewport, but since there's nothing to scroll, it never does
- After a successful page load, we now use `requestAnimationFrame` to re-check if the sentinel is still visible and clear the gate if so, allowing the next page to load
- The existing `LoopTracker` already prevents runaway fetches, so this is safe

## Test plan
- [ ] Open collection modal on a large viewport (iPad portrait sim or tall browser window)
- [ ] Verify pages keep loading until content fills the scroll area or all pages are exhausted
- [ ] On normal-sized viewports, verify scroll-triggered pagination still works without rapid-firing