### PR TITLE
Fix null-element weapon image 404s in WeaponRep

### DIFF
--- a/src/lib/components/reps/WeaponRep.svelte
+++ b/src/lib/components/reps/WeaponRep.svelte
@@ -26,6 +26,7 @@
 
 	function weaponFallbackUrl(w?: GridWeapon, isMain = false): string | undefined {
 		if (w?.weapon?.element !== 0) return undefined
+		if (w?.element) return undefined
 		const variant = isMain ? 'main' : 'grid'
 		const transformation = getWeaponTransformation(
 			w?.weapon?.uncap?.transcendence,

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -72,8 +72,10 @@
 	})
 
 	// Fallback URL for element-changeable weapons whose _0 image doesn't exist
+	// Only needed when the instance has no element set (element is 0 or null)
 	let fallbackUrl = $derived.by(() => {
 		if (item?.weapon?.element !== 0) return undefined
+		if (item?.element) return undefined
 		const isMain = position === -1 || item?.mainhand
 		const variant = isMain ? 'main' : 'grid'
 		const transformation = getWeaponTransformation(


### PR DESCRIPTION
## Summary
- WeaponUnit already had fallback handling for null-element weapons whose `_0` image doesn't exist, but WeaponRep (party cards) was missing it
- Added `weaponFallbackUrl()` helper and `onerror` handlers to both mainhand and grid weapon images so they fall back to the base filename

## Test plan
- [ ] Find a null-element weapon as mainhand in a party card — should show the base image instead of broken
- [ ] Grid null-element weapons should also fall back
- [ ] Non-null-element weapons unaffected