### PR TITLE
Unjam 30-day refresh loop and extend refresh cookie lifetime

### DIFF
--- a/src/__tests__/hooks.server.test.ts
+++ b/src/__tests__/hooks.server.test.ts
@@ -18,10 +18,14 @@ vi.mock('$lib/utils/fonts', () => ({
 
 const mockGetAccountFromCookies = vi.fn()
 const mockGetUserFromCookies = vi.fn()
+const mockGetRefreshFromCookies = vi.fn()
+const mockClearAuthCookies = vi.fn()
 
 vi.mock('$lib/auth/cookies', () => ({
 	getAccountFromCookies: (...args: unknown[]) => mockGetAccountFromCookies(...args),
-	getUserFromCookies: (...args: unknown[]) => mockGetUserFromCookies(...args)
+	getUserFromCookies: (...args: unknown[]) => mockGetUserFromCookies(...args),
+	getRefreshFromCookies: (...args: unknown[]) => mockGetRefreshFromCookies(...args),
+	clearAuthCookies: (...args: unknown[]) => mockClearAuthCookies(...args)
 }))
 
 const mockPerformRefresh = vi.fn()
@@ -78,6 +82,7 @@ const healedAccount: AccountCookie = {
 beforeEach(() => {
 	vi.clearAllMocks()
 	mockGetUserFromCookies.mockReturnValue(null)
+	mockGetRefreshFromCookies.mockReturnValue('valid-refresh-cookie')
 })
 
 describe('handleSession', () => {
@@ -164,6 +169,7 @@ describe('handleSession', () => {
 
 	it('does nothing special for an unauthenticated visitor', async () => {
 		mockGetAccountFromCookies.mockReturnValue(null)
+		mockGetRefreshFromCookies.mockReturnValue(null)
 
 		const event = createEvent()
 		const resolve = vi.fn().mockResolvedValue(new Response('ok'))
@@ -171,9 +177,48 @@ describe('handleSession', () => {
 		await handleSession({ event, resolve } as Parameters<typeof handleSession>[0])
 
 		expect(mockPerformRefresh).not.toHaveBeenCalled()
+		expect(mockClearAuthCookies).not.toHaveBeenCalled()
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		expect((event.locals as any).session.isAuthenticated).toBe(false)
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		expect((event.locals as any).auth).toBeNull()
+	})
+
+	it('clears stale account cookie when the refresh cookie is gone', async () => {
+		// Post-#835 shape: account cookie looks fine (has expires_at) but the
+		// browser has already purged the refresh cookie because it was pinned
+		// to the same expiry. Without this branch, SSR keeps rehydrating the
+		// client into a /auth/refresh → 401 → redirect → SSR loop.
+		mockGetAccountFromCookies.mockReturnValue(healthyAccount)
+		mockGetRefreshFromCookies.mockReturnValue(null)
+
+		const event = createEvent()
+		const resolve = vi.fn().mockResolvedValue(new Response('ok'))
+
+		await handleSession({ event, resolve } as Parameters<typeof handleSession>[0])
+
+		expect(mockClearAuthCookies).toHaveBeenCalledTimes(1)
+		expect(mockPerformRefresh).not.toHaveBeenCalled()
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const session = (event.locals as any).session
+		expect(session.account).toBeNull()
+		expect(session.user).toBeNull()
+		expect(session.isAuthenticated).toBe(false)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((event.locals as any).auth).toBeNull()
+	})
+
+	it('does not clear cookies when both account and refresh are present', async () => {
+		mockGetAccountFromCookies.mockReturnValue(healthyAccount)
+		mockGetRefreshFromCookies.mockReturnValue('refresh-token-still-alive')
+
+		const event = createEvent()
+		const resolve = vi.fn().mockResolvedValue(new Response('ok'))
+
+		await handleSession({ event, resolve } as Parameters<typeof handleSession>[0])
+
+		expect(mockClearAuthCookies).not.toHaveBeenCalled()
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((event.locals as any).session.account).toBe(healthyAccount)
 	})
 })

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -2,7 +2,12 @@ import type { Handle, HandleFetch } from '@sveltejs/kit'
 import { sequence } from '@sveltejs/kit/hooks'
 import { paraglideMiddleware } from '$lib/paraglide/server'
 import { dev } from '$app/environment'
-import { getAccountFromCookies, getUserFromCookies } from '$lib/auth/cookies'
+import {
+	clearAuthCookies,
+	getAccountFromCookies,
+	getRefreshFromCookies,
+	getUserFromCookies
+} from '$lib/auth/cookies'
 import { performRefresh } from '$lib/auth/refresh'
 import { PUBLIC_SIERO_API_URL } from '$env/static/public'
 import { generateFontFaceCSS, getFontPreloadLinks } from '$lib/utils/fonts'
@@ -50,6 +55,19 @@ export const handleSession: Handle = async ({ event, resolve }) => {
 		}
 		// On refresh_failed (transient backend error), leave the broken
 		// cookie in place and try again on the next request.
+	}
+
+	// Unjam users whose refresh cookie has been purged by the browser
+	// (e.g. because #835 tied its lifetime to the access token). They
+	// still have a valid-looking account cookie, so the client hydrates
+	// as authenticated, calls /auth/refresh, gets 401, redirects to
+	// /auth/login, and SSR rehydrates the stale cookie — a tight loop.
+	// Drop the cookies here so the user lands in a clean unauthenticated
+	// state and can log in once to recover.
+	if (account?.token && !getRefreshFromCookies(event.cookies)) {
+		clearAuthCookies(event.cookies)
+		account = null
+		user = null
 	}
 
 	event.locals.session = {

--- a/src/lib/auth/__tests__/cookies.test.ts
+++ b/src/lib/auth/__tests__/cookies.test.ts
@@ -117,25 +117,26 @@ describe('setRefreshCookie', () => {
 		)
 	})
 
-	it('includes expires when provided', () => {
-		const cookies = createMockCookies()
-		const expires = new Date('2025-06-01')
-
-		setRefreshCookie(cookies as unknown as import('@sveltejs/kit').Cookies, 'ref-tok', {
-			secure: true,
-			expires
-		})
-
-		expect(cookies.setCalls[0]!.opts.expires).toEqual(expires)
-	})
-
-	it('omits expires when not provided', () => {
+	it('uses a 60-day maxAge so the refresh cookie outlives the access token', () => {
 		const cookies = createMockCookies()
 
 		setRefreshCookie(cookies as unknown as import('@sveltejs/kit').Cookies, 'ref-tok', {
 			secure: true
 		})
 
+		expect(cookies.setCalls[0]!.opts.maxAge).toBe(60 * 60 * 24 * 60)
+	})
+
+	it('does not tie the refresh cookie lifetime to an access token expires Date', () => {
+		const cookies = createMockCookies()
+
+		setRefreshCookie(cookies as unknown as import('@sveltejs/kit').Cookies, 'ref-tok', {
+			secure: true
+		})
+
+		// Regression for the 30-day loop: if we re-introduce an expires tied to
+		// accessTokenExpiresAt, the refresh cookie gets dropped the moment the
+		// access token dies and the user can't refresh.
 		expect(cookies.setCalls[0]!.opts).not.toHaveProperty('expires')
 	})
 })

--- a/src/lib/auth/__tests__/refresh.test.ts
+++ b/src/lib/auth/__tests__/refresh.test.ts
@@ -70,7 +70,7 @@ describe('performRefresh', () => {
 		expect(mockSetAccountCookie).not.toHaveBeenCalled()
 	})
 
-	it('writes account + refresh cookies with matching expiry on success', async () => {
+	it('writes account cookie with access-token expiry and refresh cookie decoupled from it', async () => {
 		const fetchFn = vi.fn().mockResolvedValue({
 			ok: true,
 			status: 200,
@@ -97,11 +97,11 @@ describe('performRefresh', () => {
 		})
 		expect(accountOpts).toMatchObject({ secure: true, expires: expectedExpiry })
 
-		expect(mockSetRefreshCookie).toHaveBeenCalledWith(
-			expect.anything(),
-			'new-refresh',
-			expect.objectContaining({ secure: true, expires: expectedExpiry })
-		)
+		// The refresh cookie must NOT carry the access-token expiry, otherwise
+		// the browser drops it at the exact moment we need it to refresh.
+		const [, refreshToken, refreshOpts] = mockSetRefreshCookie.mock.calls[0]!
+		expect(refreshToken).toBe('new-refresh')
+		expect(refreshOpts).toEqual({ secure: true })
 	})
 
 	it('sends grant_type=refresh_token to the OAuth token endpoint', async () => {

--- a/src/lib/auth/cookies.ts
+++ b/src/lib/auth/cookies.ts
@@ -37,17 +37,17 @@ export function setUserCookie(
 	})
 }
 
-export function setRefreshCookie(
-	cookies: Cookies,
-	data: string,
-	{ secure, expires }: { secure: boolean; expires?: Date }
-) {
+export function setRefreshCookie(cookies: Cookies, data: string, { secure }: { secure: boolean }) {
+	// Refresh cookie lifetime must outlive the access token so we can
+	// exchange it for a new pair once the access token expires. Tying
+	// its expiry to the access token (as we did in #835) left users
+	// with no refresh cookie at the 30-day boundary → refresh loop.
 	cookies.set(REFRESH_COOKIE, data, {
 		path: '/',
 		httpOnly: true,
 		sameSite: 'lax',
 		secure,
-		...(expires ? { expires } : {})
+		maxAge: SIXTY_DAYS
 	})
 }
 

--- a/src/lib/auth/refresh.ts
+++ b/src/lib/auth/refresh.ts
@@ -80,7 +80,7 @@ export async function performRefresh(
 		{ secure, expires: accessTokenExpiresAt }
 	)
 
-	setRefreshCookie(cookies, data.refresh_token, { secure, expires: accessTokenExpiresAt })
+	setRefreshCookie(cookies, data.refresh_token, { secure })
 
 	return { ok: true, data, accessTokenExpiresAt }
 }

--- a/src/routes/auth/login/+server.ts
+++ b/src/routes/auth/login/+server.ts
@@ -37,7 +37,7 @@ export const POST: RequestHandler = async ({ request, cookies, fetch }) => {
 
 		setAccountCookie(cookies, account, { secure, expires: accessTokenExpiresAt })
 		setUserCookie(cookies, user, { secure, expires: accessTokenExpiresAt })
-		setRefreshCookie(cookies, refresh, { secure, expires: accessTokenExpiresAt })
+		setRefreshCookie(cookies, refresh, { secure })
 
 		// Sync locale cookie so Paraglide renders the correct language
 		if (user.language && user.language !== 'en') {

--- a/src/routes/auth/refresh/__tests__/refresh.test.ts
+++ b/src/routes/auth/refresh/__tests__/refresh.test.ts
@@ -93,7 +93,7 @@ describe('POST /auth/refresh', () => {
 		expect(opts).toMatchObject({ secure: true, expires: expectedExpiry })
 	})
 
-	it('writes refresh cookie with explicit expires (not a session cookie)', async () => {
+	it('writes refresh cookie without an expires tied to the access token', async () => {
 		const fetchFn = vi.fn().mockResolvedValue({
 			ok: true,
 			status: 200,
@@ -102,14 +102,12 @@ describe('POST /auth/refresh', () => {
 
 		await callRefresh(fetchFn as unknown as typeof fetch)
 
-		const expectedExpiry = new Date(
-			(validRefreshResponse.created_at + validRefreshResponse.expires_in) * 1000
-		)
-		expect(mockSetRefreshCookie).toHaveBeenCalledWith(
-			expect.anything(),
-			'new-refresh',
-			expect.objectContaining({ secure: true, expires: expectedExpiry })
-		)
+		// The refresh cookie's lifetime is managed inside setRefreshCookie via
+		// maxAge, not via expires tied to the access token — otherwise the
+		// browser drops the refresh cookie at the moment it's needed.
+		const [, refreshToken, opts] = mockSetRefreshCookie.mock.calls[0]!
+		expect(refreshToken).toBe('new-refresh')
+		expect(opts).toEqual({ secure: true })
 	})
 
 	it('returns 502 on upstream non-401 failure without clearing cookies', async () => {

--- a/src/routes/auth/signup/+server.ts
+++ b/src/routes/auth/signup/+server.ts
@@ -96,7 +96,7 @@ export const POST: RequestHandler = async ({ request, cookies, fetch }) => {
 		const secure = !dev
 		setAccountCookie(cookies, account, { secure, expires: accessTokenExpiresAt })
 		setUserCookie(cookies, user, { secure, expires: accessTokenExpiresAt })
-		setRefreshCookie(cookies, refresh, { secure, expires: accessTokenExpiresAt })
+		setRefreshCookie(cookies, refresh, { secure })
 
 		// Sync locale cookie so Paraglide renders the correct language
 		if (user.language && user.language !== 'en') {


### PR DESCRIPTION
## Summary

#835 + #837 stopped the pre-fix bug from creating *new* victims but two things were still wrong:

1. **Refresh cookie expires with the access token.** `setRefreshCookie` was called with \`expires: accessTokenExpiresAt\`, so the browser dropped the refresh cookie at the same 30-day boundary the access token died. At that moment there's nothing left to exchange, \`/auth/refresh\` returns 401, the client calls \`clearAuth()\` + redirects to \`/auth/login\`, SSR rehydrates the still-present (httpOnly) account cookie, and we loop.
2. **Client \`clearAuth()\` doesn't touch cookies.** So even if the client decides the session is dead, the next SSR happily hands it back.

Confirmed via a stuck user whose cookies showed \`account\`/\`user\` present, \`refresh\` gone.

## Changes

- **setRefreshCookie** owns its own \`maxAge: SIXTY_DAYS\`; callers no longer pass \`expires\`. The refresh cookie now outlives the access token by ~30 days.
- **hooks.server.ts** treats \`account cookie present, refresh cookie gone\` as stale and clears all three auth cookies. Affected users land in a clean unauthenticated state and can log in once to recover — no manual "clear cookies" step.
- Call sites updated in \`/auth/login\`, \`/auth/signup\`, and \`performRefresh\`.
- New/updated tests cover both behaviors.

## Test plan

- [x] \`pnpm test\` — 1430 passing (new hooks unjam tests + regression test that \`setRefreshCookie\` no longer carries \`expires\`)
- [x] \`pnpm check\` — 0 errors
- [ ] Manual: reproduce the stuck state by deleting the \`refresh\` cookie in DevTools while keeping \`account\`. Hard reload. Expect: account cookie is cleared, page renders logged-out, login works normally.
- [ ] Manual: log in fresh and confirm the \`refresh\` cookie's Expires column is ~60 days out rather than ~30.