### PR TITLE
Disable hover effects on read-only uncap stars

### DIFF
--- a/src/lib/components/uncap/TranscendenceStar.svelte
+++ b/src/lib/components/uncap/TranscendenceStar.svelte
@@ -108,6 +108,7 @@
 			<div
 				{...props}
 				class="star TranscendenceStar"
+				class:readonly={!editable}
 				class:immutable
 				class:empty={currentStage === 0}
 				class:stage1={currentStage === 1}
@@ -200,11 +201,15 @@
 		position: relative;
 		cursor: pointer;
 
+		&.readonly {
+			cursor: default;
+		}
+
 		&.small {
 			--size: 12px;
 		}
 
-		&:hover {
+		&:not(.readonly):hover {
 			transform: scale(1.2);
 		}
 
@@ -320,10 +325,10 @@
 					background-image: url('$src/assets/icons/transcendence/interactive/interactive-base@3x.png');
 				}
 			}
+		}
 
-			&:hover {
-				transform: scale(1.2);
-			}
+		&:not(.readonly) .figure:hover {
+			transform: scale(1.2);
 		}
 
 		&.small .figure {

--- a/src/lib/components/uncap/UncapIndicator.svelte
+++ b/src/lib/components/uncap/UncapIndicator.svelte
@@ -27,6 +27,7 @@
 		flb?: boolean
 		ulb?: boolean
 		index: number
+		editable?: boolean
 		tabindex?: number
 		size?: 'regular' | 'small'
 		onStarClick: (index: number, empty: boolean) => void
@@ -141,6 +142,7 @@
 				flb: options.flb,
 				ulb: options.ulb,
 				special: options.special,
+				editable,
 				tabindex: editable ? 0 : undefined,
 				size,
 				onStarClick: editable ? toggleStar : () => {}

--- a/src/lib/components/uncap/UncapStar.svelte
+++ b/src/lib/components/uncap/UncapStar.svelte
@@ -5,6 +5,7 @@
 		flb?: boolean
 		ulb?: boolean
 		index: number
+		editable?: boolean
 		tabindex?: number
 		size?: 'regular' | 'small'
 		onStarClick: (index: number, empty: boolean) => void
@@ -16,6 +17,7 @@
 		flb = false,
 		ulb = false,
 		index,
+		editable = false,
 		tabindex,
 		size = 'regular',
 		onStarClick
@@ -35,6 +37,7 @@
 	class:flb
 	class:ulb
 	class:small={size === 'small'}
+	class:readonly={!editable}
 	{tabindex}
 	onclick={handleClick}
 	role="button"
@@ -51,11 +54,15 @@
 		width: var(--size);
 		cursor: pointer;
 
+		&.readonly {
+			cursor: default;
+		}
+
 		&.small {
 			--size: 12px;
 		}
 
-		&:hover {
+		&:not(.readonly):hover {
 			transform: scale(1.2);
 		}
 
@@ -66,7 +73,7 @@
 		&.empty.special {
 			background-image: url('$src/assets/icons/uncap/empty@3x.png');
 
-			&:hover {
+			&:not(.readonly):hover {
 				background-image: url('$src/assets/icons/uncap/empty-hover@3x.png');
 			}
 		}
@@ -74,7 +81,7 @@
 		&.mlb {
 			background-image: url('$src/assets/icons/uncap/yellow@3x.png');
 
-			&:hover {
+			&:not(.readonly):hover {
 				background-image: url('$src/assets/icons/uncap/yellow-hover@3x.png');
 			}
 		}
@@ -82,7 +89,7 @@
 		&.special {
 			background-image: url('$src/assets/icons/uncap/red@3x.png');
 
-			&:hover {
+			&:not(.readonly):hover {
 				background-image: url('$src/assets/icons/uncap/red-hover@3x.png');
 			}
 		}
@@ -90,7 +97,7 @@
 		&.flb {
 			background-image: url('$src/assets/icons/uncap/blue@3x.png');
 
-			&:hover {
+			&:not(.readonly):hover {
 				background-image: url('$src/assets/icons/uncap/blue-hover@3x.png');
 			}
 		}
@@ -98,7 +105,7 @@
 		&.ulb {
 			background-image: url('$src/assets/icons/uncap/purple@3x.png');
 
-			&:hover {
+			&:not(.readonly):hover {
 				background-image: url('$src/assets/icons/uncap/purple-hover@3x.png');
 			}
 		}
@@ -111,7 +118,7 @@
 				--size: 12px;
 			}
 
-			&:hover {
+			&:not(.readonly):hover {
 				transform: scale(1);
 			}
 		}


### PR DESCRIPTION
## Summary
- Uncap stars no longer scale up or swap to hover images when the indicator is read-only
- Adds `editable` prop to `UncapStar` and uses existing `editable` on `TranscendenceStar` to gate hover styles behind a `.readonly` class
- Also removes `cursor: pointer` on read-only stars

Closes #747