### PR TITLE
Fix 30-day refresh-token loop

### DIFF
--- a/src/lib/stores/__tests__/auth.store.test.ts
+++ b/src/lib/stores/__tests__/auth.store.test.ts
@@ -138,6 +138,22 @@ describe('initFromServer', () => {
 
 		expect(authStore.isAuthenticated).toBe(false)
 	})
+
+	// Regression: a refresh that wrote a malformed account cookie used to
+	// bubble up here as an empty-string expiresAt, which is falsy and silently
+	// cleared the session even though the server-side cookie still had a valid
+	// token. That mismatch produced the visible refresh-loop symptoms.
+	it('clears auth when expiresAt is an empty string', () => {
+		const user = { id: 'u1', username: 'grug' }
+		authStore.setAuth('tok', user, 3600)
+
+		authStore.initFromServer('tok', user, '')
+
+		expect(authStore.accessToken).toBeNull()
+		expect(authStore.user).toBeNull()
+		expect(authStore.expiresAt).toBeNull()
+		expect(authStore.isAuthenticated).toBe(false)
+	})
 })
 
 // ============================================================================

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -1,8 +1,8 @@
 import type { RequestHandler } from '@sveltejs/kit'
 import { json } from '@sveltejs/kit'
+import { clearAuthCookies } from '$lib/auth/cookies'
 
 export const POST: RequestHandler = async ({ cookies }) => {
-	cookies.delete('account', { path: '/' })
-	cookies.delete('user', { path: '/' })
+	clearAuthCookies(cookies)
 	return json({ success: true })
 }

--- a/src/routes/auth/logout/__tests__/logout.test.ts
+++ b/src/routes/auth/logout/__tests__/logout.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockClearAuthCookies = vi.fn()
+
+vi.mock('$lib/auth/cookies', () => ({
+	clearAuthCookies: (...args: unknown[]) => mockClearAuthCookies(...args)
+}))
+
+function createMockCookies() {
+	return {
+		set: vi.fn(),
+		get: vi.fn(),
+		delete: vi.fn()
+	}
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+describe('POST /auth/logout', () => {
+	it('clears all auth cookies (account, user, refresh)', async () => {
+		const cookies = createMockCookies()
+		const { POST } = await import('../+server')
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const response = await (POST as any)({
+			cookies: cookies as unknown as import('@sveltejs/kit').Cookies
+		})
+
+		expect(response.status).toBe(200)
+		expect(mockClearAuthCookies).toHaveBeenCalledTimes(1)
+		expect(mockClearAuthCookies).toHaveBeenCalledWith(cookies)
+	})
+})

--- a/src/routes/auth/refresh/+server.ts
+++ b/src/routes/auth/refresh/+server.ts
@@ -59,7 +59,8 @@ export const POST: RequestHandler = async ({ cookies, fetch }) => {
 			userId: data.user.id,
 			username: data.user.username,
 			token: data.access_token,
-			role: data.user.role
+			role: data.user.role,
+			expires_at: accessTokenExpiresAt.toISOString()
 		},
 		{
 			secure,
@@ -67,7 +68,7 @@ export const POST: RequestHandler = async ({ cookies, fetch }) => {
 		}
 	)
 
-	setRefreshCookie(cookies, data.refresh_token, { secure })
+	setRefreshCookie(cookies, data.refresh_token, { secure, expires: accessTokenExpiresAt })
 
 	return json({
 		success: true,

--- a/src/routes/auth/refresh/__tests__/refresh.test.ts
+++ b/src/routes/auth/refresh/__tests__/refresh.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('$app/environment', () => ({ dev: false }))
+vi.mock('$env/static/public', () => ({ PUBLIC_SIERO_API_URL: 'http://localhost:3000' }))
+
+const mockSetAccountCookie = vi.fn()
+const mockSetRefreshCookie = vi.fn()
+const mockClearAuthCookies = vi.fn()
+const mockGetRefreshFromCookies = vi.fn()
+
+vi.mock('$lib/auth/cookies', () => ({
+	setAccountCookie: (...args: unknown[]) => mockSetAccountCookie(...args),
+	setRefreshCookie: (...args: unknown[]) => mockSetRefreshCookie(...args),
+	clearAuthCookies: (...args: unknown[]) => mockClearAuthCookies(...args),
+	getRefreshFromCookies: (...args: unknown[]) => mockGetRefreshFromCookies(...args)
+}))
+
+function createMockCookies() {
+	return {
+		set: vi.fn(),
+		get: vi.fn(),
+		delete: vi.fn()
+	}
+}
+
+const validRefreshResponse = {
+	access_token: 'new-access',
+	token_type: 'Bearer' as const,
+	expires_in: 60 * 60 * 24 * 30, // 30 days
+	refresh_token: 'new-refresh',
+	created_at: 1_700_000_000,
+	user: { id: 'u1', username: 'grug', role: 0 }
+}
+
+async function callRefresh(fetchFn: typeof fetch, cookies = createMockCookies()) {
+	const { POST } = await import('../+server')
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const response = await (POST as any)({
+		cookies: cookies as unknown as import('@sveltejs/kit').Cookies,
+		fetch: fetchFn
+	})
+	return { response, cookies }
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	mockGetRefreshFromCookies.mockReturnValue('existing-refresh')
+})
+
+describe('POST /auth/refresh', () => {
+	it('returns 401 when no refresh cookie is present', async () => {
+		mockGetRefreshFromCookies.mockReturnValue(null)
+		const fetchFn = vi.fn()
+
+		const { response } = await callRefresh(fetchFn as unknown as typeof fetch)
+
+		expect(response.status).toBe(401)
+		expect(fetchFn).not.toHaveBeenCalled()
+	})
+
+	it('clears auth cookies when upstream returns 401', async () => {
+		const fetchFn = vi.fn().mockResolvedValue({ ok: false, status: 401 })
+
+		const { response } = await callRefresh(fetchFn as unknown as typeof fetch)
+
+		expect(response.status).toBe(401)
+		expect(mockClearAuthCookies).toHaveBeenCalledTimes(1)
+	})
+
+	it('writes account cookie with expires_at on successful refresh', async () => {
+		const fetchFn = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => validRefreshResponse
+		})
+
+		await callRefresh(fetchFn as unknown as typeof fetch)
+
+		expect(mockSetAccountCookie).toHaveBeenCalledTimes(1)
+		const [, account, opts] = mockSetAccountCookie.mock.calls[0]!
+		const expectedExpiry = new Date(
+			(validRefreshResponse.created_at + validRefreshResponse.expires_in) * 1000
+		)
+
+		expect(account).toMatchObject({
+			userId: 'u1',
+			username: 'grug',
+			token: 'new-access',
+			role: 0,
+			expires_at: expectedExpiry.toISOString()
+		})
+		expect(typeof account.expires_at).toBe('string')
+		expect(opts).toMatchObject({ secure: true, expires: expectedExpiry })
+	})
+
+	it('writes refresh cookie with explicit expires (not a session cookie)', async () => {
+		const fetchFn = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => validRefreshResponse
+		})
+
+		await callRefresh(fetchFn as unknown as typeof fetch)
+
+		const expectedExpiry = new Date(
+			(validRefreshResponse.created_at + validRefreshResponse.expires_in) * 1000
+		)
+		expect(mockSetRefreshCookie).toHaveBeenCalledWith(
+			expect.anything(),
+			'new-refresh',
+			expect.objectContaining({ secure: true, expires: expectedExpiry })
+		)
+	})
+
+	it('returns 502 on upstream non-401 failure without clearing cookies', async () => {
+		const fetchFn = vi.fn().mockResolvedValue({ ok: false, status: 503 })
+
+		const { response } = await callRefresh(fetchFn as unknown as typeof fetch)
+
+		expect(response.status).toBe(502)
+		expect(mockClearAuthCookies).not.toHaveBeenCalled()
+		expect(mockSetAccountCookie).not.toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
## Summary

Users hitting the site ~30 days after launch were seeing refresh loops and 401s on every API call. Root cause was in the SvelteKit `/auth/refresh` endpoint:

- The refresh endpoint inlined the account cookie payload and **omitted `expires_at`**. The login endpoint includes it via `buildCookies()`, but refresh diverged.
- After a successful refresh, the `account` cookie had no `expires_at`. On the next page load, `hooks.server.ts` passed an empty string to the client, which the auth store treated as falsy and silently called `clearAuth()` — even though the cookie still held a valid token.
- Subsequent API requests went out with no `Authorization` header → 401 → another refresh attempt → loop.

The 30-day timing isn't a coincidence: Doorkeeper is configured with `access_token_expires_in 1.month`, so launch-day tokens are only now hitting their first rotation.

While in there, two adjacent bugs:

- `/auth/logout` only deleted `account` and `user`, leaving the `refresh` cookie behind. Swapped to the existing `clearAuthCookies` helper.
- `/auth/refresh` called `setRefreshCookie` without `expires`, silently degrading the refresh cookie to a session cookie after rotation.

## Tests

- New `src/routes/auth/refresh/__tests__/refresh.test.ts` — asserts the refreshed `account` cookie includes `expires_at` and that `setRefreshCookie` receives `expires`.
- New `src/routes/auth/logout/__tests__/logout.test.ts` — asserts logout calls `clearAuthCookies` (covers all three cookies).
- Regression case in `auth.store.test.ts` — `initFromServer('tok', user, '')` must clear the session, which is the bug's exact manifestation.

All 189 server tests pass; `pnpm check` is clean.

## Test plan

- [ ] Reproduce on `main`: log in, manually delete `expires_at` from the `account` cookie, hard refresh — observe logged-out shell + 401 storm.
- [ ] Apply branch, repeat reproduction — store hydrates correctly, no loop.
- [ ] Force the proactive refresh path (set `expires_at` to ~4 minutes out), trigger an authenticated request, confirm new `account` cookie carries `expires_at` and subsequent calls send a fresh Bearer token.
- [ ] Logout — confirm `account`, `user`, and `refresh` cookies are all gone.

## Follow-up (separate PR)

Doorkeeper 5.8 rotates refresh tokens via the "revoked-on-use" pattern: the previous refresh token only gets revoked once the new access token is *used*. If a user closes the laptop after a refresh but before their first API call, stale tabs can keep refreshing with the old token. Tightening this is a real concern but trades off against the network-race scenario the current behavior protects against — worth its own PR with proper consideration.