### PR TITLE
Non-owner empty state for collection Missing toggle

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -961,6 +961,8 @@
 	"collection_filter_missing": "Missing",
 	"collection_empty_unowned": "You have everything!",
 	"collection_empty_unowned_hint": "There are no missing items matching your filters",
+	"collection_empty_unowned_other": "Nothing is missing",
+	"collection_empty_unowned_other_hint": "No missing items match the current filters",
 
 	"favorites_loading": "Loading favorites",
 	"favorites_load_error": "Failed to load favorites: {error}",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -961,6 +961,8 @@
 	"collection_filter_missing": "未所持",
 	"collection_empty_unowned": "全て所持しています！",
 	"collection_empty_unowned_hint": "フィルターに該当する未所持アイテムはありません",
+	"collection_empty_unowned_other": "未所持のアイテムはありません",
+	"collection_empty_unowned_other_hint": "フィルターに該当する未所持アイテムはありません",
 
 	"favorites_loading": "お気に入りを読み込み中",
 	"favorites_load_error": "お気に入りの読み込みに失敗しました: {error}",

--- a/src/routes/(app)/[username]/collection/characters/+page.svelte
+++ b/src/routes/(app)/[username]/collection/characters/+page.svelte
@@ -223,8 +223,14 @@
 			<div class="empty-state">
 				{#if unowned}
 					<Icon name="check-circle" size={48} />
-					<h3>{m.collection_empty_unowned()}</h3>
-					<p>{m.collection_empty_unowned_hint()}</p>
+					<h3>
+						{data.isOwner ? m.collection_empty_unowned() : m.collection_empty_unowned_other()}
+					</h3>
+					<p>
+						{data.isOwner
+							? m.collection_empty_unowned_hint()
+							: m.collection_empty_unowned_other_hint()}
+					</p>
 				{:else if data.isOwner}
 					<Icon name="users" size={48} />
 					<h3>{m.collection_empty_characters()}</h3>

--- a/src/routes/(app)/[username]/collection/summons/+page.svelte
+++ b/src/routes/(app)/[username]/collection/summons/+page.svelte
@@ -200,8 +200,14 @@
 			<div class="empty-state">
 				{#if unowned}
 					<Icon name="check-circle" size={48} />
-					<h3>{m.collection_empty_unowned()}</h3>
-					<p>{m.collection_empty_unowned_hint()}</p>
+					<h3>
+						{data.isOwner ? m.collection_empty_unowned() : m.collection_empty_unowned_other()}
+					</h3>
+					<p>
+						{data.isOwner
+							? m.collection_empty_unowned_hint()
+							: m.collection_empty_unowned_other_hint()}
+					</p>
 				{:else if data.isOwner}
 					<Icon name="star" size={48} />
 					<h3>{m.collection_empty_summons()}</h3>

--- a/src/routes/(app)/[username]/collection/weapons/+page.svelte
+++ b/src/routes/(app)/[username]/collection/weapons/+page.svelte
@@ -205,8 +205,14 @@
 			<div class="empty-state">
 				{#if unowned}
 					<Icon name="check-circle" size={48} />
-					<h3>{m.collection_empty_unowned()}</h3>
-					<p>{m.collection_empty_unowned_hint()}</p>
+					<h3>
+						{data.isOwner ? m.collection_empty_unowned() : m.collection_empty_unowned_other()}
+					</h3>
+					<p>
+						{data.isOwner
+							? m.collection_empty_unowned_hint()
+							: m.collection_empty_unowned_other_hint()}
+					</p>
 				{:else if data.isOwner}
 					<Icon name="sword" size={48} />
 					<h3>{m.collection_empty_weapons()}</h3>


### PR DESCRIPTION
## Summary
- Adds separate empty-state messages for non-owners viewing another user's collection with Missing selected. Previously they'd see the owner-voiced "You have everything!" which both read wrong and often appeared because the API was returning 403 before the message was even accurate.
- Paired with hensei-api PR #401 which lifts the owner-only gate on the `unowned=true` query (privacy still enforced).

## Test plan
- [ ] On your own collection + Missing: "You have everything!" when truly empty (owner copy, unchanged)
- [ ] On another user's collection + Missing + filters matching nothing: "Nothing is missing" / "No missing items match the current filters"
- [ ] On another user's public collection + Missing: list populates (requires API PR #401 merged)
- [ ] JP locale variants read naturally in both cases