### PR TITLE
Fix RangeError in formatRelativeTime on mobile

### DIFF
--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { formatRelativeTime } from './date'
+
+describe('formatRelativeTime', () => {
+	it('returns relative time for a recent valid ISO date', () => {
+		const fiveMinutesAgo = new Date(Date.now() - 5 * 60_000).toISOString()
+		const result = formatRelativeTime(fiveMinutesAgo)
+		expect(result).toMatch(/minute/)
+	})
+
+	it('returns absolute date for dates beyond cutoff', () => {
+		const twoWeeksAgo = new Date(Date.now() - 14 * 86_400_000).toISOString()
+		const result = formatRelativeTime(twoWeeksAgo)
+		// Should be an absolute date string, not a relative one
+		expect(result).not.toMatch(/ago/)
+	})
+
+	it('returns the raw string for an invalid date without throwing', () => {
+		expect(formatRelativeTime('not-a-date')).toBe('not-a-date')
+	})
+
+	it('returns the raw string for an empty string without throwing', () => {
+		expect(formatRelativeTime('')).toBe('')
+	})
+
+	it('handles dates that some browsers fail to parse', () => {
+		// Space-separated datetime (fails in Safari)
+		const result = formatRelativeTime('2024-01-15 10:30:00')
+		expect(typeof result).toBe('string')
+	})
+})

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -59,6 +59,9 @@ export function formatRelativeTime(
 	cutoffDays: number = 7
 ): string {
 	const date = new Date(dateString)
+	if (isNaN(date.getTime())) {
+		return dateString
+	}
 	const now = Date.now()
 	const diffMs = date.getTime() - now
 	const absDiffMs = Math.abs(diffMs)


### PR DESCRIPTION
## Summary
- Adds a guard in `formatRelativeTime()` against invalid Date objects
- Mobile Safari can fail to parse certain date strings, causing NaN to hit `Intl.RelativeTimeFormat.format()` which throws `RangeError: number argument must be finite`
- Falls back to returning the raw date string instead of crashing

## Test plan
- [x] Added unit tests for valid dates, invalid dates, and edge cases
- [x] `pnpm check` passes with 0 errors
- [x] All 1402 tests pass