### PR TITLE
Heal stale auth cookies on SSR

### DIFF
--- a/src/__tests__/hooks.server.test.ts
+++ b/src/__tests__/hooks.server.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { AccountCookie } from '$lib/types/AccountCookie'
+
+vi.mock('$app/environment', () => ({ dev: false }))
+vi.mock('$env/static/public', () => ({
+	PUBLIC_SIERO_API_URL: 'http://localhost:3000'
+}))
+vi.mock('$lib/paraglide/server', () => ({
+	paraglideMiddleware: (
+		_req: Request,
+		cb: (ctx: { request: Request; locale: string }) => unknown
+	) => cb({ request: new Request('http://localhost/'), locale: 'en' })
+}))
+vi.mock('$lib/utils/fonts', () => ({
+	generateFontFaceCSS: () => '',
+	getFontPreloadLinks: () => ''
+}))
+
+const mockGetAccountFromCookies = vi.fn()
+const mockGetUserFromCookies = vi.fn()
+
+vi.mock('$lib/auth/cookies', () => ({
+	getAccountFromCookies: (...args: unknown[]) => mockGetAccountFromCookies(...args),
+	getUserFromCookies: (...args: unknown[]) => mockGetUserFromCookies(...args)
+}))
+
+const mockPerformRefresh = vi.fn()
+vi.mock('$lib/auth/refresh', () => ({
+	performRefresh: (...args: unknown[]) => mockPerformRefresh(...args)
+}))
+
+const { handleSession } = await import('../hooks.server')
+
+function createMockCookies() {
+	return {
+		set: vi.fn(),
+		get: vi.fn(),
+		delete: vi.fn()
+	} as unknown as import('@sveltejs/kit').Cookies
+}
+
+function createEvent(overrides: Partial<Record<string, unknown>> = {}) {
+	return {
+		cookies: createMockCookies(),
+		fetch: vi.fn(),
+		url: new URL('http://localhost/some-path'),
+		request: new Request('http://localhost/some-path'),
+		locals: {} as Record<string, unknown>,
+		...overrides
+	} as unknown as Parameters<typeof handleSession>[0]['event']
+}
+
+const healthyAccount: AccountCookie = {
+	userId: 'u1',
+	username: 'grug',
+	token: 'valid-token',
+	role: 0,
+	expires_at: '2030-01-01T00:00:00.000Z'
+}
+
+// A cookie written by the pre-#835 refresh endpoint: token present,
+// expires_at missing.
+const brokenAccount: AccountCookie = {
+	userId: 'u1',
+	username: 'grug',
+	token: 'valid-but-stuck-token',
+	role: 0
+} as AccountCookie
+
+const healedAccount: AccountCookie = {
+	userId: 'u1',
+	username: 'grug',
+	token: 'fresh-token',
+	role: 0,
+	expires_at: '2030-02-01T00:00:00.000Z'
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	mockGetUserFromCookies.mockReturnValue(null)
+})
+
+describe('handleSession', () => {
+	it('does not attempt healing when the account cookie has expires_at', async () => {
+		mockGetAccountFromCookies.mockReturnValue(healthyAccount)
+		const event = createEvent()
+		const resolve = vi.fn().mockResolvedValue(new Response('ok'))
+
+		await handleSession({ event, resolve } as Parameters<typeof handleSession>[0])
+
+		expect(mockPerformRefresh).not.toHaveBeenCalled()
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((event.locals as any).session.account).toBe(healthyAccount)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((event.locals as any).auth.expiresAt).toBe(healthyAccount.expires_at)
+	})
+
+	it('heals a broken cookie silently via performRefresh', async () => {
+		// First read returns the broken cookie; after healing, re-read
+		// returns the fresh one.
+		mockGetAccountFromCookies.mockReturnValueOnce(brokenAccount).mockReturnValueOnce(healedAccount)
+		mockPerformRefresh.mockResolvedValue({
+			ok: true,
+			data: {},
+			accessTokenExpiresAt: new Date(healedAccount.expires_at!)
+		})
+
+		const event = createEvent()
+		const resolve = vi.fn().mockResolvedValue(new Response('ok'))
+
+		await handleSession({ event, resolve } as Parameters<typeof handleSession>[0])
+
+		expect(mockPerformRefresh).toHaveBeenCalledTimes(1)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const session = (event.locals as any).session
+		expect(session.account).toBe(healedAccount)
+		expect(session.isAuthenticated).toBe(true)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((event.locals as any).auth.accessToken).toBe(healedAccount.token)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((event.locals as any).auth.expiresAt).toBe(healedAccount.expires_at)
+	})
+
+	it('drops session state when the upstream refresh is unauthorized', async () => {
+		mockGetAccountFromCookies.mockReturnValue(brokenAccount)
+		mockGetUserFromCookies.mockReturnValue({ language: 'en' })
+		mockPerformRefresh.mockResolvedValue({
+			ok: false,
+			reason: 'refresh_unauthorized'
+		})
+
+		const event = createEvent()
+		const resolve = vi.fn().mockResolvedValue(new Response('ok'))
+
+		await handleSession({ event, resolve } as Parameters<typeof handleSession>[0])
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const session = (event.locals as any).session
+		expect(session.account).toBeNull()
+		expect(session.user).toBeNull()
+		expect(session.isAuthenticated).toBe(false)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((event.locals as any).auth).toBeNull()
+	})
+
+	it('leaves the broken cookie alone on transient refresh failure', async () => {
+		mockGetAccountFromCookies.mockReturnValue(brokenAccount)
+		mockPerformRefresh.mockResolvedValue({ ok: false, reason: 'refresh_failed' })
+
+		const event = createEvent()
+		const resolve = vi.fn().mockResolvedValue(new Response('ok'))
+
+		await handleSession({ event, resolve } as Parameters<typeof handleSession>[0])
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const session = (event.locals as any).session
+		// We don't clear — the user can retry on the next request.
+		expect(session.account).toBe(brokenAccount)
+		// expiresAt is still empty, so the client will still refuse to hydrate
+		// — but at least we didn't log them out during a Rails outage.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((event.locals as any).auth.expiresAt).toBe('')
+	})
+
+	it('does nothing special for an unauthenticated visitor', async () => {
+		mockGetAccountFromCookies.mockReturnValue(null)
+
+		const event = createEvent()
+		const resolve = vi.fn().mockResolvedValue(new Response('ok'))
+
+		await handleSession({ event, resolve } as Parameters<typeof handleSession>[0])
+
+		expect(mockPerformRefresh).not.toHaveBeenCalled()
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((event.locals as any).session.isAuthenticated).toBe(false)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((event.locals as any).auth).toBeNull()
+	})
+})

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -3,6 +3,7 @@ import { sequence } from '@sveltejs/kit/hooks'
 import { paraglideMiddleware } from '$lib/paraglide/server'
 import { dev } from '$app/environment'
 import { getAccountFromCookies, getUserFromCookies } from '$lib/auth/cookies'
+import { performRefresh } from '$lib/auth/refresh'
 import { PUBLIC_SIERO_API_URL } from '$env/static/public'
 import { generateFontFaceCSS, getFontPreloadLinks } from '$lib/utils/fonts'
 
@@ -29,8 +30,27 @@ const handleBotFilter: Handle = async ({ event, resolve }) => {
 }
 
 export const handleSession: Handle = async ({ event, resolve }) => {
-	const account = getAccountFromCookies(event.cookies)
-	const user = getUserFromCookies(event.cookies)
+	let account = getAccountFromCookies(event.cookies)
+	let user = getUserFromCookies(event.cookies)
+
+	// Heal cookies from the pre-#835 refresh bug: the old /auth/refresh
+	// wrote an account cookie without expires_at, which made the client
+	// bail during hydration and enter a visible refresh loop. Users who
+	// hit that path before the fix shipped are still stuck. Detect the
+	// broken shape and exchange the refresh cookie for a fresh pair so
+	// they recover silently.
+	if (account?.token && !account.expires_at) {
+		const healed = await performRefresh(event.cookies, event.fetch)
+		if (healed.ok) {
+			account = getAccountFromCookies(event.cookies)
+		} else if (healed.reason === 'refresh_unauthorized') {
+			// performRefresh already cleared cookies; drop local state too.
+			account = null
+			user = null
+		}
+		// On refresh_failed (transient backend error), leave the broken
+		// cookie in place and try again on the next request.
+	}
 
 	event.locals.session = {
 		account,

--- a/src/lib/auth/__tests__/refresh.test.ts
+++ b/src/lib/auth/__tests__/refresh.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('$app/environment', () => ({ dev: false }))
+vi.mock('$env/static/public', () => ({ PUBLIC_SIERO_API_URL: 'http://localhost:3000' }))
+
+const mockSetAccountCookie = vi.fn()
+const mockSetRefreshCookie = vi.fn()
+const mockClearAuthCookies = vi.fn()
+const mockGetRefreshFromCookies = vi.fn()
+
+vi.mock('../cookies', () => ({
+	setAccountCookie: (...args: unknown[]) => mockSetAccountCookie(...args),
+	setRefreshCookie: (...args: unknown[]) => mockSetRefreshCookie(...args),
+	clearAuthCookies: (...args: unknown[]) => mockClearAuthCookies(...args),
+	getRefreshFromCookies: (...args: unknown[]) => mockGetRefreshFromCookies(...args)
+}))
+
+const { performRefresh } = await import('../refresh')
+
+function createMockCookies() {
+	return {
+		set: vi.fn(),
+		get: vi.fn(),
+		delete: vi.fn()
+	} as unknown as import('@sveltejs/kit').Cookies
+}
+
+const validRefreshResponse = {
+	access_token: 'new-access',
+	token_type: 'Bearer' as const,
+	expires_in: 60 * 60 * 24 * 30,
+	refresh_token: 'new-refresh',
+	created_at: 1_700_000_000,
+	user: { id: 'u1', username: 'grug', role: 0 }
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	mockGetRefreshFromCookies.mockReturnValue('existing-refresh')
+})
+
+describe('performRefresh', () => {
+	it('returns no_refresh_token when the cookie is missing', async () => {
+		mockGetRefreshFromCookies.mockReturnValue(null)
+		const fetchFn = vi.fn()
+
+		const result = await performRefresh(createMockCookies(), fetchFn as unknown as typeof fetch)
+
+		expect(result).toEqual({ ok: false, reason: 'no_refresh_token' })
+		expect(fetchFn).not.toHaveBeenCalled()
+		expect(mockClearAuthCookies).not.toHaveBeenCalled()
+	})
+
+	it('clears cookies and returns refresh_unauthorized on 401', async () => {
+		const fetchFn = vi.fn().mockResolvedValue({ ok: false, status: 401 })
+
+		const result = await performRefresh(createMockCookies(), fetchFn as unknown as typeof fetch)
+
+		expect(result).toEqual({ ok: false, reason: 'refresh_unauthorized' })
+		expect(mockClearAuthCookies).toHaveBeenCalledTimes(1)
+	})
+
+	it('returns refresh_failed without clearing cookies on upstream 5xx', async () => {
+		const fetchFn = vi.fn().mockResolvedValue({ ok: false, status: 503 })
+
+		const result = await performRefresh(createMockCookies(), fetchFn as unknown as typeof fetch)
+
+		expect(result).toEqual({ ok: false, reason: 'refresh_failed' })
+		expect(mockClearAuthCookies).not.toHaveBeenCalled()
+		expect(mockSetAccountCookie).not.toHaveBeenCalled()
+	})
+
+	it('writes account + refresh cookies with matching expiry on success', async () => {
+		const fetchFn = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => validRefreshResponse
+		})
+
+		const result = await performRefresh(createMockCookies(), fetchFn as unknown as typeof fetch)
+
+		if (!result.ok) throw new Error('expected success')
+
+		const expectedExpiry = new Date(
+			(validRefreshResponse.created_at + validRefreshResponse.expires_in) * 1000
+		)
+		expect(result.accessTokenExpiresAt).toEqual(expectedExpiry)
+		expect(result.data).toBe(validRefreshResponse)
+
+		const [, account, accountOpts] = mockSetAccountCookie.mock.calls[0]!
+		expect(account).toMatchObject({
+			userId: 'u1',
+			username: 'grug',
+			token: 'new-access',
+			role: 0,
+			expires_at: expectedExpiry.toISOString()
+		})
+		expect(accountOpts).toMatchObject({ secure: true, expires: expectedExpiry })
+
+		expect(mockSetRefreshCookie).toHaveBeenCalledWith(
+			expect.anything(),
+			'new-refresh',
+			expect.objectContaining({ secure: true, expires: expectedExpiry })
+		)
+	})
+
+	it('sends grant_type=refresh_token to the OAuth token endpoint', async () => {
+		const fetchFn = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => validRefreshResponse
+		})
+
+		await performRefresh(createMockCookies(), fetchFn as unknown as typeof fetch)
+
+		expect(fetchFn).toHaveBeenCalledWith(
+			'http://localhost:3000/oauth/token',
+			expect.objectContaining({
+				method: 'POST',
+				body: JSON.stringify({
+					refresh_token: 'existing-refresh',
+					grant_type: 'refresh_token'
+				})
+			})
+		)
+	})
+})

--- a/src/lib/auth/refresh.ts
+++ b/src/lib/auth/refresh.ts
@@ -1,0 +1,86 @@
+import type { Cookies } from '@sveltejs/kit'
+import { dev } from '$app/environment'
+import { PUBLIC_SIERO_API_URL } from '$env/static/public'
+import {
+	getRefreshFromCookies,
+	setAccountCookie,
+	setRefreshCookie,
+	clearAuthCookies
+} from './cookies'
+
+const OAUTH_BASE = `${PUBLIC_SIERO_API_URL}/oauth`
+
+export type OAuthRefreshResponse = {
+	access_token: string
+	token_type: 'Bearer'
+	expires_in: number
+	refresh_token: string
+	created_at: number
+	user: {
+		id: string
+		username: string
+		role: number
+	}
+}
+
+export type RefreshResult =
+	| { ok: true; data: OAuthRefreshResponse; accessTokenExpiresAt: Date }
+	| { ok: false; reason: 'no_refresh_token' | 'refresh_unauthorized' | 'refresh_failed' }
+
+/**
+ * Exchanges the refresh cookie for a fresh access + refresh token pair and
+ * writes both back as cookies. Shared by /auth/refresh and the SSR healing
+ * path in hooks.server.ts.
+ *
+ * On a 401 from the upstream OAuth server we clear all auth cookies so the
+ * user lands in a clean unauthenticated state. On other failures we leave
+ * cookies alone so transient backend outages don't log everyone out.
+ */
+export async function performRefresh(
+	cookies: Cookies,
+	fetch: typeof globalThis.fetch
+): Promise<RefreshResult> {
+	const refresh = getRefreshFromCookies(cookies)
+	if (!refresh) {
+		return { ok: false, reason: 'no_refresh_token' }
+	}
+
+	const res = await fetch(`${OAUTH_BASE}/token`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			refresh_token: refresh,
+			grant_type: 'refresh_token'
+		})
+	})
+
+	if (res.status === 401) {
+		clearAuthCookies(cookies)
+		return { ok: false, reason: 'refresh_unauthorized' }
+	}
+
+	if (!res.ok) {
+		return { ok: false, reason: 'refresh_failed' }
+	}
+
+	const data = (await res.json()) as OAuthRefreshResponse
+	// Use secure cookies in production (dev flag handles this correctly behind proxies)
+	const secure = !dev
+	const accessTokenExpiresAt = new Date((data.created_at + data.expires_in) * 1000)
+
+	setAccountCookie(
+		cookies,
+		{
+			userId: data.user.id,
+			username: data.user.username,
+			token: data.access_token,
+			role: data.user.role,
+			expires_at: accessTokenExpiresAt.toISOString()
+		},
+		{ secure, expires: accessTokenExpiresAt }
+	)
+
+	setRefreshCookie(cookies, data.refresh_token, { secure, expires: accessTokenExpiresAt })
+
+	return { ok: true, data, accessTokenExpiresAt }
+}

--- a/src/routes/auth/refresh/+server.ts
+++ b/src/routes/auth/refresh/+server.ts
@@ -1,75 +1,18 @@
 import type { RequestHandler } from '@sveltejs/kit'
 import { json } from '@sveltejs/kit'
-import { dev } from '$app/environment'
-import { PUBLIC_SIERO_API_URL } from '$env/static/public'
-import {
-	getRefreshFromCookies,
-	setAccountCookie,
-	setRefreshCookie,
-	clearAuthCookies
-} from '$lib/auth/cookies'
-
-const OAUTH_BASE = `${PUBLIC_SIERO_API_URL}/oauth`
-
-type OAuthRefreshResponse = {
-	access_token: string
-	token_type: 'Bearer'
-	expires_in: number
-	refresh_token: string
-	created_at: number
-	user: {
-		id: string
-		username: string
-		role: number
-	}
-}
+import { performRefresh } from '$lib/auth/refresh'
 
 export const POST: RequestHandler = async ({ cookies, fetch }) => {
-	const refresh = getRefreshFromCookies(cookies)
-	if (!refresh) {
-		return json({ error: 'no_refresh_token' }, { status: 401 })
-	}
+	const result = await performRefresh(cookies, fetch)
 
-	const res = await fetch(`${OAUTH_BASE}/token`, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			refresh_token: refresh,
-			grant_type: 'refresh_token'
-		})
-	})
-
-	if (res.status === 401) {
-		clearAuthCookies(cookies)
-		return json({ error: 'refresh_unauthorized' }, { status: 401 })
-	}
-
-	if (!res.ok) {
-		return json({ error: 'refresh_failed' }, { status: 502 })
-	}
-
-	const data = (await res.json()) as OAuthRefreshResponse
-	// Use secure cookies in production (dev flag handles this correctly behind proxies)
-	const secure = !dev
-	const accessTokenExpiresAt = new Date((data.created_at + data.expires_in) * 1000)
-
-	setAccountCookie(
-		cookies,
-		{
-			userId: data.user.id,
-			username: data.user.username,
-			token: data.access_token,
-			role: data.user.role,
-			expires_at: accessTokenExpiresAt.toISOString()
-		},
-		{
-			secure,
-			expires: accessTokenExpiresAt
+	if (!result.ok) {
+		if (result.reason === 'refresh_failed') {
+			return json({ error: 'refresh_failed' }, { status: 502 })
 		}
-	)
+		return json({ error: result.reason }, { status: 401 })
+	}
 
-	setRefreshCookie(cookies, data.refresh_token, { secure, expires: accessTokenExpiresAt })
-
+	const { data, accessTokenExpiresAt } = result
 	return json({
 		success: true,
 		username: data.user.username,


### PR DESCRIPTION
## Summary

PR #835 stopped *new* users from getting stuck in the refresh loop, but users who already rotated their token on the broken endpoint still have an `account` cookie without `expires_at`. The client's hydration check treats that as unauthenticated and drops the session on every page load, so those users stay stuck until they manually clear cookies.

This PR heals them silently. In `hooks.server.ts`, if we see the broken shape (token present, `expires_at` missing), we call the refresh endpoint server-side and re-read the freshly-written cookie before the request resolves. The user sees nothing — one SSR render later, they're healthy again.

- Extracts the refresh flow into `src/lib/auth/refresh.ts` (`performRefresh`) so `/auth/refresh` and the SSR healing path share one implementation.
- `/auth/refresh` endpoint refactored to call the helper — no behavior change.
- `hooks.server.ts` runs the healing step when it detects the broken cookie shape.
- On 401 from upstream we drop session state (cookies already cleared by the helper). On 5xx we leave the broken cookie alone so a Rails outage doesn't log everyone out.

## Test plan

- [x] `pnpm test` — new tests for `performRefresh` (5) and `handleSession` healing (5) pass; prior `/auth/refresh` tests still pass through the helper
- [x] `pnpm check` — 0 errors
- [ ] Manual: log in, then in DevTools delete `expires_at` from the `account` cookie. Hard reload — expect no visible loop; cookie should come back with `expires_at` populated.
- [ ] Manual: confirm a healthy session (with `expires_at`) never triggers the healing path.