### PR TITLE
Use null-variant image for null-element grid weapons in WeaponRep

### DIFF
--- a/src/lib/components/reps/WeaponRep.svelte
+++ b/src/lib/components/reps/WeaponRep.svelte
@@ -40,7 +40,7 @@
 		const variant = isMain ? 'main' : 'grid'
 		// For weapons with null element that have an instance element, use it.
 		// Mainhand images don't have a null-element variant, so default to fire (2).
-		const element = w?.weapon?.element === 0 ? w?.element || (isMain ? 2 : undefined) : undefined
+		const element = w?.weapon?.element === 0 ? (w?.element ?? (isMain ? 2 : 0)) : undefined
 		const transformation = getWeaponTransformation(
 			w?.weapon?.uncap?.transcendence,
 			w?.uncapLevel,


### PR DESCRIPTION
## Summary
- `WeaponRep` now matches `WeaponUnit`: for null-element weapons (`weapon.element === 0`) without a user-set element, request the null-variant art (`{id}_0.jpg`) instead of the generic `{id}.jpg`.
- Mainhand keeps fire (2) as its default since no null-variant exists for mainhand images.
- Existing `weaponFallbackUrl` continues to swap in `{id}.jpg` if `_0.jpg` doesn't exist on the CDN.

## Test plan
- [ ] Open a party with a null-element grid weapon (e.g. Draconic/Dark Opus) and no user-set element; confirm the null-variant art renders in `PartySegmentedControl`'s desktop WeaponRep.
- [ ] Set an element on the weapon; confirm the element-tinted art appears.
- [ ] Confirm the null-element mainhand still renders fire fallback.