### PR TITLE
Fix ProfileHeader icons inconsistent across tabs

### DIFF
--- a/src/routes/(app)/[username]/collection/+layout.svelte
+++ b/src/routes/(app)/[username]/collection/+layout.svelte
@@ -7,6 +7,7 @@
 	import { setContext } from 'svelte'
 	import { createQuery } from '@tanstack/svelte-query'
 	import { sidebar } from '$lib/stores/sidebar.svelte'
+	import { crewStore } from '$lib/stores/crew.store.svelte'
 	import { viewMode } from '$lib/stores/viewMode.svelte'
 	import ProfileHeader from '$lib/components/profile/ProfileHeader.svelte'
 	import CollectionSegmentedControl from '$lib/components/collection/CollectionSegmentedControl.svelte'
@@ -33,6 +34,9 @@
 	import { extractErrorMessage } from '$lib/utils/errors'
 
 	let { data, children }: { data: LayoutData; children: any } = $props()
+
+	const viewerCrewRole = $derived(crewStore.membership?.role ?? null)
+	const viewerCrewId = $derived(crewStore.crew?.id ?? null)
 
 	// Query for collection counts
 	const countsQuery = createQuery(() => collectionQueries.counts(data.user?.id ?? ''))
@@ -190,9 +194,12 @@
 		showCrewGamertag={data.user?.showCrewGamertag}
 		crewGamertag={data.user?.crewGamertag}
 		crewName={data.user?.crewName}
+		userId={data.user?.id}
 		title={username ?? ''}
 		activeTab="collection"
 		isOwner={data.isOwner}
+		{viewerCrewRole}
+		{viewerCrewId}
 		collectionPrivacy={data.user?.collectionPrivacy}
 		isAuthenticated={$page.data?.isAuthenticated}
 	/>

--- a/src/routes/(app)/[username]/playlists/+page.svelte
+++ b/src/routes/(app)/[username]/playlists/+page.svelte
@@ -77,6 +77,8 @@
 		element={data.user?.avatar?.element}
 		granblueId={data.user?.granblueId}
 		showGranblueId={data.user?.showGranblueId}
+		wikiProfile={data.user?.wikiProfile}
+		showWikiProfile={data.user?.showWikiProfile}
 		youtube={data.user?.youtube}
 		showYoutube={data.user?.showYoutube}
 		showCrewGamertag={data.user?.showCrewGamertag}


### PR DESCRIPTION
## Summary
- Added missing `wikiProfile`/`showWikiProfile` props on the playlists page
- Added missing `userId`, `viewerCrewRole`, `viewerCrewId` props on the collection layout (+ crewStore import)

Previously wiki icon was missing on playlists tab and the ellipsis menu was missing on collection tab.