### PR TITLE
Add 4 new races

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1248,6 +1248,10 @@
 	"race_harvin": "Harvin",
 	"race_primal": "Primal",
 	"race_other": "Other",
+	"race_geonoid": "Geonoid",
+	"race_levleath": "Levleath",
+	"race_grokkle": "Grokkle",
+	"race_wolvir": "Wolvir",
 
 	"gender_unknown": "Unknown",
 	"gender_male": "Male",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1230,6 +1230,10 @@
 	"race_harvin": "ハーヴィン",
 	"race_primal": "星晶獣",
 	"race_other": "その他",
+	"race_geonoid": "ゼオノイド",
+	"race_levleath": "レヴリス",
+	"race_grokkle": "グラックル",
+	"race_wolvir": "ヴォルヴィル",
 
 	"gender_unknown": "不明",
 	"gender_male": "男性",

--- a/src/lib/utils/race.ts
+++ b/src/lib/utils/race.ts
@@ -12,7 +12,11 @@ export const RACE_LABELS: Record<number, string> = {
 	3: 'Draph',
 	4: 'Harvin',
 	5: 'Primal',
-	6: 'Other'
+	6: 'Other',
+	7: 'Geonoid',
+	8: 'Levleath',
+	9: 'Grokkle',
+	10: 'Wolvir'
 }
 
 export function getRaceLabel(race?: number | null): string {
@@ -24,7 +28,11 @@ export function getRaceLabel(race?: number | null): string {
 		3: m.race_draph,
 		4: m.race_harvin,
 		5: m.race_primal,
-		6: m.race_other
+		6: m.race_other,
+		7: m.race_geonoid,
+		8: m.race_levleath,
+		9: m.race_grokkle,
+		10: m.race_wolvir
 	}
 	const messageFn = raceMessages[race]
 	return messageFn ? messageFn() : '—'
@@ -46,7 +54,11 @@ export function getRaceOptions() {
 		3: m.race_draph,
 		4: m.race_harvin,
 		5: m.race_primal,
-		6: m.race_other
+		6: m.race_other,
+		7: m.race_geonoid,
+		8: m.race_levleath,
+		9: m.race_grokkle,
+		10: m.race_wolvir
 	}
 	const options = [
 		{ value: null as unknown as number, label: m.proficiency_none() },


### PR DESCRIPTION
## Summary
- Add Geonoid (7), Levleath (8), Grokkle (9), Wolvir (10) to the race enum
- Extend `RACE_LABELS`, `getRaceLabel`, and `getRaceOptions` in `src/lib/utils/race.ts`
- Add EN/JP message keys for the new races

Backend counterpart: jedmund/hensei-api PR (paired).

## Test plan
- [ ] Race dropdowns in the database character edit form show the 4 new options in EN and JP
- [ ] Collection filters list and filter on the new races
- [ ] Sidebar `BasicInfoSection` displays the new race labels for race 7–10
- [ ] Race icons render once the corresponding S3 assets are uploaded