### PR TITLE
Improve registration error handling

### DIFF
--- a/src/routes/auth/register/+page.server.ts
+++ b/src/routes/auth/register/+page.server.ts
@@ -44,9 +44,9 @@ export const actions: Actions = {
 		}
 
 		const j = await res.json().catch(() => ({}))
-		return fail(res.status, {
+		return fail(Math.min(res.status, 499), {
 			error: 'failed' as const,
-			details: j.details,
+			details: j.messages ?? j.details,
 			username,
 			email
 		})

--- a/src/routes/auth/signup/+server.ts
+++ b/src/routes/auth/signup/+server.ts
@@ -56,15 +56,23 @@ export const POST: RequestHandler = async ({ request, cookies, fetch }) => {
 		if (!signupRes.ok) {
 			const errorData = await signupRes.json().catch(() => ({}))
 
-			// Handle specific API errors (username/email already taken)
+			if (dev) console.error('Signup API error:', signupRes.status, errorData)
+
+			// Handle specific API errors (username/email already taken, validation errors)
 			if (signupRes.status === 409 || signupRes.status === 422) {
 				return json(
-					{ error: errorData.error || 'Username or email already in use' },
+					{
+						error: errorData.error || 'Username or email already in use',
+						messages: errorData.messages
+					},
 					{ status: 409 }
 				)
 			}
 
-			return json({ error: errorData.error || 'Signup failed' }, { status: signupRes.status })
+			return json(
+				{ error: errorData.error || 'Signup failed', messages: errorData.messages },
+				{ status: signupRes.status }
+			)
 		}
 
 		// 2. Auto-login the new user


### PR DESCRIPTION
## Summary
- Pass validation `messages` from API errors through to the registration form
- Clamp error status to 499 so `fail()` never returns a 5xx form failure
- Add dev-mode logging for signup API errors

## Test plan
- [ ] Test registration with invalid data — form should show error messages
- [ ] Test with API returning various error codes (422, 500)
- [ ] Verify successful registration flow still works