### PR TITLE
Fix locale redirect on language switch

### DIFF
--- a/src/lib/components/LanguageToggle.svelte
+++ b/src/lib/components/LanguageToggle.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { getLocale } from '$lib/paraglide/runtime.js'
+	import { getLocale, localizeHref, deLocalizeHref } from '$lib/paraglide/runtime.js'
 	import { invalidateAll } from '$app/navigation'
 	import { Switch as SwitchPrimitive } from 'bits-ui'
 	import * as m from '$lib/paraglide/messages'
@@ -24,10 +24,11 @@
 			}
 		}
 
-		// Unauthenticated fallback: set locale cookie directly and reload
+		// Unauthenticated fallback: set locale cookie directly and navigate
 		document.cookie = `PARAGLIDE_LOCALE=${newLocale};path=/;max-age=${60 * 60 * 24 * 365};SameSite=Lax`
 		await invalidateAll()
-		window.location.reload()
+		const basePath = deLocalizeHref(window.location.pathname + window.location.search + window.location.hash)
+		window.location.href = localizeHref(basePath, { locale: newLocale })
 	}
 </script>
 

--- a/src/lib/components/UserSettingsModal.svelte
+++ b/src/lib/components/UserSettingsModal.svelte
@@ -18,6 +18,7 @@
 	import { crewQueries } from '$lib/api/queries/crew.queries'
 	import { userAdapter } from '$lib/api/adapters/user.adapter'
 	import { themeStore, type ThemePreference } from '$lib/stores/theme.svelte'
+	import { localizeHref, deLocalizeHref } from '$lib/paraglide/runtime'
 
 	interface Props {
 		open: boolean
@@ -251,10 +252,11 @@
 				themeStore.setTheme(theme as ThemePreference)
 			}
 
-			// If language or bahamut mode changed, we need a full page reload
+			// If language or bahamut mode changed, navigate to the re-localized URL
 			if (originalLanguage !== language || user.bahamut !== bahamut) {
 				await invalidateAll()
-				window.location.reload()
+				const basePath = deLocalizeHref(window.location.pathname + window.location.search + window.location.hash)
+				window.location.href = localizeHref(basePath, { locale: language })
 			} else {
 				// For other changes (element, picture, gender, theme), invalidate to refresh layout data
 				await invalidateAll()

--- a/src/lib/services/__tests__/settings-sync.test.ts
+++ b/src/lib/services/__tests__/settings-sync.test.ts
@@ -30,6 +30,13 @@ vi.mock('$app/navigation', () => ({
 	invalidateAll: () => mockInvalidateAll()
 }))
 
+// Mock Paraglide runtime — deLocalizeHref strips locale prefix, localizeHref adds it
+vi.mock('$lib/paraglide/runtime', () => ({
+	deLocalizeHref: (href: string) => href.replace(/^\/ja/, '') || '/',
+	localizeHref: (href: string, opts?: { locale?: string }) =>
+		opts?.locale === 'ja' ? `/ja${href}` : href
+}))
+
 const mockFetch = vi.fn(async () => new Response(JSON.stringify({ success: true })))
 
 const baseUser: UserCookie = {
@@ -44,7 +51,9 @@ beforeEach(() => {
 	callOrder = []
 	vi.clearAllMocks()
 	vi.stubGlobal('fetch', mockFetch)
-	vi.stubGlobal('window', { location: { reload: vi.fn() } })
+	vi.stubGlobal('window', {
+		location: { href: '', pathname: '/ja/teams', search: '', hash: '', reload: vi.fn() }
+	})
 
 	// Track ordering
 	mockUsersUpdate.mockImplementation(async () => {
@@ -137,7 +146,7 @@ describe('syncTheme', () => {
 })
 
 describe('syncLanguage', () => {
-	it('persists to DB, updates cookie, then reloads', async () => {
+	it('persists to DB, updates cookie, then navigates to localized URL', async () => {
 		const { syncLanguage } = await import('../settings-sync')
 
 		await syncLanguage('user-1', baseUser, 'ja')
@@ -147,7 +156,7 @@ describe('syncLanguage', () => {
 			'fetch:/api/settings',
 			'invalidateAll'
 		])
-		expect(window.location.reload).toHaveBeenCalled()
+		expect(window.location.href).toBe('/ja/teams')
 	})
 
 	it('calls users.update with the new language', async () => {
@@ -168,10 +177,10 @@ describe('syncLanguage', () => {
 		expect(body.theme).toBe('system')
 	})
 
-	it('awaits DB and cookie update before reloading', async () => {
+	it('awaits DB and cookie update before navigating', async () => {
 		const { syncLanguage } = await import('../settings-sync')
 
-		// Make users.update slow to verify we don't reload early
+		// Make users.update slow to verify we don't navigate early
 		mockUsersUpdate.mockImplementation(
 			() => new Promise((resolve) => {
 				setTimeout(() => {
@@ -183,28 +192,39 @@ describe('syncLanguage', () => {
 
 		await syncLanguage('user-1', baseUser, 'ja')
 
-		// reload must come after both async steps
-		const reloadIndex = callOrder.indexOf('invalidateAll')
+		// navigation must come after both async steps
+		const navIndex = callOrder.indexOf('invalidateAll')
 		const updateIndex = callOrder.indexOf('users.update')
 		const fetchIndex = callOrder.indexOf('fetch:/api/settings')
 
 		expect(updateIndex).toBeLessThan(fetchIndex)
-		expect(fetchIndex).toBeLessThan(reloadIndex)
+		expect(fetchIndex).toBeLessThan(navIndex)
 	})
 
-	it('does not reload on API failure', async () => {
+	it('navigates to correct URL when switching to English', async () => {
 		const { syncLanguage } = await import('../settings-sync')
+
+		await syncLanguage('user-1', baseUser, 'en')
+
+		// /ja/teams delocalized → /teams, localized for 'en' → /teams
+		expect(window.location.href).toBe('/teams')
+	})
+
+	it('does not navigate on API failure', async () => {
+		const { syncLanguage } = await import('../settings-sync')
+		const originalHref = window.location.href
 
 		mockUsersUpdate.mockRejectedValue(new Error('network error'))
 
 		await syncLanguage('user-1', baseUser, 'ja')
 
 		expect(mockInvalidateAll).not.toHaveBeenCalled()
-		expect(window.location.reload).not.toHaveBeenCalled()
+		expect(window.location.href).toBe(originalHref)
 	})
 
-	it('does not reload on non-ok /api/settings response', async () => {
+	it('does not navigate on non-ok /api/settings response', async () => {
 		const { syncLanguage } = await import('../settings-sync')
+		const originalHref = window.location.href
 
 		mockFetch.mockImplementation(async () => {
 			callOrder.push('fetch:/api/settings')
@@ -213,6 +233,6 @@ describe('syncLanguage', () => {
 
 		await syncLanguage('user-1', baseUser, 'ja')
 
-		expect(window.location.reload).not.toHaveBeenCalled()
+		expect(window.location.href).toBe(originalHref)
 	})
 })

--- a/src/lib/services/settings-sync.ts
+++ b/src/lib/services/settings-sync.ts
@@ -1,6 +1,7 @@
 import { users } from '$lib/api/resources/users'
 import { themeStore, type ThemePreference } from '$lib/stores/theme.svelte'
 import { invalidateAll } from '$app/navigation'
+import { localizeHref, deLocalizeHref } from '$lib/paraglide/runtime'
 import type { UserCookie } from '$lib/types/UserCookie'
 
 /**
@@ -63,7 +64,12 @@ export async function syncLanguage(
 		}
 
 		await invalidateAll()
-		window.location.reload()
+
+		// Navigate to the re-localized URL so the locale prefix is correct
+		// (e.g. /ja/teams → /teams when switching to English)
+		const basePath = deLocalizeHref(window.location.pathname + window.location.search + window.location.hash)
+		const newPath = localizeHref(basePath, { locale: newLanguage })
+		window.location.href = newPath
 	} catch (err) {
 		console.error('Failed to persist language:', err)
 	}


### PR DESCRIPTION
## Summary
- Language toggle and settings modal used `window.location.reload()` after changing language, which reloads the same `/ja/...` URL — Paraglide's URL strategy sees the `/ja` prefix and overrides the cookie, reverting to Japanese
- Now uses `deLocalizeHref` + `localizeHref` to navigate to the correct URL for the new locale (e.g. `/ja/teams` → `/teams` when switching to English)
- Fixed in all three paths: `syncLanguage` helper, `LanguageToggle` unauthed fallback, and `UserSettingsModal`

## Test plan
- [ ] On a `/ja/` page, switch language to English via toggle → should navigate to the English URL
- [ ] On an English page, switch to Japanese → should navigate to `/ja/` URL
- [ ] Same behavior from the settings modal language dropdown