### PR TITLE
Hide proficiency sort for summon collections

### DIFF
--- a/src/lib/components/collection/CollectionFilters.svelte
+++ b/src/lib/components/collection/CollectionFilters.svelte
@@ -120,15 +120,19 @@
 		...showFilters
 	})
 
-	// Sort options
-	const sortOptions: { value: CollectionSortKey; label: string }[] = [
+	// Sort options (exclude proficiency for summons since they don't have weapon types)
+	const sortOptions = $derived([
 		{ value: 'name_asc', label: m.sort_name_asc() },
 		{ value: 'name_desc', label: m.sort_name_desc() },
 		{ value: 'element_asc', label: m.sort_element_asc() },
 		{ value: 'element_desc', label: m.sort_element_desc() },
-		{ value: 'proficiency_asc', label: m.sort_proficiency_asc() },
-		{ value: 'proficiency_desc', label: m.sort_proficiency_desc() }
-	]
+		...(entityType !== 'summon'
+			? [
+					{ value: 'proficiency_asc', label: m.sort_proficiency_asc() },
+					{ value: 'proficiency_desc', label: m.sort_proficiency_desc() }
+				]
+			: [])
+	] as { value: CollectionSortKey; label: string }[])
 
 	// Constants
 	const elements = getElementOptions().map((opt) => ({


### PR DESCRIPTION
## Summary
- Summons don't have weapon proficiencies, so the proficiency sort options shouldn't show in the sort dropdown for summon collections
- Made `sortOptions` derived based on `entityType`, excluding proficiency sort when viewing summons

## Test plan
- [ ] Check summon collection page — sort dropdown should only show name and element options
- [ ] Check character/weapon collection pages — proficiency sort options still present