### PR TITLE
Universal collection missing toggle + SSR rarity default

### DIFF
--- a/src/lib/stores/collectionFilters.svelte.ts
+++ b/src/lib/stores/collectionFilters.svelte.ts
@@ -45,18 +45,18 @@ type EntityFilters = {
 	artifacts: ArtifactFilters
 }
 
-const DEFAULTS: EntityFilters = {
+export const COLLECTION_FILTER_DEFAULTS: EntityFilters = {
 	characters: {
 		element: [],
-		rarity: [],
+		rarity: [3],
 		series: [],
 		race: [],
 		proficiency: [],
 		gender: [],
 		sort: 'name_asc'
 	},
-	weapons: { element: [], rarity: [], proficiency: [], series: [], sort: 'name_asc' },
-	summons: { element: [], rarity: [], series: [], sort: 'name_asc' },
+	weapons: { element: [], rarity: [3], proficiency: [], series: [], sort: 'name_asc' },
+	summons: { element: [], rarity: [3], series: [], sort: 'name_asc' },
 	artifacts: {
 		element: [],
 		proficiency: [],
@@ -70,10 +70,10 @@ const DEFAULTS: EntityFilters = {
 }
 
 class CollectionFiltersStore {
-	#characters = $state<CharacterFilters>({ ...DEFAULTS.characters })
-	#weapons = $state<WeaponFilters>({ ...DEFAULTS.weapons })
-	#summons = $state<SummonFilters>({ ...DEFAULTS.summons })
-	#artifacts = $state<ArtifactFilters>({ ...DEFAULTS.artifacts })
+	#characters = $state<CharacterFilters>({ ...COLLECTION_FILTER_DEFAULTS.characters })
+	#weapons = $state<WeaponFilters>({ ...COLLECTION_FILTER_DEFAULTS.weapons })
+	#summons = $state<SummonFilters>({ ...COLLECTION_FILTER_DEFAULTS.summons })
+	#artifacts = $state<ArtifactFilters>({ ...COLLECTION_FILTER_DEFAULTS.artifacts })
 	#initialized = false
 
 	constructor() {
@@ -86,10 +86,10 @@ class CollectionFiltersStore {
 		if (this.#initialized) return
 		this.#initialized = true
 
-		this.#characters = this.#load('characters', DEFAULTS.characters)
-		this.#weapons = this.#load('weapons', DEFAULTS.weapons)
-		this.#summons = this.#load('summons', DEFAULTS.summons)
-		this.#artifacts = this.#load('artifacts', DEFAULTS.artifacts)
+		this.#characters = this.#load('characters', COLLECTION_FILTER_DEFAULTS.characters)
+		this.#weapons = this.#load('weapons', COLLECTION_FILTER_DEFAULTS.weapons)
+		this.#summons = this.#load('summons', COLLECTION_FILTER_DEFAULTS.summons)
+		this.#artifacts = this.#load('artifacts', COLLECTION_FILTER_DEFAULTS.artifacts)
 	}
 
 	#load<K extends keyof EntityFilters>(key: K, defaults: EntityFilters[K]): EntityFilters[K] {

--- a/src/routes/(app)/[username]/collection/artifacts/+page.svelte
+++ b/src/routes/(app)/[username]/collection/artifacts/+page.svelte
@@ -14,7 +14,10 @@
 	import Icon from '$lib/components/Icon.svelte'
 	import MultiSelect from '$lib/components/ui/MultiSelect.svelte'
 	import { sidebar } from '$lib/stores/sidebar.svelte'
-	import { collectionFilters } from '$lib/stores/collectionFilters.svelte'
+	import {
+		collectionFilters,
+		COLLECTION_FILTER_DEFAULTS
+	} from '$lib/stores/collectionFilters.svelte'
 	import { viewMode } from '$lib/stores/viewMode.svelte'
 	import type { CollectionSortKey } from '$lib/types/api/collection'
 	import Select from '$lib/components/ui/Select.svelte'
@@ -33,19 +36,22 @@
 		data.user?.avatar?.element as 'wind' | 'fire' | 'water' | 'earth' | 'dark' | 'light' | undefined
 	)
 
-	// Filter state (initialized from localStorage)
-	let elementFilters = $state<number[]>(collectionFilters.artifacts.element)
-	let proficiencyFilters = $state<number[]>(collectionFilters.artifacts.proficiency)
-	let rarityFilter = $state<'all' | 'standard' | 'quirk'>(collectionFilters.artifacts.rarity)
+	// Filter state: owners load saved filters from localStorage; non-owners start from defaults
+	const initialFilters = data.isOwner
+		? collectionFilters.artifacts
+		: COLLECTION_FILTER_DEFAULTS.artifacts
+	let elementFilters = $state<number[]>(initialFilters.element)
+	let proficiencyFilters = $state<number[]>(initialFilters.proficiency)
+	let rarityFilter = $state<'all' | 'standard' | 'quirk'>(initialFilters.rarity)
 
-	// Skill filter state - array of modifier IDs per slot (initialized from localStorage)
-	let slot1Filters = $state<number[]>(collectionFilters.artifacts.slot1)
-	let slot2Filters = $state<number[]>(collectionFilters.artifacts.slot2)
-	let slot3Filters = $state<number[]>(collectionFilters.artifacts.slot3)
-	let slot4Filters = $state<number[]>(collectionFilters.artifacts.slot4)
+	// Skill filter state - array of modifier IDs per slot
+	let slot1Filters = $state<number[]>(initialFilters.slot1)
+	let slot2Filters = $state<number[]>(initialFilters.slot2)
+	let slot3Filters = $state<number[]>(initialFilters.slot3)
+	let slot4Filters = $state<number[]>(initialFilters.slot4)
 
 	// Sort state
-	let sortBy = $state<CollectionSortKey>(collectionFilters.artifacts.sort)
+	let sortBy = $state<CollectionSortKey>(initialFilters.sort)
 
 	const sortOptions: { value: CollectionSortKey; label: string }[] = [
 		{ value: 'score_desc', label: 'Score ↓' },
@@ -125,7 +131,7 @@
 		slot4Filters = []
 	}
 
-	// Persist all filter state to localStorage
+	// Persist filter state — owners only (don't pollute viewer's saved state on others' pages)
 	$effect(() => {
 		const filters = {
 			element: elementFilters,
@@ -137,6 +143,7 @@
 			slot4: slot4Filters,
 			sort: sortBy
 		}
+		if (!data.isOwner) return
 		untrack(() => collectionFilters.setArtifacts(filters))
 	})
 

--- a/src/routes/(app)/[username]/collection/characters/+page.svelte
+++ b/src/routes/(app)/[username]/collection/characters/+page.svelte
@@ -19,7 +19,10 @@
 	import SelectableCollectionRow from '$lib/components/collection/SelectableCollectionRow.svelte'
 	import Icon from '$lib/components/Icon.svelte'
 	import { sidebar } from '$lib/stores/sidebar.svelte'
-	import { collectionFilters } from '$lib/stores/collectionFilters.svelte'
+	import {
+		collectionFilters,
+		COLLECTION_FILTER_DEFAULTS
+	} from '$lib/stores/collectionFilters.svelte'
 	import { collectionTeamsPane } from '$lib/stores/collectionTeamsPane.svelte'
 	import { viewMode } from '$lib/stores/viewMode.svelte'
 	import { LOADED_IDS_KEY, type LoadedIdsContext } from '$lib/stores/selectionMode.svelte'
@@ -37,18 +40,21 @@
 		data.user?.avatar?.element as 'wind' | 'fire' | 'water' | 'earth' | 'dark' | 'light' | undefined
 	)
 
-	// Filter state (initialized from localStorage)
-	let elementFilters = $state<number[]>(collectionFilters.characters.element)
-	let rarityFilters = $state<number[]>(collectionFilters.characters.rarity)
-	let seriesFilters = $state<string[]>(collectionFilters.characters.series)
-	let raceFilters = $state<number[]>(collectionFilters.characters.race)
-	let proficiencyFilters = $state<number[]>(collectionFilters.characters.proficiency)
-	let genderFilters = $state<number[]>(collectionFilters.characters.gender)
+	// Filter state: owners load saved filters from localStorage; non-owners start from defaults
+	const initialFilters = data.isOwner
+		? collectionFilters.characters
+		: COLLECTION_FILTER_DEFAULTS.characters
+	let elementFilters = $state<number[]>(initialFilters.element)
+	let rarityFilters = $state<number[]>(initialFilters.rarity)
+	let seriesFilters = $state<string[]>(initialFilters.series)
+	let raceFilters = $state<number[]>(initialFilters.race)
+	let proficiencyFilters = $state<number[]>(initialFilters.proficiency)
+	let genderFilters = $state<number[]>(initialFilters.gender)
 	let searchQuery = $state('')
 	let unowned = $state(false)
 
-	// Sort state (initialized from localStorage)
-	let sortBy = $state<CollectionSortKey>(collectionFilters.characters.sort)
+	// Sort state
+	let sortBy = $state<CollectionSortKey>(initialFilters.sort)
 
 	// Sentinel for infinite scroll
 	let sentinelEl = $state<HTMLElement>()
@@ -118,7 +124,7 @@
 		genderFilters = filters.gender
 	}
 
-	// Persist all filter and sort state to localStorage
+	// Persist filter and sort state — owners only (don't pollute viewer's saved state on others' pages)
 	$effect(() => {
 		const filters = {
 			element: elementFilters,
@@ -129,6 +135,7 @@
 			gender: genderFilters,
 			sort: sortBy
 		}
+		if (!data.isOwner) return
 		untrack(() => collectionFilters.setCharacters(filters))
 	})
 
@@ -200,7 +207,7 @@
 				proficiency: true,
 				gender: true
 			}}
-			showUnowned={data.isOwner}
+			showUnowned
 			element={userElement}
 		/>
 	</div>

--- a/src/routes/(app)/[username]/collection/summons/+page.svelte
+++ b/src/routes/(app)/[username]/collection/summons/+page.svelte
@@ -19,7 +19,10 @@
 	import SelectableCollectionRow from '$lib/components/collection/SelectableCollectionRow.svelte'
 	import Icon from '$lib/components/Icon.svelte'
 	import { sidebar } from '$lib/stores/sidebar.svelte'
-	import { collectionFilters } from '$lib/stores/collectionFilters.svelte'
+	import {
+		collectionFilters,
+		COLLECTION_FILTER_DEFAULTS
+	} from '$lib/stores/collectionFilters.svelte'
 	import { collectionTeamsPane } from '$lib/stores/collectionTeamsPane.svelte'
 	import { viewMode } from '$lib/stores/viewMode.svelte'
 	import { LOADED_IDS_KEY, type LoadedIdsContext } from '$lib/stores/selectionMode.svelte'
@@ -37,15 +40,18 @@
 		data.user?.avatar?.element as 'wind' | 'fire' | 'water' | 'earth' | 'dark' | 'light' | undefined
 	)
 
-	// Filter state (initialized from localStorage)
-	let elementFilters = $state<number[]>(collectionFilters.summons.element)
-	let rarityFilters = $state<number[]>(collectionFilters.summons.rarity)
-	let seriesFilters = $state<(number | string)[]>(collectionFilters.summons.series ?? [])
+	// Filter state: owners load saved filters from localStorage; non-owners start from defaults
+	const initialFilters = data.isOwner
+		? collectionFilters.summons
+		: COLLECTION_FILTER_DEFAULTS.summons
+	let elementFilters = $state<number[]>(initialFilters.element)
+	let rarityFilters = $state<number[]>(initialFilters.rarity)
+	let seriesFilters = $state<(number | string)[]>(initialFilters.series ?? [])
 	let searchQuery = $state('')
 	let unowned = $state(false)
 
-	// Sort state (initialized from localStorage)
-	let sortBy = $state<CollectionSortKey>(collectionFilters.summons.sort)
+	// Sort state
+	let sortBy = $state<CollectionSortKey>(initialFilters.sort)
 
 	// Sentinel for infinite scroll
 	let sentinelEl = $state<HTMLElement>()
@@ -109,7 +115,7 @@
 		seriesFilters = filters.series
 	}
 
-	// Persist all filter and sort state to localStorage
+	// Persist filter and sort state — owners only (don't pollute viewer's saved state on others' pages)
 	$effect(() => {
 		const filters = {
 			element: elementFilters,
@@ -117,6 +123,7 @@
 			series: seriesFilters,
 			sort: sortBy
 		}
+		if (!data.isOwner) return
 		untrack(() => collectionFilters.setSummons(filters))
 	})
 
@@ -177,7 +184,7 @@
 			bind:sortBy
 			bind:unowned
 			onFiltersChange={handleFiltersChange}
-			showUnowned={data.isOwner}
+			showUnowned
 			element={userElement}
 		/>
 	</div>

--- a/src/routes/(app)/[username]/collection/weapons/+page.svelte
+++ b/src/routes/(app)/[username]/collection/weapons/+page.svelte
@@ -19,7 +19,10 @@
 	import SelectableCollectionRow from '$lib/components/collection/SelectableCollectionRow.svelte'
 	import Icon from '$lib/components/Icon.svelte'
 	import { sidebar } from '$lib/stores/sidebar.svelte'
-	import { collectionFilters } from '$lib/stores/collectionFilters.svelte'
+	import {
+		collectionFilters,
+		COLLECTION_FILTER_DEFAULTS
+	} from '$lib/stores/collectionFilters.svelte'
 	import { collectionTeamsPane } from '$lib/stores/collectionTeamsPane.svelte'
 	import { viewMode } from '$lib/stores/viewMode.svelte'
 	import { LOADED_IDS_KEY, type LoadedIdsContext } from '$lib/stores/selectionMode.svelte'
@@ -37,16 +40,19 @@
 		data.user?.avatar?.element as 'wind' | 'fire' | 'water' | 'earth' | 'dark' | 'light' | undefined
 	)
 
-	// Filter state (initialized from localStorage)
-	let elementFilters = $state<number[]>(collectionFilters.weapons.element)
-	let rarityFilters = $state<number[]>(collectionFilters.weapons.rarity)
-	let proficiencyFilters = $state<number[]>(collectionFilters.weapons.proficiency)
-	let seriesFilters = $state<(number | string)[]>(collectionFilters.weapons.series)
+	// Filter state: owners load saved filters from localStorage; non-owners start from defaults
+	const initialFilters = data.isOwner
+		? collectionFilters.weapons
+		: COLLECTION_FILTER_DEFAULTS.weapons
+	let elementFilters = $state<number[]>(initialFilters.element)
+	let rarityFilters = $state<number[]>(initialFilters.rarity)
+	let proficiencyFilters = $state<number[]>(initialFilters.proficiency)
+	let seriesFilters = $state<(number | string)[]>(initialFilters.series)
 	let searchQuery = $state('')
 	let unowned = $state(false)
 
-	// Sort state (initialized from localStorage)
-	let sortBy = $state<CollectionSortKey>(collectionFilters.weapons.sort)
+	// Sort state
+	let sortBy = $state<CollectionSortKey>(initialFilters.sort)
 
 	// Sentinel for infinite scroll
 	let sentinelEl = $state<HTMLElement>()
@@ -112,7 +118,7 @@
 		seriesFilters = filters.series
 	}
 
-	// Persist all filter and sort state to localStorage
+	// Persist filter and sort state — owners only (don't pollute viewer's saved state on others' pages)
 	$effect(() => {
 		const filters = {
 			element: elementFilters,
@@ -121,6 +127,7 @@
 			series: seriesFilters,
 			sort: sortBy
 		}
+		if (!data.isOwner) return
 		untrack(() => collectionFilters.setWeapons(filters))
 	})
 
@@ -182,7 +189,7 @@
 			bind:sortBy
 			bind:unowned
 			onFiltersChange={handleFiltersChange}
-			showUnowned={data.isOwner}
+			showUnowned
 			element={userElement}
 		/>
 	</div>


### PR DESCRIPTION
## Summary
- Owned|Missing toggle is now visible to anyone viewing a user's collection (characters, weapons, summons), not just the owner. Privacy is still enforced server-side.
- Default collection rarity filter is now SSR only (for fresh users and non-owners). Other defaults unchanged.
- On another user's collection page, filters no longer load from (or overwrite) the viewer's saved localStorage preferences.

## Test plan
- [ ] Clear localStorage, visit your own `/me/collection/characters` — rarity pre-filtered to SSR
- [ ] Change filters on your own collection, reload — filters persist
- [ ] Visit another user's collection — starts at defaults (SSR rarity, nothing else)
- [ ] Toggle Missing on another user's collection — works and shows their unowned items
- [ ] Change filters on another user's collection, return to your own — your saved filters are untouched
- [ ] Repeat for `/weapons`, `/summons`, `/artifacts` (artifacts has no Missing toggle, rarity default unchanged)
- [ ] Editing/uncap/transcendence still gated to owner only