### PR TITLE
Add dev:mobile script for LAN access

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev --port 5174",
+		"dev:mobile": "vite dev --port 5174 --host",
 		"build": "vite build",
 		"preview": "vite preview",
 		"prepare": "husky || true; svelte-kit sync || echo ''",


### PR DESCRIPTION
## Summary
- Adds `dev:mobile` script that runs vite with `--host` flag to expose on LAN
- For iPhone debugging: set `PUBLIC_SIERO_API_URL` to your Mac's LAN IP in `.env.local`

## Usage
```bash
# Get your Mac's IP
ipconfig getifaddr en0

# Create .env.local with your IP
echo 'PUBLIC_SIERO_API_URL=http://<your-ip>:3000
PUBLIC_SIERO_OAUTH_URL=http://<your-ip>:3000/oauth
PUBLIC_SIERO_IMG_URL=""' > .env.local

# Run
pnpm dev:mobile
```