### PR TITLE
Mobile navigation and responsive layouts

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -464,6 +464,7 @@
 	"explore_end": "You've reached the end of all teams!",
 
 	"explore_filter_placeholder": "Start typing...",
+	"explore_filter_placeholder_mobile": "Filter teams...",
 	"explore_filter": "Filter",
 	"explore_filter_tagline": "to find the perfect team",
 	"explore_searching": "Searching...",
@@ -495,6 +496,7 @@
 	"explore_settings_original_desc": "Exclude remixes",
 	"explore_settings_apply": "Apply",
 	"explore_settings_reset": "Reset",
+	"explore_advanced_filters": "Advanced filters",
 
 	"modal_cancel": "Nevermind",
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -1283,6 +1283,7 @@
 
 	"artifact_equipped": "Equipped",
 	"extra_summons_subaura": "Subaura Summons",
+	"summon_friend_label": "Friend",
 
 	"placeholder_select_proficiency": "Select proficiency",
 	"placeholder_select_element": "Select element",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -464,6 +464,7 @@
 	"explore_end": "すべての編成を表示しました！",
 
 	"explore_filter_placeholder": "入力して検索...",
+	"explore_filter_placeholder_mobile": "チームを絞り込む...",
 	"explore_filter": "フィルター",
 	"explore_filter_tagline": "で最適な編成を見つけよう",
 	"explore_searching": "検索中...",
@@ -495,6 +496,7 @@
 	"explore_settings_original_desc": "リミックスを除外",
 	"explore_settings_apply": "フィルターを保存する",
 	"explore_settings_reset": "リセット",
+	"explore_advanced_filters": "詳細フィルター",
 
 	"modal_cancel": "キャンセル",
 

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1265,6 +1265,7 @@
 
 	"artifact_equipped": "装備中",
 	"extra_summons_subaura": "サブ加護召喚石",
+	"summon_friend_label": "サポート",
 
 	"placeholder_select_proficiency": "得意武器を選択",
 	"placeholder_select_element": "属性を選択",

--- a/src/lib/components/MobileNavigation.svelte
+++ b/src/lib/components/MobileNavigation.svelte
@@ -1,0 +1,500 @@
+<script lang="ts">
+	import { localizeHref } from '$lib/paraglide/runtime'
+	import { m } from '$lib/paraglide/messages'
+	import { page } from '$app/stores'
+	import { goto } from '$app/navigation'
+	import { createQuery } from '@tanstack/svelte-query'
+	import { crewQueries } from '$lib/api/queries/crew.queries'
+	import Button from './ui/Button.svelte'
+	import Icon from './Icon.svelte'
+	import NotificationBadge from './ui/NotificationBadge.svelte'
+	import BottomSheet from './ui/BottomSheet.svelte'
+	import type { UserCookie } from '$lib/types/UserCookie'
+	import { getAvatarSrc, getAvatarSrcSet } from '$lib/utils/avatar'
+	import UserSettingsModal from './UserSettingsModal.svelte'
+	import InvitationsModal from './crew/InvitationsModal.svelte'
+	import { authStore } from '$lib/stores/auth.store.svelte'
+	import { invalidateAll, beforeNavigate } from '$app/navigation'
+	import { toast } from 'svelte-sonner'
+	import { extractErrorMessage } from '$lib/utils/errors'
+	import LanguageToggle from './LanguageToggle.svelte'
+	import ThemeToggle from './ThemeToggle.svelte'
+
+	const {
+		account,
+		currentUser,
+		isAuthenticated: isAuthProp
+	} = $props<{
+		account?: {
+			userId: string
+			username: string
+			role: number
+		} | null
+		currentUser?: UserCookie | null
+		isAuthenticated?: boolean
+	}>()
+
+	const username = $derived(account?.username ?? '')
+	const isAuth = $derived(authStore.isAuthenticated || (isAuthProp ?? false))
+	const role = $derived(account?.role ?? null)
+	const userElement = $derived(
+		currentUser?.element as 'wind' | 'fire' | 'water' | 'earth' | 'dark' | 'light' | undefined
+	)
+
+	const isBahamut = $derived(currentUser?.bahamut === true)
+
+	// Localized links
+	const galleryHref = $derived(localizeHref('/teams/explore'))
+	const meHref = $derived(localizeHref('/me'))
+	const loginHref = $derived(localizeHref('/auth/login'))
+	const registerHref = $derived(localizeHref('/auth/register'))
+	const databaseHref = $derived(localizeHref('/database'))
+	const newTeamHref = $derived(localizeHref('/teams/new'))
+	const crewHref = $derived(localizeHref('/crew'))
+	const collectionHref = $derived(
+		isAuth ? localizeHref(`/${username}/collection`) : localizeHref('/collection')
+	)
+	const aboutHref = $derived(localizeHref('/about'))
+	const extensionHref = $derived(localizeHref('/extension'))
+
+	const elementClass = $derived(userElement ? `element-${userElement}` : '')
+
+	// Avatar
+	const avatarSrc = $derived(getAvatarSrc(currentUser?.picture))
+	const avatarSrcSet = $derived(getAvatarSrcSet(currentUser?.picture))
+
+	// Route detection
+	function isNavSelected(href: string): boolean {
+		const path = $page.url.pathname
+		if (href === galleryHref) return path === href
+		return path === href || path.startsWith(href + '/')
+	}
+
+	const userProfilePath = $derived(localizeHref(`/${username}`))
+	const isProfileSelected = $derived(
+		isAuth &&
+			($page.url.pathname === meHref ||
+				$page.url.pathname === userProfilePath ||
+				$page.url.pathname.startsWith(userProfilePath + '/'))
+	)
+
+	// Current page label
+	const currentPageLabel = $derived.by(() => {
+		if (isNavSelected(galleryHref)) return m.nav_gallery()
+		if (isNavSelected(crewHref)) return m.nav_crew()
+		if (isNavSelected(collectionHref)) return m.nav_collection()
+		if (isProfileSelected) return username
+		if (isNavSelected(aboutHref)) return m.nav_about()
+		if (isNavSelected(extensionHref)) return m.nav_extension()
+		if (isNavSelected(databaseHref)) return m.nav_database()
+		if (isNavSelected(loginHref)) return m.nav_login()
+		if (isNavSelected(registerHref)) return m.nav_register()
+		return m.nav_gallery()
+	})
+
+	// Sheet state
+	let sheetOpen = $state(false)
+
+	// Close sheet on navigation
+	beforeNavigate(() => {
+		sheetOpen = false
+	})
+
+	// Modal state
+	let settingsModalOpen = $state(false)
+	let invitationsModalOpen = $state(false)
+
+	// Queries
+	const myCrewQuery = createQuery(() => ({
+		...crewQueries.myCrew(),
+		enabled: isAuth
+	}))
+
+	const isInCrew = $derived(myCrewQuery.data != null)
+
+	const pendingInvitationsQuery = createQuery(() => ({
+		...crewQueries.pendingInvitations(),
+		enabled: isAuth
+	}))
+
+	const pendingPhantomClaimsQuery = createQuery(() => ({
+		...crewQueries.pendingPhantomClaims(),
+		enabled: isAuth && isInCrew
+	}))
+
+	const pendingInvitationCount = $derived(pendingInvitationsQuery.data?.length ?? 0)
+	const pendingPhantomClaimCount = $derived(pendingPhantomClaimsQuery.data?.length ?? 0)
+	const totalNotificationCount = $derived(pendingInvitationCount + pendingPhantomClaimCount)
+
+	// Bahamut off
+	async function handleBahamutOff() {
+		if (!currentUser) return
+		const updatedUser = { ...currentUser, bahamut: false }
+		await fetch('/api/settings', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(updatedUser)
+		})
+		await invalidateAll()
+		window.location.reload()
+	}
+
+	// Logout
+	async function handleLogout() {
+		try {
+			const response = await fetch('/auth/logout', {
+				method: 'POST',
+				credentials: 'include'
+			})
+
+			if (response.ok) {
+				await goto('/auth/login')
+			}
+		} catch (error) {
+			console.error('Logout failed:', error)
+			toast.error(extractErrorMessage(error, 'Failed to log out'))
+		}
+	}
+</script>
+
+{#if isBahamut}
+	<button class="bahamut-bar" onclick={handleBahamutOff}>
+		{m.nav_bahamut_mode_on()}
+	</button>
+{/if}
+
+<nav aria-label="Global" class={elementClass}>
+	<button class="mobile-nav-trigger" onclick={() => (sheetOpen = true)}>
+		<span class="trigger-label">{currentPageLabel}</span>
+		<Icon name="chevron-down" size={14} />
+	</button>
+
+	<Button
+		icon="plus"
+		iconOnly
+		shape="circle"
+		variant={userElement ? 'primary' : 'subtle'}
+		{...userElement ? { element: userElement } : {}}
+		elementStyle={Boolean(userElement)}
+		class="new-team-button"
+		aria-label={m.nav_new_team()}
+		href={newTeamHref}
+	/>
+</nav>
+
+<BottomSheet bind:open={sheetOpen}>
+	<div class="mobile-nav-sheet {elementClass}">
+		{#if isAuth}
+			<ul class="sheet-nav-group" role="list">
+				<li>
+					<a href={galleryHref} class:selected={isNavSelected(galleryHref)}>{m.nav_gallery()}</a>
+				</li>
+				<li>
+					<a href={crewHref} class:selected={isNavSelected(crewHref)}>
+						{m.nav_crew()}
+						{#if totalNotificationCount > 0}
+							<span class="crew-notification-dot {userElement ?? ''}"></span>
+						{/if}
+					</a>
+				</li>
+				<li>
+					<a href={meHref} class:selected={isProfileSelected} class="profile-link">
+						<span>{username}</span>
+						{#if avatarSrc}
+							<img
+								src={avatarSrc}
+								srcset={avatarSrcSet}
+								alt={username}
+								class="user-avatar"
+								width="24"
+								height="24"
+							/>
+						{/if}
+					</a>
+				</li>
+			</ul>
+			<hr class="sheet-separator" />
+			<ul class="sheet-nav-group" role="list">
+				<li><a href={aboutHref}>{m.nav_about()}</a></li>
+				<li><a href={extensionHref}>{m.nav_extension()}</a></li>
+				{#if role !== null && role >= 7}
+					<li><a href={databaseHref}>{m.nav_database()}</a></li>
+				{/if}
+			</ul>
+			<hr class="sheet-separator" />
+			<ul class="sheet-nav-group" role="list">
+				<li>
+					<button
+						class="sheet-button-with-badge"
+						onclick={() => {
+							sheetOpen = false
+							invitationsModalOpen = true
+						}}
+					>
+						<span>{m.nav_notifications()}</span>
+						{#if totalNotificationCount > 0}
+							<NotificationBadge count={totalNotificationCount} showCount element={userElement} />
+						{/if}
+					</button>
+				</li>
+				<li>
+					<button
+						onclick={() => {
+							sheetOpen = false
+							settingsModalOpen = true
+						}}
+					>
+						{m.nav_settings()}
+					</button>
+				</li>
+			</ul>
+			<hr class="sheet-separator" />
+			<div class="sheet-nav-toggles">
+				<LanguageToggle />
+				<ThemeToggle />
+			</div>
+			<hr class="sheet-separator" />
+			<ul class="sheet-nav-group" role="list">
+				<li><button onclick={handleLogout}>{m.nav_logout()}</button></li>
+			</ul>
+		{:else}
+			<ul class="sheet-nav-group" role="list">
+				<li>
+					<a href={galleryHref} class:selected={isNavSelected(galleryHref)}>{m.nav_gallery()}</a>
+				</li>
+				<li>
+					<a href={crewHref} class:selected={isNavSelected(crewHref)}>{m.nav_crew()}</a>
+				</li>
+				<li>
+					<a href={collectionHref} class:selected={isNavSelected(collectionHref)}
+						>{m.nav_collection()}</a
+					>
+				</li>
+			</ul>
+			<hr class="sheet-separator" />
+			<ul class="sheet-nav-group" role="list">
+				<li><a href={aboutHref}>{m.nav_about()}</a></li>
+				<li><a href={extensionHref}>{m.nav_extension()}</a></li>
+			</ul>
+			<hr class="sheet-separator" />
+			<div class="sheet-nav-toggles">
+				<LanguageToggle />
+				<ThemeToggle />
+			</div>
+			<hr class="sheet-separator" />
+			<ul class="sheet-nav-group" role="list">
+				<li><a href={loginHref}>{m.nav_login()}</a></li>
+				<li><a href={registerHref}>{m.nav_register()}</a></li>
+			</ul>
+		{/if}
+	</div>
+</BottomSheet>
+
+{#if isAuth && account && currentUser}
+	<UserSettingsModal
+		bind:open={settingsModalOpen}
+		onOpenChange={(open) => (settingsModalOpen = open)}
+		{username}
+		userId={account.userId}
+		user={currentUser}
+		role={role ?? 0}
+	/>
+{/if}
+
+{#if isAuth}
+	<InvitationsModal
+		bind:open={invitationsModalOpen}
+		invitations={pendingInvitationsQuery.data ?? []}
+		phantomClaims={pendingPhantomClaimsQuery.data ?? []}
+		isLoading={pendingInvitationsQuery.isLoading || pendingPhantomClaimsQuery.isLoading}
+	/>
+{/if}
+
+<style lang="scss">
+	@use '$src/themes/effects' as effects;
+	@use '$src/themes/layout' as layout;
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+
+	$elements: wind, fire, water, earth, dark, light;
+
+	// Bahamut bar (same as Navigation)
+	.bahamut-bar {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 100%;
+		padding: spacing.$unit;
+		background-color: #7c3aed;
+		color: white;
+		border: none;
+		cursor: pointer;
+		font-family: var(--font-family);
+		font-size: typography.$font-tiny;
+		font-weight: typography.$medium;
+		transition: background-color 0.2s ease;
+
+		&:hover {
+			background-color: #6d28d9;
+		}
+	}
+
+	nav {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: center;
+		padding: spacing.$unit 0;
+		max-width: var(--main-max-width);
+		margin: 0 auto;
+		width: 100%;
+
+		@media (max-width: 768px) {
+			padding: spacing.$unit;
+		}
+	}
+
+	.mobile-nav-trigger {
+		background-color: var(--menu-bg);
+		border: effects.$page-border;
+		box-shadow: effects.$page-elevation;
+		border-radius: layout.$full-corner;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: spacing.$unit;
+		height: calc(spacing.$unit * 5.5);
+		padding: 0 (spacing.$unit * 1.5);
+		cursor: pointer;
+		font-family: var(--font-family);
+		font-size: typography.$font-small;
+		font-weight: typography.$medium;
+		color: var(--menu-text);
+		flex: 1;
+		margin-right: spacing.$unit;
+	}
+
+	.trigger-label {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	// Sheet styles
+	.mobile-nav-sheet {
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+	}
+
+	.sheet-nav-group {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+
+		li {
+			a,
+			button {
+				display: flex;
+				align-items: center;
+				width: 100%;
+				padding: calc(spacing.$unit * 1.5) spacing.$unit;
+				border-radius: layout.$card-corner;
+				color: var(--text-primary);
+				text-decoration: none;
+				font-size: typography.$font-regular;
+				font-weight: typography.$medium;
+				background: none;
+				border: none;
+				cursor: pointer;
+				font-family: var(--font-family);
+				gap: spacing.$unit-half;
+
+				&:hover {
+					background: var(--menu-bg-item-hover);
+				}
+			}
+		}
+	}
+
+	.sheet-button-with-badge {
+		justify-content: space-between;
+	}
+
+	.sheet-separator {
+		border: none;
+		height: 2px;
+		background-color: var(--separator-bg);
+		border-radius: 1px;
+		margin: spacing.$unit 0;
+	}
+
+	.sheet-nav-toggles {
+		padding: spacing.$unit-half 0;
+
+		:global(.language-row),
+		:global(.theme-row) {
+			padding: calc(spacing.$unit * 1.5) spacing.$unit;
+		}
+
+		:global(.language-label),
+		:global(.theme-label) {
+			font-size: typography.$font-regular;
+			color: var(--text-primary);
+		}
+	}
+
+	// Profile link with avatar on right
+	.profile-link {
+		justify-content: space-between;
+
+		.user-avatar {
+			width: 24px;
+			height: 24px;
+			border-radius: 50%;
+			object-fit: cover;
+		}
+	}
+
+	// Crew notification dot
+	.crew-notification-dot {
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		background: var(--button-primary-bg);
+		animation: notification-pulse 2s ease-in-out infinite;
+		flex-shrink: 0;
+	}
+
+	@each $el in $elements {
+		.crew-notification-dot.#{$el} {
+			background: var(--#{$el}-button-bg);
+		}
+	}
+
+	@keyframes notification-pulse {
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.6;
+		}
+	}
+
+	// Element-specific selected states in sheet
+	@each $el in $elements {
+		.mobile-nav-sheet.element-#{$el} {
+			.sheet-nav-group li a.selected {
+				background-color: var(--#{$el}-nav-selected-bg);
+				color: var(--#{$el}-nav-selected-text);
+			}
+		}
+	}
+
+	// Fallback selected state when no element is set
+	.sheet-nav-group li a.selected {
+		background-color: var(--null-nav-selected-bg);
+		color: var(--null-nav-selected-text);
+	}
+</style>

--- a/src/lib/components/explore/ExploreFilters.svelte
+++ b/src/lib/components/explore/ExploreFilters.svelte
@@ -7,6 +7,10 @@
 	import ExploreFilterPill from './ExploreFilterPill.svelte'
 	import FilterDropdown from './FilterDropdown.svelte'
 	import Icon from '$lib/components/Icon.svelte'
+	import Button from '$lib/components/ui/Button.svelte'
+	import Input from '$lib/components/ui/Input.svelte'
+	import BottomSheet from '$lib/components/ui/BottomSheet.svelte'
+	import Switch from '$lib/components/ui/switch/Switch.svelte'
 	import * as m from '$lib/paraglide/messages'
 	import { getLocale } from '$lib/paraglide/runtime'
 	import { localizedName } from '$lib/utils/locale'
@@ -17,6 +21,9 @@
 		getBoostOptions,
 		getSideOptions
 	} from '$lib/utils/exploreFilterOptions'
+	import { MediaQuery } from 'svelte/reactivity'
+
+	type ElementName = 'wind' | 'fire' | 'water' | 'earth' | 'dark' | 'light'
 
 	interface Props {
 		filters: FilterItem[]
@@ -25,6 +32,15 @@
 		/** Use when placed on a card/white surface — gives the pill a visible background */
 		contained?: boolean
 		allRaids?: RaidFull[]
+		/** Mobile-only: collection filter state */
+		collectionFilterActive?: boolean
+		onCollectionFilterChange?: (active: boolean) => void
+		/** Mobile-only: open the advanced filters modal */
+		onAdvancedFiltersOpen?: () => void
+		/** User's element for theming */
+		element?: ElementName
+		/** Whether the user is authenticated (controls collection filter visibility) */
+		isAuthenticated?: boolean
 	}
 
 	let {
@@ -32,8 +48,15 @@
 		onFiltersChange,
 		excludedKinds = [],
 		contained = false,
-		allRaids = []
+		allRaids = [],
+		collectionFilterActive = $bindable(false),
+		onCollectionFilterChange,
+		onAdvancedFiltersOpen,
+		element,
+		isAuthenticated = false
 	}: Props = $props()
+
+	const isMobile = new MediaQuery('(max-width: 768px)')
 
 	let inputValue = $state('')
 	let dropdownOpen = $state(false)
@@ -388,6 +411,9 @@
 		}
 	}
 
+	// Mobile gear sheet state
+	let gearSheetOpen = $state(false)
+
 	function handleWindowClick(e: MouseEvent) {
 		const target = e.target as Node
 		if (!target.isConnected) return
@@ -399,64 +425,164 @@
 
 <svelte:window onclick={handleWindowClick} />
 
-<div class="explore-filters" class:contained bind:this={containerEl}>
-	<div class="filter-row">
-		{#if dropdownOpen}
-			<div class="filter-input-wrapper">
-				<input
-					bind:this={inputEl}
+<div
+	class="explore-filters"
+	class:contained
+	class:mobile={isMobile.current}
+	bind:this={containerEl}
+>
+	{#if isMobile.current}
+		<!-- Mobile layout: full-width input + gear button -->
+		<div class="mobile-filter-row">
+			<div class="mobile-input-wrapper">
+				<Input
+					leftIcon="search"
+					placeholder={m.explore_filter_placeholder_mobile()}
 					bind:value={inputValue}
-					type="text"
-					class="filter-input"
-					placeholder={m.explore_filter_placeholder()}
+					fullWidth
+					size="medium"
+					onfocus={openDropdown}
 					onkeydown={handleKeydown}
 					oncompositionstart={handleCompositionStart}
 					oncompositionend={handleCompositionEnd}
 				/>
 			</div>
-		{:else}
-			<button type="button" class="filter-trigger" onclick={openDropdown}>
-				<span>{m.explore_filter()}</span>
-				<Icon name="plus" size={9} />
-			</button>
+			<Button
+				icon="gear"
+				iconOnly
+				shape="circle"
+				variant="subtle"
+				onclick={() => (gearSheetOpen = true)}
+				aria-label={m.explore_settings_aria()}
+			/>
+		</div>
 
-			{#if filters.length === 0}
-				<span class="tagline">{m.explore_filter_tagline()}</span>
-			{/if}
+		{#if filters.length > 0}
+			<div class="mobile-pills-row">
+				{#each filters as filter, i (i)}
+					{@const pillElement =
+						filter.kind === 'entity'
+							? filter.element
+							: filter.kind === 'element'
+								? filter.value
+								: undefined}
+					<ExploreFilterPill
+						label={filter.label}
+						kind={filter.kind}
+						mode={filter.kind === 'entity' ? filter.mode : undefined}
+						element={pillElement}
+						pinned={filter.pinned}
+						onRemove={() => removeFilter(i)}
+						onToggleMode={() => toggleEntityMode(i)}
+					/>
+				{/each}
+			</div>
 		{/if}
 
-		{#each filters as filter, i (i)}
-			{@const pillElement =
-				filter.kind === 'entity'
-					? filter.element
-					: filter.kind === 'element'
-						? filter.value
-						: undefined}
-			<ExploreFilterPill
-				label={filter.label}
-				kind={filter.kind}
-				mode={filter.kind === 'entity' ? filter.mode : undefined}
-				element={pillElement}
-				pinned={filter.pinned}
-				onRemove={() => removeFilter(i)}
-				onToggleMode={() => toggleEntityMode(i)}
+		{#if dropdownOpen}
+			<FilterDropdown
+				{inputValue}
+				{isSearching}
+				{placeholderSuggestions}
+				{displayResults}
+				{selectedIndex}
+				onSelectedIndexChange={(i) => (selectedIndex = i)}
+				onSelectOption={selectOption}
+				onSuggestionClick={(s) => {
+					if (s.option) selectOption(s.option)
+				}}
 			/>
-		{/each}
-	</div>
+		{/if}
 
-	{#if dropdownOpen}
-		<FilterDropdown
-			{inputValue}
-			{isSearching}
-			{placeholderSuggestions}
-			{displayResults}
-			{selectedIndex}
-			onSelectedIndexChange={(i) => (selectedIndex = i)}
-			onSelectOption={selectOption}
-			onSuggestionClick={(s) => {
-				if (s.option) selectOption(s.option)
-			}}
-		/>
+		<BottomSheet bind:open={gearSheetOpen}>
+			<div class="gear-sheet">
+				{#if isAuthenticated}
+					<div class="gear-sheet-row">
+						<span class="gear-sheet-label">{m.explore_collection_only()}</span>
+						<Switch
+							checked={collectionFilterActive}
+							onCheckedChange={(checked) => {
+								collectionFilterActive = checked
+								onCollectionFilterChange?.(checked)
+							}}
+							size="small"
+							{element}
+						/>
+					</div>
+					<hr class="gear-sheet-separator" />
+				{/if}
+				<button
+					class="gear-sheet-row gear-sheet-button"
+					onclick={() => {
+						gearSheetOpen = false
+						onAdvancedFiltersOpen?.()
+					}}
+				>
+					<span class="gear-sheet-label">{m.explore_advanced_filters()}</span>
+					<Icon name="chevron-right" size={16} />
+				</button>
+			</div>
+		</BottomSheet>
+	{:else}
+		<!-- Desktop layout: existing filter trigger + inline pills -->
+		<div class="filter-row">
+			{#if dropdownOpen}
+				<div class="filter-input-wrapper">
+					<input
+						bind:this={inputEl}
+						bind:value={inputValue}
+						type="text"
+						class="filter-input"
+						placeholder={m.explore_filter_placeholder()}
+						onkeydown={handleKeydown}
+						oncompositionstart={handleCompositionStart}
+						oncompositionend={handleCompositionEnd}
+					/>
+				</div>
+			{:else}
+				<button type="button" class="filter-trigger" onclick={openDropdown}>
+					<span>{m.explore_filter()}</span>
+					<Icon name="plus" size={9} />
+				</button>
+
+				{#if filters.length === 0}
+					<span class="tagline">{m.explore_filter_tagline()}</span>
+				{/if}
+			{/if}
+
+			{#each filters as filter, i (i)}
+				{@const pillElement =
+					filter.kind === 'entity'
+						? filter.element
+						: filter.kind === 'element'
+							? filter.value
+							: undefined}
+				<ExploreFilterPill
+					label={filter.label}
+					kind={filter.kind}
+					mode={filter.kind === 'entity' ? filter.mode : undefined}
+					element={pillElement}
+					pinned={filter.pinned}
+					onRemove={() => removeFilter(i)}
+					onToggleMode={() => toggleEntityMode(i)}
+				/>
+			{/each}
+		</div>
+
+		{#if dropdownOpen}
+			<FilterDropdown
+				{inputValue}
+				{isSearching}
+				{placeholderSuggestions}
+				{displayResults}
+				{selectedIndex}
+				onSelectedIndexChange={(i) => (selectedIndex = i)}
+				onSelectOption={selectOption}
+				onSuggestionClick={(s) => {
+					if (s.option) selectOption(s.option)
+				}}
+			/>
+		{/if}
 	{/if}
 </div>
 
@@ -474,6 +600,10 @@
 
 	.explore-filters {
 		position: relative;
+
+		&.mobile {
+			width: 100%;
+		}
 
 		// Aura gradient colors — bright pastels for light, muted for dark
 		--aura-1: #f9c4d2;
@@ -648,5 +778,68 @@
 		&::placeholder {
 			color: var(--text-tertiary);
 		}
+	}
+
+	// Mobile layout styles
+	.mobile-filter-row {
+		display: flex;
+		align-items: center;
+		gap: $unit;
+	}
+
+	.mobile-input-wrapper {
+		flex: 1;
+		min-width: 0;
+
+		:global(.fieldset .input) {
+			min-height: calc($unit * 5.5);
+		}
+	}
+
+	.mobile-pills-row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: $unit-half;
+		margin-top: $unit;
+	}
+
+	// Gear sheet styles
+	.gear-sheet {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.gear-sheet-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: calc($unit * 1.5) $unit;
+	}
+
+	.gear-sheet-button {
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-family: var(--font-family);
+		border-radius: $card-corner;
+		color: var(--text-primary);
+
+		&:hover {
+			background: var(--menu-bg-item-hover);
+		}
+	}
+
+	.gear-sheet-label {
+		font-size: $font-regular;
+		font-weight: $medium;
+		color: var(--text-primary);
+	}
+
+	.gear-sheet-separator {
+		border: none;
+		height: 2px;
+		background-color: var(--separator-bg);
+		border-radius: 1px;
+		margin: $unit-half 0;
 	}
 </style>

--- a/src/lib/components/explore/FilterDropdown.svelte
+++ b/src/lib/components/explore/FilterDropdown.svelte
@@ -120,6 +120,10 @@
 		box-shadow: $dialog-elevation;
 		z-index: $z-popover;
 		overflow: hidden;
+
+		@media (max-width: 768px) {
+			width: 100%;
+		}
 	}
 
 	.results {

--- a/src/lib/components/extra/ExtraSummonsGrid.svelte
+++ b/src/lib/components/extra/ExtraSummonsGrid.svelte
@@ -62,14 +62,16 @@
 			gap: $unit-2x;
 			padding: $unit-2x;
 			flex-direction: column;
+			align-items: center;
+			margin: 0;
+		}
 
-			#ExtraSummons {
-				max-width: 50vw;
-				margin: 0 auto;
-			}
+		@media (max-width: 768px) {
+			margin: 0;
 		}
 
 		h3 {
+			margin: 0;
 			color: var(--subaura-orange-text);
 			display: flex;
 			align-items: center;
@@ -83,11 +85,14 @@
 			display: grid;
 			gap: $unit-3x;
 			grid-template-columns: repeat(2, minmax(0, 1fr));
+			padding: 0;
+			margin: 0;
 
 			@include breakpoint(tablet) {
 				gap: $unit-2x;
 			}
 			@include breakpoint(phone) {
+				display: flex;
 				gap: $unit;
 			}
 

--- a/src/lib/components/grids/CharacterGrid.svelte
+++ b/src/lib/components/grids/CharacterGrid.svelte
@@ -143,6 +143,17 @@
 		grid-template-columns: repeat(5, minmax(0, 1fr));
 		gap: $unit-3x;
 
+		@media (max-width: 768px) {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: center;
+			gap: $unit-3x $unit;
+
+			& > li {
+				width: calc((100% - $unit * 2) / 3);
+			}
+		}
+
 		&.unlimited {
 			// Use flexbox to center the partial second row
 			display: flex;
@@ -152,6 +163,14 @@
 			// 6 units must fit in space of 5
 			& > li {
 				width: 116px;
+			}
+
+			@media (max-width: 768px) {
+				gap: $unit-3x $unit;
+
+				& > li {
+					width: calc((100% - $unit * 2) / 3);
+				}
 			}
 		}
 

--- a/src/lib/components/grids/SummonGrid.svelte
+++ b/src/lib/components/grids/SummonGrid.svelte
@@ -15,6 +15,7 @@
 
 	import SummonUnit from '$lib/components/units/SummonUnit.svelte'
 	import ExtraSummons from '$lib/components/extra/ExtraSummonsGrid.svelte'
+	import * as m from '$lib/paraglide/messages'
 
 	const ctx = usePartyContext()
 	const dragContext = getDragDropContext()
@@ -134,11 +135,22 @@
 			</ul>
 		</section>
 
-		<div class="LabeledUnit">
+		<!-- Friend summon: in main grid on desktop, hidden on mobile -->
+		<div class="LabeledUnit friend-desktop">
 			<SummonUnit item={friend} position={6} />
 		</div>
 	</div>
-	<ExtraSummons {summons} offset={4} />
+
+	<!-- Bottom row: friend box (mobile only) + subaura box -->
+	<div class="bottom-row">
+		<div class="friend-mobile">
+			<h3>{m.summon_friend_label()}</h3>
+			<div class="friend-unit">
+				<SummonUnit item={friend} position={6} sizeOverride="grid" />
+			</div>
+		</div>
+		<ExtraSummons {summons} offset={4} />
+	</div>
 </div>
 
 <style lang="scss">
@@ -165,6 +177,10 @@
 			gap: $unit;
 		}
 
+		@media (max-width: 768px) {
+			grid-template-columns: 1fr 2fr;
+		}
+
 		.summons {
 			display: grid;
 			grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -185,5 +201,52 @@
 				list-style: none;
 			}
 		}
+	}
+
+	.friend-desktop {
+		@media (max-width: 768px) {
+			display: none;
+		}
+	}
+
+	.bottom-row {
+		display: contents;
+
+		@media (max-width: 768px) {
+			display: flex;
+			gap: $unit;
+			margin-top: $unit-2x;
+		}
+	}
+
+	.friend-mobile {
+		display: none;
+
+		@media (max-width: 768px) {
+			display: grid;
+			grid-template-columns: 2.32fr 2fr;
+			background: var(--button-contained-bg);
+			border-radius: layout.$input-corner;
+			padding: $unit-2x;
+			box-sizing: border-box;
+			flex: 1;
+
+			h3 {
+				color: var(--text-secondary);
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				line-height: 1.2;
+				font-weight: $medium;
+				text-align: center;
+				margin: 0;
+			}
+		}
+	}
+
+	.friend-unit {
+		display: flex;
+		align-items: center;
+		justify-content: center;
 	}
 </style>

--- a/src/lib/components/grids/SummonGrid.svelte
+++ b/src/lib/components/grids/SummonGrid.svelte
@@ -178,7 +178,7 @@
 		}
 
 		@media (max-width: 768px) {
-			grid-template-columns: 1fr 2fr;
+			grid-template-columns: 1.2fr 2fr;
 		}
 
 		.summons {
@@ -223,8 +223,9 @@
 		display: none;
 
 		@media (max-width: 768px) {
-			display: grid;
-			grid-template-columns: 2.32fr 2fr;
+			display: flex;
+			flex-direction: column;
+			gap: $unit-2x;
 			background: var(--button-contained-bg);
 			border-radius: layout.$input-corner;
 			padding: $unit-2x;
@@ -233,9 +234,6 @@
 
 			h3 {
 				color: var(--text-secondary);
-				display: flex;
-				align-items: center;
-				justify-content: center;
 				line-height: 1.2;
 				font-weight: $medium;
 				text-align: center;

--- a/src/lib/components/job/JobSection.svelte
+++ b/src/lib/components/job/JobSection.svelte
@@ -193,10 +193,10 @@
 		width: 100%;
 		box-sizing: border-box;
 
-		@media (max-width: 800px) {
+		@media (max-width: 768px) {
 			flex-direction: column;
-			align-items: center;
-			gap: spacing.$unit-2x;
+			gap: spacing.$unit;
+			padding: spacing.$unit;
 		}
 	}
 
@@ -217,10 +217,9 @@
 		align-items: center;
 		justify-content: center;
 
-		@media (max-width: 800px) {
+		@media (max-width: 768px) {
 			width: 100%;
 			height: auto;
-			aspect-ratio: 16/9;
 		}
 
 		.job-portrait {

--- a/src/lib/components/party/PartySegmentedControl.svelte
+++ b/src/lib/components/party/PartySegmentedControl.svelte
@@ -5,12 +5,14 @@
 	import { GridType } from '$lib/types/enums'
 	import SegmentedControl from '$lib/components/ui/segmented-control/SegmentedControl.svelte'
 	import RepSegment from '$lib/components/ui/segmented-control/RepSegment.svelte'
+	import Segment from '$lib/components/ui/segmented-control/Segment.svelte'
 	import CharacterRep from '$lib/components/reps/CharacterRep.svelte'
 	import WeaponRep from '$lib/components/reps/WeaponRep.svelte'
 	import SummonRep from '$lib/components/reps/SummonRep.svelte'
 	import { sidebar } from '$lib/stores/sidebar.svelte'
 	import { getJobIconUrl } from '$lib/utils/jobUtils'
 	import * as m from '$lib/paraglide/messages'
+	import { MediaQuery } from 'svelte/reactivity'
 
 	interface Props {
 		selectedTab?: GridType
@@ -20,6 +22,8 @@
 	}
 
 	let { selectedTab = GridType.Character, onTabChange, party, class: className }: Props = $props()
+
+	const isMobile = new MediaQuery('(max-width: 768px)')
 
 	// Derived values to ensure reactivity propagates through snippet boundaries
 	// When party updates from TanStack Query cache, these will trigger re-renders
@@ -40,31 +44,49 @@
 </script>
 
 <nav class={className}>
-	<SegmentedControl bind:value onValueChange={handleValueChange} gap={true} grow={true}>
-		<RepSegment
-			value={GridType.Character}
-			label={m.party_segmented_control_characters()}
-			labelIcon={jobIcon}
-			selected={value === GridType.Character}
-		>
-			<CharacterRep {party} {characters} {unlimited} />
-		</RepSegment>
+	<SegmentedControl
+		bind:value
+		onValueChange={handleValueChange}
+		gap={true}
+		grow={true}
+		class={isMobile.current ? 'mobile-padded' : ''}
+	>
+		{#if isMobile.current}
+			<Segment value={GridType.Character}>
+				{m.party_segmented_control_characters()}
+			</Segment>
+			<Segment value={GridType.Weapon}>
+				{m.party_segmented_control_weapons()}
+			</Segment>
+			<Segment value={GridType.Summon}>
+				{m.party_segmented_control_summons()}
+			</Segment>
+		{:else}
+			<RepSegment
+				value={GridType.Character}
+				label={m.party_segmented_control_characters()}
+				labelIcon={jobIcon}
+				selected={value === GridType.Character}
+			>
+				<CharacterRep {party} {characters} {unlimited} />
+			</RepSegment>
 
-		<RepSegment
-			value={GridType.Weapon}
-			label={m.party_segmented_control_weapons()}
-			selected={value === GridType.Weapon}
-		>
-			<WeaponRep {weapons} />
-		</RepSegment>
+			<RepSegment
+				value={GridType.Weapon}
+				label={m.party_segmented_control_weapons()}
+				selected={value === GridType.Weapon}
+			>
+				<WeaponRep {weapons} />
+			</RepSegment>
 
-		<RepSegment
-			value={GridType.Summon}
-			label={m.party_segmented_control_summons()}
-			selected={value === GridType.Summon}
-		>
-			<SummonRep {summons} />
-		</RepSegment>
+			<RepSegment
+				value={GridType.Summon}
+				label={m.party_segmented_control_summons()}
+				selected={value === GridType.Summon}
+			>
+				<SummonRep {summons} />
+			</RepSegment>
+		{/if}
 	</SegmentedControl>
 </nav>
 
@@ -73,5 +95,9 @@
 
 	nav {
 		width: 100%;
+
+		:global(.mobile-padded) {
+			padding: $unit-half;
+		}
 	}
 </style>

--- a/src/lib/components/party/info/VideoTile.svelte
+++ b/src/lib/components/party/info/VideoTile.svelte
@@ -174,6 +174,10 @@
 		color: var(--text-primary);
 		line-height: 1.3;
 		align-self: center;
+		display: -webkit-box;
+		-webkit-line-clamp: 3;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
 	}
 
 	.expand-icon {

--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -29,14 +29,23 @@
 		position: number
 		notInCollection?: boolean
 		inCollection?: boolean
+		sizeOverride?: 'main' | 'grid' | undefined
 	}
 
-	let { item, position, notInCollection = false, inCollection = false }: Props = $props()
+	let {
+		item,
+		position,
+		notInCollection = false,
+		inCollection = false,
+		sizeOverride = undefined
+	}: Props = $props()
 
 	const ctx = usePartyContext()
 
 	// Use position (not data flags) to determine sizing — position is authoritative
-	let isMainSized = $derived(position === -1 || position === 6)
+	let isMainSized = $derived(
+		sizeOverride ? sizeOverride === 'main' : position === -1 || position === 6
+	)
 
 	let imageUrl = $derived.by(() => {
 		const variant = isMainSized ? 'main' : 'grid'
@@ -179,8 +188,8 @@
 					{#key item?.id ?? position}
 						<div
 							class="frame summon {elementClass}"
-							class:main={position === -1}
-							class:friend={position === 6}
+							class:main={isMainSized && position === -1}
+							class:friend={isMainSized && position === 6}
 							class:cell={!isMainSized}
 							class:editable={ctx?.canEdit()}
 							class:is-active={isActive}
@@ -265,9 +274,9 @@
 		{#key `empty-${position}`}
 			<div
 				class="frame summon"
-				class:main={position === -1}
-				class:friend={position === 6}
-				class:cell={!(position === -1 || position === 6)}
+				class:main={isMainSized && position === -1}
+				class:friend={isMainSized && position === 6}
+				class:cell={!isMainSized}
 				class:editable={ctx?.canEdit()}
 				class:is-selected={isSelected}
 				role="button"

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -2,6 +2,8 @@
 	import type { Snippet } from 'svelte'
 	import * as m from '$lib/paraglide/messages'
 	import Navigation from '$lib/components/Navigation.svelte'
+	import MobileNavigation from '$lib/components/MobileNavigation.svelte'
+	import { MediaQuery } from 'svelte/reactivity'
 	import Sidebar from '$lib/components/ui/Sidebar.svelte'
 	import { sidebar } from '$lib/stores/sidebar.svelte'
 	import { Tooltip } from 'bits-ui'
@@ -53,6 +55,9 @@
 			event.preventDefault()
 		}
 	}
+
+	// Mobile detection
+	const isMobile = new MediaQuery('(max-width: 768px)')
 
 	// Bahamut mode bar affects layout positioning
 	const isBahamut = $derived(data?.currentUser?.bahamut === true)
@@ -166,11 +171,19 @@
 		<div class="main-pane" style:--bahamut-offset={isBahamut ? '16px' : '0px'}>
 			<div class="nav-blur-background" class:scrolled={isScrolled}></div>
 			<div class="main-navigation">
-				<Navigation
-					isAuthenticated={data?.isAuthenticated}
-					account={data?.account}
-					currentUser={data?.currentUser}
-				/>
+				{#if isMobile.current}
+					<MobileNavigation
+						isAuthenticated={data?.isAuthenticated}
+						account={data?.account}
+						currentUser={data?.currentUser}
+					/>
+				{:else}
+					<Navigation
+						isAuthenticated={data?.isAuthenticated}
+						account={data?.account}
+						currentUser={data?.currentUser}
+					/>
+				{/if}
 			</div>
 			<main class="main-content" bind:this={mainContent} onscroll={handleScroll}>
 				<svelte:boundary
@@ -371,6 +384,7 @@
 		.app-container {
 			.main-pane {
 				.main-content {
+					padding-top: calc(60px + var(--bahamut-offset, 0px));
 					// Improve mobile scrolling performance
 					-webkit-overflow-scrolling: touch;
 				}

--- a/src/routes/(app)/teams/explore/+page.svelte
+++ b/src/routes/(app)/teams/explore/+page.svelte
@@ -24,6 +24,9 @@
 	import { localizeHref } from '$lib/paraglide/runtime'
 	import { serializeExploreFilters } from '$lib/utils/exploreFilterParams'
 	import { localizedName } from '$lib/utils/locale'
+	import { MediaQuery } from 'svelte/reactivity'
+
+	const isMobile = new MediaQuery('(max-width: 768px)')
 
 	const { data } = $props() as { data: PageData }
 
@@ -239,56 +242,74 @@
 
 <section class="explore">
 	<div class="filters-row">
-		<ExploreFilters bind:filters={filterItems} onFiltersChange={handleFiltersChange} {allRaids} />
-		<div class="filters-actions">
-			{#if isAuthenticated}
-				<CollectionFilterButton
-					active={collectionFilterActive}
-					element={currentUser?.element as
-						| 'wind'
-						| 'fire'
-						| 'water'
-						| 'earth'
-						| 'dark'
-						| 'light'
-						| undefined}
-					onclick={() => (collectionFilterActive = !collectionFilterActive)}
-					aria-label={m.explore_collection_aria()}
-					aria-pressed={collectionFilterActive}
-				>
-					{m.explore_collection_only()}
-				</CollectionFilterButton>
-			{/if}
-			<Tooltip content={advancedFilterTooltip} disabled={advancedFilterCount === 0}>
-				{#if advancedFilterCount > 0}
-					<Button
-						variant="ghost"
-						size="small"
-						shape="pill"
-						onclick={() => (settingsOpen = true)}
-						aria-label={m.explore_settings_aria()}
+		<ExploreFilters
+			bind:filters={filterItems}
+			onFiltersChange={handleFiltersChange}
+			{allRaids}
+			bind:collectionFilterActive
+			onCollectionFilterChange={(active) => (collectionFilterActive = active)}
+			onAdvancedFiltersOpen={() => (settingsOpen = true)}
+			element={currentUser?.element as
+				| 'wind'
+				| 'fire'
+				| 'water'
+				| 'earth'
+				| 'dark'
+				| 'light'
+				| undefined}
+			{isAuthenticated}
+		/>
+		{#if !isMobile.current}
+			<div class="filters-actions">
+				{#if isAuthenticated}
+					<CollectionFilterButton
+						active={collectionFilterActive}
+						element={currentUser?.element as
+							| 'wind'
+							| 'fire'
+							| 'water'
+							| 'earth'
+							| 'dark'
+							| 'light'
+							| undefined}
+						onclick={() => (collectionFilterActive = !collectionFilterActive)}
+						aria-label={m.explore_collection_aria()}
+						aria-pressed={collectionFilterActive}
 					>
-						{#snippet leftAccessory()}
-							<Icon name="gear" size={14} />
-						{/snippet}
-						{advancedFilterCount}
-					</Button>
-				{:else}
-					<Button
-						variant="ghost"
-						size="small"
-						shape="pill"
-						iconOnly
-						onclick={() => (settingsOpen = true)}
-						aria-label={m.explore_settings_aria()}
-					>
-						{#snippet leftAccessory()}
-							<Icon name="gear" size={14} />
-						{/snippet}
-					</Button>
+						{m.explore_collection_only()}
+					</CollectionFilterButton>
 				{/if}
-			</Tooltip>
-		</div>
+				<Tooltip content={advancedFilterTooltip} disabled={advancedFilterCount === 0}>
+					{#if advancedFilterCount > 0}
+						<Button
+							variant="ghost"
+							size="small"
+							shape="pill"
+							onclick={() => (settingsOpen = true)}
+							aria-label={m.explore_settings_aria()}
+						>
+							{#snippet leftAccessory()}
+								<Icon name="gear" size={14} />
+							{/snippet}
+							{advancedFilterCount}
+						</Button>
+					{:else}
+						<Button
+							variant="ghost"
+							size="small"
+							shape="pill"
+							iconOnly
+							onclick={() => (settingsOpen = true)}
+							aria-label={m.explore_settings_aria()}
+						>
+							{#snippet leftAccessory()}
+								<Icon name="gear" size={14} />
+							{/snippet}
+						</Button>
+					{/if}
+				</Tooltip>
+			</div>
+		{/if}
 	</div>
 
 	<ExploreSettingsModal
@@ -368,6 +389,10 @@
 
 	.explore {
 		padding: $unit-2x 0;
+
+		@media (max-width: 768px) {
+			padding: 0 $unit $unit-2x;
+		}
 	}
 
 	.filters-row {
@@ -375,7 +400,7 @@
 		align-items: flex-start;
 		justify-content: space-between;
 		gap: $unit;
-		margin-bottom: $unit-2x;
+		margin-bottom: $unit;
 	}
 
 	.filters-actions {


### PR DESCRIPTION
## Summary
- Add mobile navigation with compact dropdown pill + bottom sheet menu
- Make explore page mobile-friendly with full-width filter input and gear sheet
- Mobile party page: text-only segmented control, 3-col character grid, video title truncation, stacked job section
- Mobile summon grid: friend summon in separate styled box with grid-size image, subaura layout fixes

## Test plan
- [ ] Test mobile nav on various screen sizes, verify auth/unauth states
- [ ] Verify explore page filters, gear sheet, and dropdown are full-width on mobile
- [ ] Check party page segmented control, character grid centering, video truncation
- [ ] Confirm friend summon appears in separate box next to subaura on mobile
- [ ] Test dark and light mode for all new components