### PR TITLE
add party difficulty editor UI to the Database section

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -449,6 +449,10 @@
 	"party_difficulty_score_label": "Difficulty score",
 	"party_difficulty_breakdown_label": "Breakdown",
 
+	"difficulty_component_all": "All",
+	"difficulty_component_job": "Job",
+	"difficulty_component_accessory": "Accessory",
+
 	"boost_omega": "Omega",
 	"boost_primal": "Primal",
 	"boost_odious": "Odious",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -449,6 +449,10 @@
 	"party_difficulty_score_label": "難易度スコア",
 	"party_difficulty_breakdown_label": "内訳",
 
+	"difficulty_component_all": "すべて",
+	"difficulty_component_job": "ジョブ",
+	"difficulty_component_accessory": "アクセサリ",
+
 	"boost_omega": "マグナ",
 	"boost_primal": "神石",
 	"boost_odious": "禁禍",

--- a/src/lib/api/adapters/difficulty.adapter.ts
+++ b/src/lib/api/adapters/difficulty.adapter.ts
@@ -22,6 +22,9 @@ export interface DifficultyComponent {
 	weight: number
 	enabled: boolean
 	minCountToScore: number
+	/** Optional cap on the denominator used for raw_score. When null the
+	 * calculator falls back to summing every rule's max contribution. */
+	targetMax: number | null
 	createdAt?: string
 	updatedAt?: string
 }

--- a/src/lib/api/adapters/difficulty.adapter.ts
+++ b/src/lib/api/adapters/difficulty.adapter.ts
@@ -8,12 +8,12 @@ export interface DifficultyRule {
 	name: string
 	description?: string | null
 	component: string
-	rule_type: string
+	ruleType: string
 	params: Record<string, unknown>
 	weight: number
 	active: boolean
-	created_at?: string
-	updated_at?: string
+	createdAt?: string
+	updatedAt?: string
 }
 
 export interface DifficultyComponent {
@@ -21,9 +21,9 @@ export interface DifficultyComponent {
 	name: string
 	weight: number
 	enabled: boolean
-	min_count_to_score: number
-	created_at?: string
-	updated_at?: string
+	minCountToScore: number
+	createdAt?: string
+	updatedAt?: string
 }
 
 export interface DifficultyPreviewResult {
@@ -32,7 +32,7 @@ export interface DifficultyPreviewResult {
 	score: number | null
 	tier: DifficultyTier | null
 	breakdown: Record<string, unknown> | null
-	ruleset_version: number
+	rulesetVersion: number
 }
 
 export interface DifficultyRuleTypes {

--- a/src/lib/api/adapters/difficulty.adapter.ts
+++ b/src/lib/api/adapters/difficulty.adapter.ts
@@ -3,7 +3,13 @@ import { DEFAULT_ADAPTER_CONFIG } from './config'
 import type { RequestOptions } from './types'
 import type { DifficultyTier } from '$lib/types/api/party'
 
-export interface DifficultyRule {
+export interface PendingMeta {
+	pending?: boolean
+	pendingOperation?: 'create' | 'update' | 'destroy' | null
+	draftId?: string | null
+}
+
+export interface DifficultyRule extends PendingMeta {
 	id: string
 	name: string
 	description?: string | null
@@ -16,7 +22,7 @@ export interface DifficultyRule {
 	updatedAt?: string
 }
 
-export interface DifficultyComponent {
+export interface DifficultyComponent extends PendingMeta {
 	id: string
 	name: string
 	weight: number
@@ -36,6 +42,49 @@ export interface DifficultyPreviewResult {
 	tier: DifficultyTier | null
 	breakdown: Record<string, unknown> | null
 	rulesetVersion: number
+	withDrafts?: boolean
+}
+
+export type DraftOperation = 'create' | 'update' | 'destroy'
+export type DraftTargetType = 'Difficulty' | 'DifficultyRule' | 'DifficultyComponent'
+
+export interface DifficultyDraft {
+	id: string
+	targetType: DraftTargetType
+	targetId: string | null
+	operation: DraftOperation
+	attributes: Record<string, unknown>
+	createdAt?: string
+	updatedAt?: string
+}
+
+export interface DraftSection {
+	creates: Array<{ draftId: string; attributes: Record<string, unknown> }>
+	updates: Array<{
+		draftId: string
+		targetId: string
+		label: string
+		changes: Record<string, { old: unknown; new: unknown }>
+	}>
+	destroys: Array<{
+		draftId: string
+		targetId: string
+		label: string
+		snapshot: Record<string, unknown>
+	}>
+}
+
+export interface DifficultyDiff {
+	tiers: DraftSection
+	rules: DraftSection
+	components: DraftSection
+}
+
+export interface CommitResult {
+	rulesetVersionAfter: number
+	committedAt: string
+	note: string | null
+	changeLogId: string
 }
 
 export interface DifficultyRuleTypes {
@@ -47,19 +96,27 @@ export interface DifficultyRuleTypes {
  * Adapter for the party difficulty scoring system.
  *
  * Editor endpoints (rules, components, preview) require role >= 7.
+ *
+ * Editor mutations (the create/update/delete methods on tiers, rules,
+ * components) stage a draft on the server rather than persisting
+ * immediately. Drafts become live only when the editor commits via
+ * `commitDrafts()`. The `{ draft }` return value reflects the staged
+ * draft, not the saved entity.
  */
 export class DifficultyAdapter extends BaseAdapter {
 	// ==================== Tiers (public read) ====================
 
-	async listTiers(options?: RequestOptions): Promise<DifficultyTier[]> {
-		return this.request<DifficultyTier[]>('/difficulties', options)
+	async listTiers(options?: RequestOptions & { withDrafts?: boolean }): Promise<DifficultyTier[]> {
+		const query = options?.withDrafts ? { with_drafts: true } : undefined
+		return this.request<DifficultyTier[]>('/difficulties', { ...options, query })
 	}
 
+	/** Stages a new tier; pending until `commitDrafts()` is called. */
 	async createTier(
 		input: Partial<DifficultyTier>,
 		options?: RequestOptions
-	): Promise<DifficultyTier> {
-		const response = await this.request<DifficultyTier>('/difficulties', {
+	): Promise<{ draft: DifficultyDraft }> {
+		const response = await this.request<{ draft: DifficultyDraft }>('/difficulties', {
 			...options,
 			method: 'POST',
 			body: JSON.stringify({ difficulty: input })
@@ -68,12 +125,13 @@ export class DifficultyAdapter extends BaseAdapter {
 		return response
 	}
 
+	/** Stages an edit to an existing tier; pending until `commitDrafts()`. */
 	async updateTier(
 		id: string,
 		input: Partial<DifficultyTier>,
 		options?: RequestOptions
-	): Promise<DifficultyTier> {
-		const response = await this.request<DifficultyTier>(`/difficulties/${id}`, {
+	): Promise<{ draft: DifficultyDraft }> {
+		const response = await this.request<{ draft: DifficultyDraft }>(`/difficulties/${id}`, {
 			...options,
 			method: 'PUT',
 			body: JSON.stringify({ difficulty: input })
@@ -92,20 +150,27 @@ export class DifficultyAdapter extends BaseAdapter {
 
 	// ==================== Components (editor only) ====================
 
-	async listComponents(options?: RequestOptions): Promise<DifficultyComponent[]> {
-		return this.request<DifficultyComponent[]>('/difficulty_components', options)
+	async listComponents(
+		options?: RequestOptions & { withDrafts?: boolean }
+	): Promise<DifficultyComponent[]> {
+		const query = options?.withDrafts ? { with_drafts: true } : undefined
+		return this.request<DifficultyComponent[]>('/difficulty_components', { ...options, query })
 	}
 
+	/** Stages an edit to a component; pending until `commitDrafts()`. */
 	async updateComponent(
 		idOrName: string,
 		input: Partial<DifficultyComponent>,
 		options?: RequestOptions
-	): Promise<DifficultyComponent> {
-		const response = await this.request<DifficultyComponent>(`/difficulty_components/${idOrName}`, {
-			...options,
-			method: 'PUT',
-			body: JSON.stringify({ difficulty_component: input })
-		})
+	): Promise<{ draft: DifficultyDraft }> {
+		const response = await this.request<{ draft: DifficultyDraft }>(
+			`/difficulty_components/${idOrName}`,
+			{
+				...options,
+				method: 'PUT',
+				body: JSON.stringify({ difficulty_component: input })
+			}
+		)
 		this.clearCache('/difficulty_components')
 		return response
 	}
@@ -113,12 +178,13 @@ export class DifficultyAdapter extends BaseAdapter {
 	// ==================== Rules (editor only) ====================
 
 	async listRules(
-		filters?: { component?: string; active?: boolean },
+		filters?: { component?: string; active?: boolean; withDrafts?: boolean },
 		options?: RequestOptions
 	): Promise<DifficultyRule[]> {
 		const query: Record<string, string | boolean> = {}
 		if (filters?.component) query.component = filters.component
 		if (filters?.active !== undefined) query.active = filters.active
+		if (filters?.withDrafts) query.with_drafts = true
 		return this.request<DifficultyRule[]>('/difficulty_rules', {
 			...options,
 			query: Object.keys(query).length > 0 ? query : undefined
@@ -129,11 +195,12 @@ export class DifficultyAdapter extends BaseAdapter {
 		return this.request<DifficultyRuleTypes>('/difficulty_rules/types', options)
 	}
 
+	/** Stages a new rule; pending until `commitDrafts()`. */
 	async createRule(
 		input: Partial<DifficultyRule>,
 		options?: RequestOptions
-	): Promise<DifficultyRule> {
-		const response = await this.request<DifficultyRule>('/difficulty_rules', {
+	): Promise<{ draft: DifficultyDraft }> {
+		const response = await this.request<{ draft: DifficultyDraft }>('/difficulty_rules', {
 			...options,
 			method: 'POST',
 			body: JSON.stringify({ difficulty_rule: input })
@@ -142,12 +209,13 @@ export class DifficultyAdapter extends BaseAdapter {
 		return response
 	}
 
+	/** Stages an edit to an existing rule; pending until `commitDrafts()`. */
 	async updateRule(
 		id: string,
 		input: Partial<DifficultyRule>,
 		options?: RequestOptions
-	): Promise<DifficultyRule> {
-		const response = await this.request<DifficultyRule>(`/difficulty_rules/${id}`, {
+	): Promise<{ draft: DifficultyDraft }> {
+		const response = await this.request<{ draft: DifficultyDraft }>(`/difficulty_rules/${id}`, {
 			...options,
 			method: 'PUT',
 			body: JSON.stringify({ difficulty_rule: input })
@@ -171,6 +239,69 @@ export class DifficultyAdapter extends BaseAdapter {
 			...options,
 			method: 'POST',
 			body: JSON.stringify({ shortcode })
+		})
+	}
+
+	// ==================== Drafts (editor only) ====================
+
+	async listDrafts(options?: RequestOptions): Promise<{
+		drafts: DifficultyDraft[]
+		pendingCount: number
+	}> {
+		return this.request('/difficulty_drafts', options)
+	}
+
+	async getDiff(options?: RequestOptions): Promise<{ diff: DifficultyDiff; pendingCount: number }> {
+		return this.request('/difficulty_drafts/diff', options)
+	}
+
+	async stageDraft(
+		input: {
+			targetType: DraftTargetType
+			targetId: string | null
+			operation: DraftOperation
+			attributes: Record<string, unknown>
+		},
+		options?: RequestOptions
+	): Promise<DifficultyDraft> {
+		return this.request<DifficultyDraft>('/difficulty_drafts', {
+			...options,
+			method: 'POST',
+			body: JSON.stringify({ draft: input })
+		})
+	}
+
+	async deleteDraft(id: string, options?: RequestOptions): Promise<void> {
+		await this.request<void>(`/difficulty_drafts/${id}`, { ...options, method: 'DELETE' })
+	}
+
+	async discardDrafts(options?: RequestOptions): Promise<{ discarded: number }> {
+		return this.request('/difficulty_drafts/all', { ...options, method: 'DELETE' })
+	}
+
+	async commitDrafts(note: string, options?: RequestOptions): Promise<CommitResult> {
+		return this.request<CommitResult>('/difficulty_drafts/commit', {
+			...options,
+			method: 'POST',
+			body: JSON.stringify({ note })
+		})
+	}
+
+	/**
+	 * Uploads a tier icon to the draft's S3 staging area. The image survives
+	 * there until commit (which promotes it to the canonical key) or discard
+	 * (which removes it). Pass the bare base64 — no `data:image/png;base64,` prefix.
+	 */
+	async uploadDraftImage(
+		draftId: string,
+		base64Image: string,
+		filename?: string,
+		options?: RequestOptions
+	): Promise<DifficultyDraft> {
+		return this.request<DifficultyDraft>(`/difficulty_drafts/${draftId}/upload_image`, {
+			...options,
+			method: 'POST',
+			body: JSON.stringify({ image: base64Image, filename })
 		})
 	}
 }

--- a/src/lib/api/queries/difficulty.queries.ts
+++ b/src/lib/api/queries/difficulty.queries.ts
@@ -10,26 +10,31 @@
 import { queryOptions } from '@tanstack/svelte-query'
 import { difficultyAdapter } from '$lib/api/adapters/difficulty.adapter'
 
+interface RuleFilters {
+	component?: string
+	active?: boolean
+}
+
 export const difficultyQueries = {
 	/**
-	 * List all difficulty tiers (public)
+	 * List all difficulty tiers. When `withDrafts: true`, the current editor's
+	 * staged changes are merged in.
 	 */
-	tiers: () =>
+	tiers: (opts: { withDrafts?: boolean } = {}) =>
 		queryOptions({
-			queryKey: ['difficulties', 'tiers'] as const,
-			queryFn: () => difficultyAdapter.listTiers(),
-			staleTime: 1000 * 60 * 30, // 30 minutes
-			gcTime: 1000 * 60 * 60 // 1 hour
+			queryKey: ['difficulties', 'tiers', { withDrafts: !!opts.withDrafts }] as const,
+			queryFn: () => difficultyAdapter.listTiers({ withDrafts: opts.withDrafts }),
+			staleTime: opts.withDrafts ? 0 : 1000 * 60 * 30
 		}),
 
 	/**
 	 * List all difficulty rules (editor only)
 	 */
-	rules: (filters?: { component?: string; active?: boolean }) =>
+	rules: (filters: RuleFilters & { withDrafts?: boolean } = {}) =>
 		queryOptions({
 			queryKey: ['difficulties', 'rules', filters] as const,
 			queryFn: () => difficultyAdapter.listRules(filters),
-			staleTime: 1000 * 60 // 1 minute (changes frequently in editor)
+			staleTime: 1000 * 60
 		}),
 
 	/**
@@ -39,16 +44,26 @@ export const difficultyQueries = {
 		queryOptions({
 			queryKey: ['difficulties', 'rule_types'] as const,
 			queryFn: () => difficultyAdapter.getRuleTypes(),
-			staleTime: 1000 * 60 * 60 * 24 // 1 day - rule types rarely change
+			staleTime: 1000 * 60 * 60 * 24
 		}),
 
 	/**
 	 * List components (editor only)
 	 */
-	components: () =>
+	components: (opts: { withDrafts?: boolean } = {}) =>
 		queryOptions({
-			queryKey: ['difficulties', 'components'] as const,
-			queryFn: () => difficultyAdapter.listComponents(),
-			staleTime: 1000 * 60 // 1 minute
+			queryKey: ['difficulties', 'components', { withDrafts: !!opts.withDrafts }] as const,
+			queryFn: () => difficultyAdapter.listComponents({ withDrafts: opts.withDrafts }),
+			staleTime: 1000 * 60
+		}),
+
+	/**
+	 * Current editor's draft diff (drives the Commit button + dialog).
+	 */
+	diff: () =>
+		queryOptions({
+			queryKey: ['difficulties', 'diff'] as const,
+			queryFn: () => difficultyAdapter.getDiff(),
+			staleTime: 0
 		})
 }

--- a/src/lib/api/schemas/transforms.ts
+++ b/src/lib/api/schemas/transforms.ts
@@ -1,4 +1,11 @@
 /**
+ * Keys that contain data maps where the keys themselves are data values
+ * (like wiki page names, rule-engine param keys), not property names that
+ * should be transformed.
+ */
+const DATA_MAP_KEYS = new Set(['wiki_data', 'wikiData', 'params'])
+
+/**
  * Transforms snake_case keys to camelCase
  */
 export function snakeToCamel<T>(obj: T): T {
@@ -12,19 +19,17 @@ export function snakeToCamel<T>(obj: T): T {
 		const result: Record<string, unknown> = {}
 		for (const [key, value] of Object.entries(obj)) {
 			const camelKey = key.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase())
-			result[camelKey] = snakeToCamel(value)
+			if (DATA_MAP_KEYS.has(key) || DATA_MAP_KEYS.has(camelKey)) {
+				result[camelKey] = value
+			} else {
+				result[camelKey] = snakeToCamel(value)
+			}
 		}
 		return result as T
 	}
 
 	return obj
 }
-
-/**
- * Keys that contain data maps where the keys themselves are data values
- * (like wiki page names), not property names that should be transformed
- */
-const DATA_MAP_KEYS = new Set(['wiki_data', 'wikiData'])
 
 /**
  * Transforms camelCase keys to snake_case

--- a/src/lib/components/DatabaseNavigation.svelte
+++ b/src/lib/components/DatabaseNavigation.svelte
@@ -24,6 +24,7 @@
 	const databaseBulletsHref = $derived(localizeHref('/database/bullets'))
 	const databaseRaidsHref = $derived(localizeHref('/database/raids'))
 	const databaseRaidGroupsHref = $derived(localizeHref('/database/raid-groups'))
+	const databaseDifficultiesHref = $derived(localizeHref('/database/difficulties'))
 
 	// Detect current database entity type
 	const currentDatabaseEntity = $derived.by(() => {
@@ -131,6 +132,10 @@
 						<DropdownMenu.Separator class="dropdown-separator" />
 						<DropdownItem>
 							<a href={databaseGwEventsHref}>{m.nav_unite_and_fight()}</a>
+						</DropdownItem>
+						<DropdownMenu.Separator class="dropdown-separator" />
+						<DropdownItem>
+							<a href={databaseDifficultiesHref}>{m.party_difficulty_label()}</a>
 						</DropdownItem>
 					</DropdownMenu.Content>
 				</DropdownMenu.Portal>

--- a/src/lib/components/party/Party.svelte
+++ b/src/lib/components/party/Party.svelte
@@ -58,6 +58,8 @@
 		isNew?: boolean
 		ensurePartyExists?: () => Promise<{ id: string; shortcode: string }>
 		initialCollectionSourceUsername?: string
+		/** When true, the difficulty tier chip becomes a link to the editor preview */
+		isEditor?: boolean
 	}
 
 	let {
@@ -69,7 +71,8 @@
 		initialTab,
 		isNew = false,
 		ensurePartyExists,
-		initialCollectionSourceUsername
+		initialCollectionSourceUsername,
+		isEditor = false
 	}: Props = $props()
 
 	// Default empty party
@@ -448,6 +451,7 @@
 				{authUser}
 				{activeCollectionUser}
 				onSwitchCollectionUser={handleSwitchCollectionUser}
+				{isEditor}
 			>
 				{#snippet menu()}
 					{#if !isNew}

--- a/src/lib/components/party/info/DescriptionTile.svelte
+++ b/src/lib/components/party/info/DescriptionTile.svelte
@@ -57,6 +57,10 @@
 		summonCount?: number | null
 		// Computed difficulty assignment (null when not yet scoreable)
 		difficulty?: PartyDifficulty | null
+		/** Party shortcode, used to build the editor preview link */
+		shortcode?: string
+		/** When true, the difficulty tier chip becomes a link to the editor preview */
+		isEditor?: boolean
 	}
 
 	let {
@@ -84,8 +88,16 @@
 		buttonCount,
 		chainCount,
 		summonCount,
-		difficulty
+		difficulty,
+		shortcode,
+		isEditor = false
 	}: Props = $props()
+
+	const difficultyPreviewHref = $derived(
+		shortcode
+			? `/database/difficulties?tab=preview&shortcode=${encodeURIComponent(shortcode)}`
+			: null
+	)
 
 	const showCollectionSwitcher = $derived(
 		!!authUser?.username &&
@@ -417,12 +429,24 @@
 				<Tooltip
 					content={m.party_difficulty_tooltip({
 						tier: difficulty.tier.name,
-						score: difficulty.score.toFixed(0)
+						score: difficulty.score?.toFixed(0) ?? '—'
 					})}
 				>
-					<span class="token difficulty" style:background={difficulty.tier.color || undefined}>
-						{difficulty.tier.name}
-					</span>
+					{#if isEditor && difficultyPreviewHref}
+						<a
+							class="token difficulty editor-link"
+							style:background={difficulty.tier.color || undefined}
+							href={difficultyPreviewHref}
+							target="_blank"
+							rel="noopener"
+						>
+							{difficulty.tier.name}
+						</a>
+					{:else}
+						<span class="token difficulty" style:background={difficulty.tier.color || undefined}>
+							{difficulty.tier.name}
+						</span>
+					{/if}
 				</Tooltip>
 			{/if}
 			{#if solo}
@@ -710,6 +734,23 @@
 
 		&.difficulty {
 			color: #1a1a1a;
+		}
+
+		&.editor-link {
+			text-decoration: none;
+			cursor: pointer;
+			transition:
+				opacity 120ms ease,
+				transform 120ms ease;
+
+			&:hover {
+				opacity: 0.85;
+			}
+
+			&:focus-visible {
+				outline: 2px solid var(--focus-ring);
+				outline-offset: 2px;
+			}
 		}
 
 		&.chargeAttack.on {

--- a/src/lib/components/party/info/PartyInfoGrid.svelte
+++ b/src/lib/components/party/info/PartyInfoGrid.svelte
@@ -29,6 +29,7 @@
 		authUser?: AvatarUser | null
 		activeCollectionUser?: 'viewer' | 'source'
 		onSwitchCollectionUser?: (target: 'viewer' | 'source') => void
+		isEditor?: boolean
 	}
 
 	let {
@@ -41,7 +42,8 @@
 		menu,
 		authUser,
 		activeCollectionUser,
-		onSwitchCollectionUser
+		onSwitchCollectionUser,
+		isEditor = false
 	}: Props = $props()
 
 	// Check if data exists for each tile
@@ -111,6 +113,8 @@
 			chainCount={party.chainCount}
 			summonCount={party.summonCount}
 			difficulty={party.difficulty}
+			shortcode={party.shortcode}
+			{isEditor}
 		/>
 	</div>
 

--- a/src/lib/components/ui/DetailItem.svelte
+++ b/src/lib/components/ui/DetailItem.svelte
@@ -158,6 +158,7 @@
 		padding: spacing.$unit 0;
 		font-size: typography.$font-regular;
 		min-height: calc(spacing.$unit * 5);
+		gap: spacing.$unit-2x;
 
 		&:not(.editable) {
 			padding: spacing.$unit;
@@ -171,8 +172,6 @@
 		.label-container {
 			display: flex;
 			flex-direction: column;
-			flex-shrink: 0;
-			margin-right: spacing.$unit-2x;
 			gap: spacing.$unit-fourth;
 		}
 
@@ -197,6 +196,7 @@
 			flex: 1;
 			display: flex;
 			flex-grow: 0;
+			flex-shrink: 0;
 			justify-content: flex-end;
 			align-items: center;
 			gap: spacing.$unit-half;

--- a/src/lib/components/ui/Notice.svelte
+++ b/src/lib/components/ui/Notice.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte'
 
-	type Variant = 'blue' | 'yellow' | 'red' | 'wind' | 'fire' | 'water' | 'earth' | 'light' | 'dark'
+	type Variant =
+		| 'gray'
+		| 'blue'
+		| 'yellow'
+		| 'red'
+		| 'wind'
+		| 'fire'
+		| 'water'
+		| 'earth'
+		| 'light'
+		| 'dark'
 
 	interface Props {
 		variant?: Variant
@@ -9,7 +19,7 @@
 		children: Snippet
 	}
 
-	let { variant = 'blue', icon, children }: Props = $props()
+	let { variant = 'gray', icon, children }: Props = $props()
 
 	const elementVariants = ['wind', 'fire', 'water', 'earth', 'light', 'dark']
 	const isElement = $derived(elementVariants.includes(variant))
@@ -21,9 +31,9 @@
 			{@render icon()}
 		</span>
 	{/if}
-	<span class="notice-text">
+	<div class="notice-text">
 		{@render children()}
-	</span>
+	</div>
 </div>
 
 <style lang="scss">
@@ -40,25 +50,43 @@
 		font-size: $font-small;
 	}
 
+	.notice-text {
+		display: flex;
+		flex-direction: column;
+		gap: $unit;
+		font-size: $font-regular;
+		line-height: 1.5;
+		margin: 0;
+
+		:global(p) {
+			margin: 0;
+		}
+	}
+
 	.notice-icon {
 		display: flex;
 		flex-shrink: 0;
 	}
 
 	// Fixed color variants
+	.gray {
+		background: var(--notice-grey-bg);
+		color: var(--notice-grey-text);
+	}
+
 	.blue {
-		background: var(--blue-subtle);
-		color: var(--accent-blue);
+		background: var(--notice-blue-bg);
+		color: var(--notice-blue-text);
 	}
 
 	.yellow {
-		background: rgba(209, 137, 58, 0.15);
-		color: var(--accent-yellow);
+		background: var(--notice-yellow-bg);
+		color: var(--notice-yellow-text);
 	}
 
 	.red {
-		background: rgba(220, 53, 53, 0.15);
-		color: var(--red);
+		background: var(--notice-red-bg);
+		color: var(--notice-red-text);
 	}
 
 	// Element variants

--- a/src/lib/features/database/difficulties/CommitDialog.svelte
+++ b/src/lib/features/database/difficulties/CommitDialog.svelte
@@ -1,0 +1,341 @@
+<script lang="ts">
+	import { createMutation, useQueryClient } from '@tanstack/svelte-query'
+	import { toast } from 'svelte-sonner'
+	import Dialog from '$lib/components/ui/Dialog.svelte'
+	import ModalHeader from '$lib/components/ui/ModalHeader.svelte'
+	import ModalFooter from '$lib/components/ui/ModalFooter.svelte'
+	import { authStore } from '$lib/stores/auth.store.svelte'
+	import { getAvatarSrc } from '$lib/utils/avatar'
+	import { difficultyAdapter, type DifficultyDiff } from '$lib/api/adapters/difficulty.adapter'
+	import { extractErrorMessage } from '$lib/utils/errors'
+
+	interface Props {
+		open?: boolean
+		diff: DifficultyDiff | null
+		onCommitted?: () => void
+	}
+
+	let { open = $bindable(false), diff, onCommitted }: Props = $props()
+
+	let note = $state('')
+	const queryClient = useQueryClient()
+
+	const commitMut = createMutation(() => ({
+		mutationFn: (n: string) => difficultyAdapter.commitDrafts(n)
+	}))
+
+	$effect(() => {
+		if (open) note = ''
+	})
+
+	const totalChanges = $derived.by(() => {
+		if (!diff) return 0
+		return (
+			diff.tiers.creates.length +
+			diff.tiers.updates.length +
+			diff.tiers.destroys.length +
+			diff.rules.creates.length +
+			diff.rules.updates.length +
+			diff.rules.destroys.length +
+			diff.components.creates.length +
+			diff.components.updates.length +
+			diff.components.destroys.length
+		)
+	})
+
+	const sections = $derived.by(() => {
+		if (!diff) return []
+		return [
+			{ key: 'tiers', label: 'Tiers', data: diff.tiers },
+			{ key: 'rules', label: 'Rules', data: diff.rules },
+			{ key: 'components', label: 'Components', data: diff.components }
+		].filter((s) => s.data.creates.length + s.data.updates.length + s.data.destroys.length > 0)
+	})
+
+	async function handleSubmit() {
+		try {
+			await commitMut.mutateAsync(note.trim())
+			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
+			toast.success('Changes committed')
+			open = false
+			onCommitted?.()
+		} catch (err) {
+			toast.error(extractErrorMessage(err, 'Commit failed'))
+		}
+	}
+
+	function summarizeAttributes(attrs: Record<string, unknown>): string {
+		const entries = Object.entries(attrs).slice(0, 4)
+		return entries.map(([k, v]) => `${k}: ${stringify(v)}`).join(', ')
+	}
+
+	function stringify(value: unknown): string {
+		if (value == null) return '—'
+		if (typeof value === 'object') return JSON.stringify(value)
+		return String(value)
+	}
+
+	const avatarSrc = $derived(getAvatarSrc(authStore.user?.avatarUrl))
+</script>
+
+<Dialog bind:open size="small">
+	<ModalHeader
+		title="Commit difficulty changes"
+		description={totalChanges === 1
+			? '1 change will go live for everyone.'
+			: `${totalChanges} changes will go live for everyone.`}
+	/>
+
+	<div class="commit-body">
+		<div class="author">
+			<img class="avatar" src={avatarSrc} alt="" />
+			<span class="username">{authStore.user?.username ?? 'You'}</span>
+		</div>
+
+		{#if sections.length === 0}
+			<p class="empty">No pending changes.</p>
+		{/if}
+
+		{#each sections as section (section.key)}
+			<details class="section" open>
+				<summary>
+					<span class="section-label">{section.label}</span>
+					<span class="section-count">
+						{section.data.creates.length +
+							section.data.updates.length +
+							section.data.destroys.length}
+					</span>
+				</summary>
+				<ul class="entries">
+					{#each section.data.creates as entry (entry.draftId)}
+						<li class="entry create">
+							<span class="entry-op">New</span>
+							<span class="entry-label">{summarizeAttributes(entry.attributes)}</span>
+						</li>
+					{/each}
+					{#each section.data.updates as entry (entry.draftId)}
+						<li class="entry update">
+							<span class="entry-op">Edit</span>
+							<div class="entry-detail">
+								<span class="entry-label">{entry.label}</span>
+								<ul class="changes">
+									{#each Object.entries(entry.changes) as [field, change] (field)}
+										<li>
+											<span class="field-name">{field}</span>
+											<span class="from">{stringify(change.old)}</span>
+											<span class="arrow">→</span>
+											<span class="to">{stringify(change.new)}</span>
+										</li>
+									{/each}
+								</ul>
+							</div>
+						</li>
+					{/each}
+					{#each section.data.destroys as entry (entry.draftId)}
+						<li class="entry destroy">
+							<span class="entry-op">Delete</span>
+							<span class="entry-label">{entry.label}</span>
+						</li>
+					{/each}
+				</ul>
+			</details>
+		{/each}
+
+		<label class="note-label">
+			<span>Note (optional)</span>
+			<textarea
+				bind:value={note}
+				rows="3"
+				placeholder="What's the intent of this change?"
+				class="note-input"
+			></textarea>
+		</label>
+	</div>
+
+	<ModalFooter
+		onCancel={() => (open = false)}
+		primaryAction={{
+			label: commitMut.isPending ? 'Committing…' : 'Commit',
+			onclick: handleSubmit,
+			disabled: commitMut.isPending || totalChanges === 0
+		}}
+	/>
+</Dialog>
+
+<style lang="scss">
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+	@use '$src/themes/layout' as layout;
+
+	.commit-body {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-2x;
+		padding: 0 spacing.$unit-2x spacing.$unit-2x;
+		max-height: 60vh;
+		overflow-y: auto;
+	}
+
+	.author {
+		display: flex;
+		align-items: center;
+		gap: spacing.$unit;
+
+		.avatar {
+			width: spacing.$unit-4x;
+			height: spacing.$unit-4x;
+			border-radius: 50%;
+			background: var(--input-bg);
+		}
+
+		.username {
+			color: var(--text-primary);
+			font-weight: typography.$medium;
+		}
+	}
+
+	.empty {
+		color: var(--text-secondary);
+		margin: 0;
+	}
+
+	.section {
+		border: 1px solid var(--border-subtle);
+		border-radius: layout.$item-corner;
+		padding: spacing.$unit;
+
+		summary {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			cursor: pointer;
+			padding: spacing.$unit-half spacing.$unit;
+			list-style: none;
+
+			&::-webkit-details-marker {
+				display: none;
+			}
+		}
+
+		.section-label {
+			font-weight: typography.$bold;
+			color: var(--text-primary);
+		}
+
+		.section-count {
+			font-size: typography.$font-small;
+			color: var(--text-tertiary);
+		}
+	}
+
+	.entries {
+		list-style: none;
+		padding: 0;
+		margin: spacing.$unit 0 0 0;
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+	}
+
+	.entry {
+		display: flex;
+		align-items: flex-start;
+		gap: spacing.$unit;
+		padding: spacing.$unit;
+		background: var(--input-bg);
+		border-radius: layout.$item-corner;
+
+		.entry-op {
+			padding: spacing.$unit-fourth spacing.$unit;
+			border-radius: layout.$full-corner;
+			font-size: typography.$font-tiny;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+			background: var(--accent-yellow, var(--card-bg));
+			color: var(--text-primary);
+			flex-shrink: 0;
+		}
+
+		&.create .entry-op {
+			background: var(--accent-green, var(--input-bg));
+		}
+
+		&.destroy .entry-op {
+			background: var(--danger-bg-subtle);
+			color: var(--danger);
+		}
+
+		.entry-detail {
+			display: flex;
+			flex-direction: column;
+			gap: spacing.$unit-half;
+			min-width: 0;
+		}
+
+		.entry-label {
+			color: var(--text-primary);
+			font-weight: typography.$medium;
+		}
+	}
+
+	.changes {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-fourth;
+
+		li {
+			display: flex;
+			align-items: center;
+			flex-wrap: wrap;
+			gap: spacing.$unit-half;
+			font-size: typography.$font-small;
+			color: var(--text-secondary);
+
+			.field-name {
+				color: var(--text-tertiary);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+			}
+
+			.from {
+				color: var(--text-tertiary);
+				text-decoration: line-through;
+			}
+
+			.arrow {
+				color: var(--text-tertiary);
+			}
+
+			.to {
+				color: var(--text-primary);
+				font-weight: typography.$medium;
+			}
+		}
+	}
+
+	.note-label {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-half;
+		font-size: typography.$font-small;
+		color: var(--text-secondary);
+	}
+
+	.note-input {
+		padding: spacing.$unit;
+		border: 1px solid var(--border-subtle);
+		border-radius: layout.$input-corner;
+		background: var(--input-bg);
+		color: var(--text-primary);
+		font: inherit;
+		resize: vertical;
+
+		&:focus {
+			outline: 2px solid var(--focus-ring);
+			outline-offset: -1px;
+			border-color: transparent;
+		}
+	}
+</style>

--- a/src/lib/features/database/difficulties/ComponentsPanel.svelte
+++ b/src/lib/features/database/difficulties/ComponentsPanel.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+	import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query'
+	import { toast } from 'svelte-sonner'
+	import DetailItem from '$lib/components/ui/DetailItem.svelte'
+	import Button from '$lib/components/ui/Button.svelte'
+	import { difficultyAdapter, type DifficultyComponent } from '$lib/api/adapters/difficulty.adapter'
+	import { difficultyQueries } from '$lib/api/queries/difficulty.queries'
+	import { extractErrorMessage } from '$lib/utils/errors'
+
+	const queryClient = useQueryClient()
+
+	const componentsQuery = createQuery(() => difficultyQueries.components())
+
+	// Local edit state, keyed by component id; populated lazily as the
+	// underlying records load. Editors see live API values and can revert by
+	// reloading the page.
+	let drafts = $state<
+		Record<string, { weight: number; enabled: boolean; min_count_to_score: number }>
+	>({})
+
+	$effect(() => {
+		const records = componentsQuery.data ?? []
+		const next: typeof drafts = {}
+		for (const c of records) {
+			next[c.id] = drafts[c.id] ?? {
+				weight: c.weight,
+				enabled: c.enabled,
+				min_count_to_score: c.min_count_to_score
+			}
+		}
+		drafts = next
+	})
+
+	const updateMut = createMutation(() => ({
+		mutationFn: (input: { id: string; data: Partial<DifficultyComponent> }) =>
+			difficultyAdapter.updateComponent(input.id, input.data)
+	}))
+
+	function isDirty(comp: DifficultyComponent): boolean {
+		const draft = drafts[comp.id]
+		if (!draft) return false
+		return (
+			Number(draft.weight) !== Number(comp.weight) ||
+			Boolean(draft.enabled) !== Boolean(comp.enabled) ||
+			Number(draft.min_count_to_score) !== Number(comp.min_count_to_score)
+		)
+	}
+
+	async function saveComponent(comp: DifficultyComponent) {
+		const draft = drafts[comp.id]
+		if (!draft) return
+		try {
+			await updateMut.mutateAsync({
+				id: comp.id,
+				data: {
+					weight: Number(draft.weight),
+					enabled: draft.enabled,
+					min_count_to_score: Number(draft.min_count_to_score)
+				}
+			})
+			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'components'] })
+			toast.success(`Saved ${comp.name}`)
+		} catch (err) {
+			toast.error(extractErrorMessage(err, `Failed to save ${comp.name}`))
+		}
+	}
+
+	const components = $derived(componentsQuery.data ?? [])
+</script>
+
+{#if componentsQuery.isLoading}
+	<p class="empty">Loading components…</p>
+{:else if components.length === 0}
+	<p class="empty">No components found. Run the seed migration first.</p>
+{:else}
+	<div class="components-list">
+		{#each components as comp (comp.id)}
+			<section class="component-card">
+				<header class="component-header">
+					<h4>{comp.name}</h4>
+					<Button
+						variant="ghost"
+						size="small"
+						onclick={() => saveComponent(comp)}
+						disabled={!isDirty(comp) || updateMut.isPending}
+					>
+						{isDirty(comp) ? 'Save' : 'Saved'}
+					</Button>
+				</header>
+				<div class="component-fields">
+					<DetailItem
+						label="Weight"
+						sublabel="Relative contribution to the composite score"
+						bind:value={drafts[comp.id]!.weight}
+						editable={true}
+						type="number"
+						min={0}
+					/>
+					<DetailItem
+						label="Min items to score"
+						sublabel="Parties below this are not scored. Use 0 for job/accessory."
+						bind:value={drafts[comp.id]!.min_count_to_score}
+						editable={true}
+						type="number"
+						min={0}
+					/>
+					<DetailItem
+						label="Enabled"
+						sublabel="Disabled components are excluded from scoring"
+						bind:value={drafts[comp.id]!.enabled}
+						editable={true}
+						type="checkbox"
+					/>
+				</div>
+			</section>
+		{/each}
+	</div>
+{/if}
+
+<style lang="scss">
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+	@use '$src/themes/layout' as layout;
+
+	.components-list {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-2x;
+	}
+
+	.component-card {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+		padding: spacing.$unit-2x 0;
+		border-bottom: 1px solid var(--border-subtle);
+
+		&:last-child {
+			border-bottom: none;
+		}
+	}
+
+	.component-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+
+		h4 {
+			margin: 0;
+			color: var(--text-primary);
+			font-size: typography.$font-medium;
+			font-weight: typography.$bold;
+			text-transform: capitalize;
+		}
+	}
+
+	.component-fields {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-half;
+	}
+
+	.empty {
+		padding: spacing.$unit-4x;
+		text-align: center;
+		color: var(--text-secondary);
+	}
+</style>

--- a/src/lib/features/database/difficulties/ComponentsPanel.svelte
+++ b/src/lib/features/database/difficulties/ComponentsPanel.svelte
@@ -11,23 +11,25 @@
 
 	const componentsQuery = createQuery(() => difficultyQueries.components())
 
-	// Local edit state, keyed by component id; populated on demand the first
-	// time a component is rendered. Editors see live API values and can revert
-	// by reloading the page.
+	// Local edit state, keyed by component id; seeded from server values before
+	// every render. Editors see live API values and can revert by reloading.
 	let drafts = $state<
 		Record<string, { weight: number; enabled: boolean; min_count_to_score: number }>
 	>({})
 
-	function ensureDraft(comp: DifficultyComponent) {
-		if (!drafts[comp.id]) {
-			drafts[comp.id] = {
-				weight: comp.weight,
-				enabled: comp.enabled,
-				min_count_to_score: comp.min_count_to_score
+	// $effect.pre runs before DOM updates, so drafts are guaranteed populated
+	// before the {#each} block evaluates bind expressions.
+	$effect.pre(() => {
+		for (const c of componentsQuery.data ?? []) {
+			if (!drafts[c.id]) {
+				drafts[c.id] = {
+					weight: c.weight,
+					enabled: c.enabled,
+					min_count_to_score: c.min_count_to_score
+				}
 			}
 		}
-		return drafts[comp.id]
-	}
+	})
 
 	const updateMut = createMutation(() => ({
 		mutationFn: (input: { id: string; data: Partial<DifficultyComponent> }) =>
@@ -73,8 +75,7 @@
 {:else}
 	<div class="components-list">
 		{#each components as comp (comp.id)}
-			{@const draft = ensureDraft(comp)}
-			{#if draft}
+			{#if drafts[comp.id]}
 				<section class="component-card">
 					<header class="component-header">
 						<h4>{comp.name}</h4>
@@ -91,7 +92,7 @@
 						<DetailItem
 							label="Weight"
 							sublabel="Relative contribution to the composite score"
-							bind:value={draft.weight}
+							bind:value={drafts[comp.id]!.weight}
 							editable={true}
 							type="number"
 							min={0}
@@ -99,7 +100,7 @@
 						<DetailItem
 							label="Min items to score"
 							sublabel="Parties below this are not scored. Use 0 for job/accessory."
-							bind:value={draft.min_count_to_score}
+							bind:value={drafts[comp.id]!.min_count_to_score}
 							editable={true}
 							type="number"
 							min={0}
@@ -107,7 +108,7 @@
 						<DetailItem
 							label="Enabled"
 							sublabel="Disabled components are excluded from scoring"
-							bind:value={draft.enabled}
+							bind:value={drafts[comp.id]!.enabled}
 							editable={true}
 							type="checkbox"
 						/>

--- a/src/lib/features/database/difficulties/ComponentsPanel.svelte
+++ b/src/lib/features/database/difficulties/ComponentsPanel.svelte
@@ -71,6 +71,9 @@
 							: Number(draft.targetMax)
 				}
 			})
+			// Drop the draft so it re-seeds from the refreshed query data; otherwise
+			// subsequent edits would be applied on top of the pre-save snapshot.
+			delete drafts[comp.id]
 			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'components'] })
 			toast.success(`Saved ${comp.name}`)
 		} catch (err) {

--- a/src/lib/features/database/difficulties/ComponentsPanel.svelte
+++ b/src/lib/features/database/difficulties/ComponentsPanel.svelte
@@ -75,7 +75,7 @@
 			// subsequent edits would be applied on top of the pre-save snapshot.
 			delete drafts[comp.id]
 			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'components'] })
-			toast.success(`Saved ${comp.name}`)
+			toast.success(`${comp.name} change staged`)
 		} catch (err) {
 			toast.error(extractErrorMessage(err, `Failed to save ${comp.name}`))
 		}

--- a/src/lib/features/database/difficulties/ComponentsPanel.svelte
+++ b/src/lib/features/database/difficulties/ComponentsPanel.svelte
@@ -14,7 +14,7 @@
 	// Local edit state, keyed by component id; seeded from server values before
 	// every render. Editors see live API values and can revert by reloading.
 	let drafts = $state<
-		Record<string, { weight: number; enabled: boolean; min_count_to_score: number }>
+		Record<string, { weight: number; enabled: boolean; minCountToScore: number }>
 	>({})
 
 	// $effect.pre runs before DOM updates, so drafts are guaranteed populated
@@ -25,7 +25,7 @@
 				drafts[c.id] = {
 					weight: c.weight,
 					enabled: c.enabled,
-					min_count_to_score: c.min_count_to_score
+					minCountToScore: c.minCountToScore
 				}
 			}
 		}
@@ -42,7 +42,7 @@
 		return (
 			Number(draft.weight) !== Number(comp.weight) ||
 			Boolean(draft.enabled) !== Boolean(comp.enabled) ||
-			Number(draft.min_count_to_score) !== Number(comp.min_count_to_score)
+			Number(draft.minCountToScore) !== Number(comp.minCountToScore)
 		)
 	}
 
@@ -55,7 +55,7 @@
 				data: {
 					weight: Number(draft.weight),
 					enabled: draft.enabled,
-					min_count_to_score: Number(draft.min_count_to_score)
+					minCountToScore: Number(draft.minCountToScore)
 				}
 			})
 			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'components'] })
@@ -100,7 +100,7 @@
 						<DetailItem
 							label="Min items to score"
 							sublabel="Parties below this are not scored. Use 0 for job/accessory."
-							bind:value={drafts[comp.id]!.min_count_to_score}
+							bind:value={drafts[comp.id]!.minCountToScore}
 							editable={true}
 							type="number"
 							min={0}

--- a/src/lib/features/database/difficulties/ComponentsPanel.svelte
+++ b/src/lib/features/database/difficulties/ComponentsPanel.svelte
@@ -11,25 +11,23 @@
 
 	const componentsQuery = createQuery(() => difficultyQueries.components())
 
-	// Local edit state, keyed by component id; populated lazily as the
-	// underlying records load. Editors see live API values and can revert by
-	// reloading the page.
+	// Local edit state, keyed by component id; populated on demand the first
+	// time a component is rendered. Editors see live API values and can revert
+	// by reloading the page.
 	let drafts = $state<
 		Record<string, { weight: number; enabled: boolean; min_count_to_score: number }>
 	>({})
 
-	$effect(() => {
-		const records = componentsQuery.data ?? []
-		const next: typeof drafts = {}
-		for (const c of records) {
-			next[c.id] = drafts[c.id] ?? {
-				weight: c.weight,
-				enabled: c.enabled,
-				min_count_to_score: c.min_count_to_score
+	function ensureDraft(comp: DifficultyComponent) {
+		if (!drafts[comp.id]) {
+			drafts[comp.id] = {
+				weight: comp.weight,
+				enabled: comp.enabled,
+				min_count_to_score: comp.min_count_to_score
 			}
 		}
-		drafts = next
-	})
+		return drafts[comp.id]
+	}
 
 	const updateMut = createMutation(() => ({
 		mutationFn: (input: { id: string; data: Partial<DifficultyComponent> }) =>
@@ -75,44 +73,47 @@
 {:else}
 	<div class="components-list">
 		{#each components as comp (comp.id)}
-			<section class="component-card">
-				<header class="component-header">
-					<h4>{comp.name}</h4>
-					<Button
-						variant="ghost"
-						size="small"
-						onclick={() => saveComponent(comp)}
-						disabled={!isDirty(comp) || updateMut.isPending}
-					>
-						{isDirty(comp) ? 'Save' : 'Saved'}
-					</Button>
-				</header>
-				<div class="component-fields">
-					<DetailItem
-						label="Weight"
-						sublabel="Relative contribution to the composite score"
-						bind:value={drafts[comp.id]!.weight}
-						editable={true}
-						type="number"
-						min={0}
-					/>
-					<DetailItem
-						label="Min items to score"
-						sublabel="Parties below this are not scored. Use 0 for job/accessory."
-						bind:value={drafts[comp.id]!.min_count_to_score}
-						editable={true}
-						type="number"
-						min={0}
-					/>
-					<DetailItem
-						label="Enabled"
-						sublabel="Disabled components are excluded from scoring"
-						bind:value={drafts[comp.id]!.enabled}
-						editable={true}
-						type="checkbox"
-					/>
-				</div>
-			</section>
+			{@const draft = ensureDraft(comp)}
+			{#if draft}
+				<section class="component-card">
+					<header class="component-header">
+						<h4>{comp.name}</h4>
+						<Button
+							variant="ghost"
+							size="small"
+							onclick={() => saveComponent(comp)}
+							disabled={!isDirty(comp) || updateMut.isPending}
+						>
+							{isDirty(comp) ? 'Save' : 'Saved'}
+						</Button>
+					</header>
+					<div class="component-fields">
+						<DetailItem
+							label="Weight"
+							sublabel="Relative contribution to the composite score"
+							bind:value={draft.weight}
+							editable={true}
+							type="number"
+							min={0}
+						/>
+						<DetailItem
+							label="Min items to score"
+							sublabel="Parties below this are not scored. Use 0 for job/accessory."
+							bind:value={draft.min_count_to_score}
+							editable={true}
+							type="number"
+							min={0}
+						/>
+						<DetailItem
+							label="Enabled"
+							sublabel="Disabled components are excluded from scoring"
+							bind:value={draft.enabled}
+							editable={true}
+							type="checkbox"
+						/>
+					</div>
+				</section>
+			{/if}
 		{/each}
 	</div>
 {/if}

--- a/src/lib/features/database/difficulties/ComponentsPanel.svelte
+++ b/src/lib/features/database/difficulties/ComponentsPanel.svelte
@@ -11,11 +11,16 @@
 
 	const componentsQuery = createQuery(() => difficultyQueries.components())
 
+	type ComponentDraft = {
+		weight: number
+		enabled: boolean
+		minCountToScore: number
+		targetMax: number | null
+	}
+
 	// Local edit state, keyed by component id; seeded from server values before
 	// every render. Editors see live API values and can revert by reloading.
-	let drafts = $state<
-		Record<string, { weight: number; enabled: boolean; minCountToScore: number }>
-	>({})
+	let drafts = $state<Record<string, ComponentDraft>>({})
 
 	// $effect.pre runs before DOM updates, so drafts are guaranteed populated
 	// before the {#each} block evaluates bind expressions.
@@ -25,7 +30,8 @@
 				drafts[c.id] = {
 					weight: c.weight,
 					enabled: c.enabled,
-					minCountToScore: c.minCountToScore
+					minCountToScore: c.minCountToScore,
+					targetMax: c.targetMax
 				}
 			}
 		}
@@ -39,10 +45,13 @@
 	function isDirty(comp: DifficultyComponent): boolean {
 		const draft = drafts[comp.id]
 		if (!draft) return false
+		const draftTarget = draft.targetMax == null ? null : Number(draft.targetMax)
+		const compTarget = comp.targetMax == null ? null : Number(comp.targetMax)
 		return (
 			Number(draft.weight) !== Number(comp.weight) ||
 			Boolean(draft.enabled) !== Boolean(comp.enabled) ||
-			Number(draft.minCountToScore) !== Number(comp.minCountToScore)
+			Number(draft.minCountToScore) !== Number(comp.minCountToScore) ||
+			draftTarget !== compTarget
 		)
 	}
 
@@ -55,7 +64,11 @@
 				data: {
 					weight: Number(draft.weight),
 					enabled: draft.enabled,
-					minCountToScore: Number(draft.minCountToScore)
+					minCountToScore: Number(draft.minCountToScore),
+					targetMax:
+						draft.targetMax == null || draft.targetMax === ('' as unknown as number)
+							? null
+							: Number(draft.targetMax)
 				}
 			})
 			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'components'] })
@@ -101,6 +114,14 @@
 							label="Min items to score"
 							sublabel="Parties below this are not scored. Use 0 for job/accessory."
 							bind:value={drafts[comp.id]!.minCountToScore}
+							editable={true}
+							type="number"
+							min={0}
+						/>
+						<DetailItem
+							label="Target max"
+							sublabel="Optional. Overrides the denominator for raw_score. Leave blank to use the sum of every rule's max contribution."
+							bind:value={drafts[comp.id]!.targetMax as number | null | undefined}
 							editable={true}
 							type="number"
 							min={0}

--- a/src/lib/features/database/difficulties/PreviewPanel.svelte
+++ b/src/lib/features/database/difficulties/PreviewPanel.svelte
@@ -201,8 +201,8 @@
 	}
 
 	.tier-swatch {
-		width: 28px;
-		height: 28px;
+		width: spacing.$unit-4x;
+		height: spacing.$unit-4x;
 		border-radius: 50%;
 		border: 1px solid var(--border-subtle);
 	}
@@ -234,11 +234,11 @@
 	.breakdown {
 		display: flex;
 		flex-direction: column;
-		gap: spacing.$unit;
+		gap: spacing.$unit-2x;
 
 		h4 {
 			margin: 0;
-			font-size: typography.$font-regular;
+			font-size: typography.$font-medium;
 			font-weight: typography.$bold;
 			color: var(--text-secondary);
 		}
@@ -249,17 +249,14 @@
 			margin: 0;
 			display: flex;
 			flex-direction: column;
-			gap: spacing.$unit;
+			gap: spacing.$unit-4x;
 		}
 	}
 
 	.breakdown-row {
-		padding: spacing.$unit;
-		border: 1px solid var(--border-subtle);
-		border-radius: layout.$item-corner;
 		display: flex;
 		flex-direction: column;
-		gap: spacing.$unit-half;
+		gap: spacing.$unit;
 
 		&.absent {
 			opacity: 0.6;
@@ -276,31 +273,42 @@
 		text-transform: capitalize;
 		color: var(--text-primary);
 		font-weight: typography.$medium;
+		font-size: typography.$font-medium;
 	}
 
 	.breakdown-score {
 		font-variant-numeric: tabular-nums;
 		color: var(--text-secondary);
-		font-size: typography.$font-small;
+		font-size: typography.$font-regular;
 	}
 
 	.fired-list {
 		display: flex;
 		flex-direction: column;
-		gap: spacing.$unit-fourth !important;
-		margin-top: spacing.$unit-half !important;
 	}
 
 	.fired-row {
 		display: flex;
 		justify-content: space-between;
-		font-size: typography.$font-small;
+		font-size: typography.$font-regular;
 		color: var(--text-secondary);
-		padding: spacing.$unit-fourth 0;
+		padding: spacing.$unit-half spacing.$unit;
+		margin: 0 calc(-1 * #{spacing.$unit});
+		border-radius: layout.$item-corner;
+		transition: background-color 120ms ease;
+
+		&:hover {
+			background: var(--page-hover);
+			color: var(--text-primary);
+
+			.fired-weight {
+				color: var(--text-primary);
+			}
+		}
 
 		&.additional {
 			color: var(--text-tertiary);
-			padding-left: spacing.$unit;
+			padding-left: spacing.$unit-2x;
 		}
 	}
 

--- a/src/lib/features/database/difficulties/PreviewPanel.svelte
+++ b/src/lib/features/database/difficulties/PreviewPanel.svelte
@@ -1,0 +1,297 @@
+<script lang="ts">
+	import Input from '$lib/components/ui/Input.svelte'
+	import Button from '$lib/components/ui/Button.svelte'
+	import {
+		difficultyAdapter,
+		type DifficultyPreviewResult
+	} from '$lib/api/adapters/difficulty.adapter'
+	import { extractErrorMessage } from '$lib/utils/errors'
+
+	let shortcode = $state('')
+	let result = $state<DifficultyPreviewResult | null>(null)
+	let error = $state<string | null>(null)
+	let loading = $state(false)
+
+	async function runPreview() {
+		const code = shortcode.trim()
+		if (!code) return
+		error = null
+		loading = true
+		result = null
+		try {
+			result = await difficultyAdapter.preview(code)
+		} catch (err) {
+			error = extractErrorMessage(err, 'Preview failed')
+		} finally {
+			loading = false
+		}
+	}
+
+	function handleKey(e: KeyboardEvent) {
+		if (e.key === 'Enter' && !loading && shortcode.trim()) runPreview()
+	}
+
+	const breakdownComponents = $derived.by(() => {
+		if (!result?.breakdown) return []
+		const components = (result.breakdown as { components?: unknown[] }).components ?? []
+		return components as Array<{
+			name: string
+			weight: number
+			present: boolean
+			raw_score: number | null
+			weighted_score: number | null
+			fired: Array<{ id: string; name: string; rule_type: string; weight: number }>
+		}>
+	})
+</script>
+
+<div class="preview-panel">
+	<p class="hint">
+		Score a real party against the current ruleset without persisting. Useful when tuning weights.
+	</p>
+
+	<div class="input-row">
+		<div class="input-wrapper">
+			<Input
+				bind:value={shortcode}
+				placeholder="Party shortcode (e.g. qRf1iR)"
+				size="medium"
+				fullWidth
+				onkeydown={handleKey}
+			/>
+		</div>
+		<Button variant="primary" onclick={runPreview} disabled={loading || !shortcode.trim()}>
+			{loading ? 'Running…' : 'Run preview'}
+		</Button>
+	</div>
+
+	{#if error}
+		<div class="error-banner">{error}</div>
+	{/if}
+
+	{#if result}
+		{#if !result.scoreable}
+			<div class="notice">
+				This party isn't scoreable yet — it hasn't met the minimum item threshold on every enabled
+				component.
+			</div>
+		{:else}
+			<div class="result-summary">
+				<div class="result-headline">
+					<span class="tier-swatch" style:background={result.tier?.color || 'var(--input-bg)'}
+					></span>
+					<div class="result-text">
+						<span class="result-tier">{result.tier?.name ?? 'Unassigned'}</span>
+						<span class="result-score">{result.score?.toFixed(2) ?? '—'} / 100</span>
+					</div>
+				</div>
+				<span class="result-version">Ruleset v{result.ruleset_version}</span>
+			</div>
+
+			{#if breakdownComponents.length > 0}
+				<div class="breakdown">
+					<h4>Component breakdown</h4>
+					<ul>
+						{#each breakdownComponents as c (c.name)}
+							<li class="breakdown-row" class:absent={!c.present}>
+								<div class="breakdown-head">
+									<span class="breakdown-name">{c.name}</span>
+									<span class="breakdown-score">
+										{#if c.present}
+											{((c.raw_score ?? 0) * 100).toFixed(0)}%
+										{:else}
+											No data
+										{/if}
+									</span>
+								</div>
+								{#if c.fired.length > 0}
+									<ul class="fired-list">
+										{#each c.fired as f (f.id)}
+											<li class="fired-row">
+												<span class="fired-name">{f.name}</span>
+												<span class="fired-weight">+{f.weight}</span>
+											</li>
+										{/each}
+									</ul>
+								{:else if c.present}
+									<p class="no-fires">No rules fired.</p>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				</div>
+			{/if}
+		{/if}
+	{/if}
+</div>
+
+<style lang="scss">
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+	@use '$src/themes/layout' as layout;
+
+	.preview-panel {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-2x;
+	}
+
+	.hint {
+		margin: 0;
+		color: var(--text-secondary);
+		font-size: typography.$font-small;
+	}
+
+	.input-row {
+		display: flex;
+		gap: spacing.$unit;
+		align-items: center;
+
+		.input-wrapper {
+			flex: 1;
+		}
+	}
+
+	.error-banner {
+		padding: spacing.$unit-2x;
+		background: var(--accent-red-bg, rgba(220, 64, 64, 0.1));
+		color: var(--accent-red, #d04040);
+		border-radius: layout.$item-corner;
+		font-size: typography.$font-small;
+	}
+
+	.notice {
+		padding: spacing.$unit-2x;
+		background: var(--input-bg);
+		color: var(--text-secondary);
+		border-radius: layout.$item-corner;
+		font-size: typography.$font-small;
+	}
+
+	.result-summary {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: spacing.$unit;
+		padding: spacing.$unit-2x;
+		background: var(--input-bg);
+		border-radius: layout.$item-corner;
+	}
+
+	.result-headline {
+		display: flex;
+		align-items: center;
+		gap: spacing.$unit;
+	}
+
+	.tier-swatch {
+		width: 28px;
+		height: 28px;
+		border-radius: 50%;
+		border: 1px solid var(--border-subtle);
+	}
+
+	.result-text {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.result-tier {
+		font-size: typography.$font-regular;
+		font-weight: typography.$bold;
+		color: var(--text-primary);
+	}
+
+	.result-score {
+		font-size: typography.$font-small;
+		color: var(--text-secondary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.result-version {
+		font-size: typography.$font-tiny;
+		color: var(--text-tertiary);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.breakdown {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+
+		h4 {
+			margin: 0;
+			font-size: typography.$font-regular;
+			font-weight: typography.$bold;
+			color: var(--text-secondary);
+		}
+
+		ul {
+			list-style: none;
+			padding: 0;
+			margin: 0;
+			display: flex;
+			flex-direction: column;
+			gap: spacing.$unit;
+		}
+	}
+
+	.breakdown-row {
+		padding: spacing.$unit;
+		border: 1px solid var(--border-subtle);
+		border-radius: layout.$item-corner;
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-half;
+
+		&.absent {
+			opacity: 0.6;
+		}
+	}
+
+	.breakdown-head {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.breakdown-name {
+		text-transform: capitalize;
+		color: var(--text-primary);
+		font-weight: typography.$medium;
+	}
+
+	.breakdown-score {
+		font-variant-numeric: tabular-nums;
+		color: var(--text-secondary);
+		font-size: typography.$font-small;
+	}
+
+	.fired-list {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-fourth !important;
+		margin-top: spacing.$unit-half !important;
+	}
+
+	.fired-row {
+		display: flex;
+		justify-content: space-between;
+		font-size: typography.$font-small;
+		color: var(--text-secondary);
+		padding: spacing.$unit-fourth 0;
+	}
+
+	.fired-weight {
+		font-variant-numeric: tabular-nums;
+		color: var(--text-tertiary);
+	}
+
+	.no-fires {
+		margin: 0;
+		color: var(--text-tertiary);
+		font-size: typography.$font-small;
+		font-style: italic;
+	}
+</style>

--- a/src/lib/features/database/difficulties/PreviewPanel.svelte
+++ b/src/lib/features/database/difficulties/PreviewPanel.svelte
@@ -49,9 +49,17 @@
 			present: boolean
 			rawScore: number | null
 			weightedScore: number | null
+			contributionSum: number | null
+			maxWeight: number | null
+			targetMax: number | null
 			fired: FiredEntry[]
 		}>
 	})
+
+	function fmt(value: number | null | undefined, digits = 1): string {
+		if (value == null) return '—'
+		return value.toFixed(digits)
+	}
 
 	function labelFor(f: FiredEntry): string {
 		if (f.kind !== 'additional') return f.name
@@ -120,6 +128,14 @@
 										{/if}
 									</span>
 								</div>
+								{#if c.present && c.contributionSum != null && c.maxWeight != null}
+									<p class="breakdown-math">
+										{fmt(c.contributionSum)} / {fmt(c.maxWeight)}
+										{#if c.targetMax != null}
+											<span class="target-tag">target max</span>
+										{/if}
+									</p>
+								{/if}
 								{#if c.fired.length > 0}
 									<ul class="fired-list">
 										{#each c.fired as f (f.id)}
@@ -291,6 +307,26 @@
 		font-variant-numeric: tabular-nums;
 		color: var(--text-secondary);
 		font-size: typography.$font-regular;
+	}
+
+	.breakdown-math {
+		margin: 0;
+		font-size: typography.$font-small;
+		color: var(--text-tertiary);
+		font-variant-numeric: tabular-nums;
+		display: flex;
+		align-items: center;
+		gap: spacing.$unit;
+	}
+
+	.target-tag {
+		font-size: typography.$font-tiny;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: spacing.$unit-fourth spacing.$unit-half;
+		background: var(--input-bg);
+		color: var(--text-secondary);
+		border-radius: layout.$item-corner-small;
 	}
 
 	.fired-list {

--- a/src/lib/features/database/difficulties/PreviewPanel.svelte
+++ b/src/lib/features/database/difficulties/PreviewPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte'
 	import Input from '$lib/components/ui/Input.svelte'
 	import Button from '$lib/components/ui/Button.svelte'
 	import {
@@ -7,10 +8,20 @@
 	} from '$lib/api/adapters/difficulty.adapter'
 	import { extractErrorMessage } from '$lib/utils/errors'
 
-	let shortcode = $state('')
+	interface Props {
+		initialShortcode?: string
+	}
+
+	let { initialShortcode }: Props = $props()
+
+	let shortcode = $state(initialShortcode ?? '')
 	let result = $state<DifficultyPreviewResult | null>(null)
 	let error = $state<string | null>(null)
 	let loading = $state(false)
+
+	onMount(() => {
+		if (initialShortcode && initialShortcode.trim()) runPreview()
+	})
 
 	async function runPreview() {
 		const code = shortcode.trim()
@@ -69,10 +80,6 @@
 </script>
 
 <div class="preview-panel">
-	<p class="hint">
-		Score a real party against the current ruleset without persisting. Useful when tuning weights.
-	</p>
-
 	<div class="input-row">
 		<div class="input-wrapper">
 			<Input
@@ -84,7 +91,12 @@
 				onkeydown={handleKey}
 			/>
 		</div>
-		<Button variant="primary" onclick={runPreview} disabled={loading || !shortcode.trim()}>
+		<Button
+			variant="primary"
+			size="medium"
+			onclick={runPreview}
+			disabled={loading || !shortcode.trim()}
+		>
 			{loading ? 'Running…' : 'Run preview'}
 		</Button>
 	</div>

--- a/src/lib/features/database/difficulties/PreviewPanel.svelte
+++ b/src/lib/features/database/difficulties/PreviewPanel.svelte
@@ -38,9 +38,9 @@
 			name: string
 			weight: number
 			present: boolean
-			raw_score: number | null
-			weighted_score: number | null
-			fired: Array<{ id: string; name: string; rule_type: string; weight: number }>
+			rawScore: number | null
+			weightedScore: number | null
+			fired: Array<{ id: string; name: string; ruleType: string; weight: number }>
 		}>
 	})
 </script>
@@ -86,7 +86,7 @@
 						<span class="result-score">{result.score?.toFixed(2) ?? '—'} / 100</span>
 					</div>
 				</div>
-				<span class="result-version">Ruleset v{result.ruleset_version}</span>
+				<span class="result-version">Ruleset v{result.rulesetVersion}</span>
 			</div>
 
 			{#if breakdownComponents.length > 0}
@@ -99,7 +99,7 @@
 									<span class="breakdown-name">{c.name}</span>
 									<span class="breakdown-score">
 										{#if c.present}
-											{((c.raw_score ?? 0) * 100).toFixed(0)}%
+											{((c.rawScore ?? 0) * 100).toFixed(0)}%
 										{:else}
 											No data
 										{/if}

--- a/src/lib/features/database/difficulties/PreviewPanel.svelte
+++ b/src/lib/features/database/difficulties/PreviewPanel.svelte
@@ -31,6 +31,15 @@
 		if (e.key === 'Enter' && !loading && shortcode.trim()) runPreview()
 	}
 
+	type FiredEntry = {
+		id: string
+		name: string
+		ruleType: string
+		weight: number
+		matchCount: number
+		kind: 'base' | 'additional'
+	}
+
 	const breakdownComponents = $derived.by(() => {
 		if (!result?.breakdown) return []
 		const components = (result.breakdown as { components?: unknown[] }).components ?? []
@@ -40,9 +49,15 @@
 			present: boolean
 			rawScore: number | null
 			weightedScore: number | null
-			fired: Array<{ id: string; name: string; ruleType: string; weight: number }>
+			fired: FiredEntry[]
 		}>
 	})
+
+	function labelFor(f: FiredEntry): string {
+		if (f.kind !== 'additional') return f.name
+		const noun = f.matchCount === 1 ? 'match' : 'matches'
+		return `+${f.matchCount} additional ${noun}`
+	}
 </script>
 
 <div class="preview-panel">
@@ -108,8 +123,8 @@
 								{#if c.fired.length > 0}
 									<ul class="fired-list">
 										{#each c.fired as f (f.id)}
-											<li class="fired-row">
-												<span class="fired-name">{f.name}</span>
+											<li class="fired-row" class:additional={f.kind === 'additional'}>
+												<span class="fired-name">{labelFor(f)}</span>
 												<span class="fired-weight">+{f.weight}</span>
 											</li>
 										{/each}
@@ -155,8 +170,8 @@
 
 	.error-banner {
 		padding: spacing.$unit-2x;
-		background: var(--accent-red-bg, rgba(220, 64, 64, 0.1));
-		color: var(--accent-red, #d04040);
+		background: var(--danger-bg-subtle);
+		color: var(--danger);
 		border-radius: layout.$item-corner;
 		font-size: typography.$font-small;
 	}
@@ -282,6 +297,11 @@
 		font-size: typography.$font-small;
 		color: var(--text-secondary);
 		padding: spacing.$unit-fourth 0;
+
+		&.additional {
+			color: var(--text-tertiary);
+			padding-left: spacing.$unit;
+		}
 	}
 
 	.fired-weight {

--- a/src/lib/features/database/difficulties/PreviewPanel.svelte
+++ b/src/lib/features/database/difficulties/PreviewPanel.svelte
@@ -55,6 +55,7 @@
 			<Input
 				bind:value={shortcode}
 				placeholder="Party shortcode (e.g. qRf1iR)"
+				variant="contained"
 				size="medium"
 				fullWidth
 				onkeydown={handleKey}

--- a/src/lib/features/database/difficulties/PreviewPanel.svelte
+++ b/src/lib/features/database/difficulties/PreviewPanel.svelte
@@ -234,13 +234,14 @@
 	.breakdown {
 		display: flex;
 		flex-direction: column;
-		gap: spacing.$unit-2x;
+		margin: 0 -#{spacing.$unit-2x};
 
 		h4 {
 			margin: 0;
 			font-size: typography.$font-medium;
 			font-weight: typography.$bold;
 			color: var(--text-secondary);
+			padding: spacing.$unit spacing.$unit-2x;
 		}
 
 		ul {
@@ -249,7 +250,10 @@
 			margin: 0;
 			display: flex;
 			flex-direction: column;
-			gap: spacing.$unit-4x;
+
+			&.fired-list {
+				gap: spacing.$unit-half;
+			}
 		}
 	}
 
@@ -257,6 +261,13 @@
 		display: flex;
 		flex-direction: column;
 		gap: spacing.$unit;
+		padding: spacing.$unit-3x spacing.$unit-2x spacing.$unit-3x;
+		border-bottom: 1px solid var(--border-subtle);
+
+		&:last-child {
+			border-bottom: none;
+			padding-bottom: 0;
+		}
 
 		&.absent {
 			opacity: 0.6;
@@ -292,7 +303,7 @@
 		justify-content: space-between;
 		font-size: typography.$font-regular;
 		color: var(--text-secondary);
-		padding: spacing.$unit-half spacing.$unit;
+		padding: spacing.$unit spacing.$unit;
 		margin: 0 calc(-1 * #{spacing.$unit});
 		border-radius: layout.$item-corner;
 		transition: background-color 120ms ease;

--- a/src/lib/features/database/difficulties/RuleModal.svelte
+++ b/src/lib/features/database/difficulties/RuleModal.svelte
@@ -291,13 +291,13 @@
 		}
 
 		&.error {
-			border-color: var(--accent-red, #d04040);
+			border-color: var(--danger);
 		}
 	}
 
 	.params-error {
 		margin: 0;
-		color: var(--accent-red, #d04040);
+		color: var(--danger);
 		font-size: typography.$font-small;
 	}
 </style>

--- a/src/lib/features/database/difficulties/RuleModal.svelte
+++ b/src/lib/features/database/difficulties/RuleModal.svelte
@@ -1,0 +1,303 @@
+<script lang="ts">
+	import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query'
+	import { toast } from 'svelte-sonner'
+	import Dialog from '$lib/components/ui/Dialog.svelte'
+	import ModalHeader from '$lib/components/ui/ModalHeader.svelte'
+	import ModalFooter from '$lib/components/ui/ModalFooter.svelte'
+	import ConfirmDialog from '$lib/components/ui/ConfirmDialog.svelte'
+	import DetailItem from '$lib/components/ui/DetailItem.svelte'
+	import Button from '$lib/components/ui/Button.svelte'
+	import { difficultyAdapter, type DifficultyRule } from '$lib/api/adapters/difficulty.adapter'
+	import { difficultyQueries } from '$lib/api/queries/difficulty.queries'
+	import { extractErrorMessage } from '$lib/utils/errors'
+
+	interface Props {
+		open?: boolean
+		rule?: DifficultyRule | null
+		onOpenChange?: (open: boolean) => void
+	}
+
+	let { open = $bindable(false), rule = null, onOpenChange }: Props = $props()
+
+	const isEditing = $derived(!!rule)
+	const title = $derived(isEditing ? 'Edit Rule' : 'New Rule')
+
+	const ruleTypesQuery = createQuery(() => difficultyQueries.ruleTypes())
+	const ruleTypeOptions = $derived(
+		(ruleTypesQuery.data?.types ?? []).map((t) => ({ value: t, label: t }))
+	)
+
+	const componentOptions = [
+		{ value: 'weapon', label: 'Weapon' },
+		{ value: 'character', label: 'Character' },
+		{ value: 'summon', label: 'Summon' },
+		{ value: 'job', label: 'Job' },
+		{ value: 'accessory', label: 'Accessory' }
+	]
+
+	// Form state
+	let name = $state('')
+	let component = $state<string>('weapon')
+	let ruleType = $state<string>('')
+	let weight = $state<number>(1)
+	let active = $state(true)
+	let paramsText = $state('{}')
+	let paramsError = $state<string | null>(null)
+
+	const queryClient = useQueryClient()
+
+	const createMut = createMutation(() => ({
+		mutationFn: (data: Partial<DifficultyRule>) => difficultyAdapter.createRule(data)
+	}))
+	const updateMut = createMutation(() => ({
+		mutationFn: (input: { id: string; data: Partial<DifficultyRule> }) =>
+			difficultyAdapter.updateRule(input.id, input.data)
+	}))
+	const deleteMut = createMutation(() => ({
+		mutationFn: (id: string) => difficultyAdapter.deleteRule(id)
+	}))
+
+	const isSaving = $derived(createMut.isPending || updateMut.isPending)
+	const isDeleting = $derived(deleteMut.isPending)
+
+	$effect(() => {
+		if (open) {
+			paramsError = null
+			if (rule) {
+				name = rule.name ?? ''
+				component = rule.component ?? 'weapon'
+				ruleType = rule.rule_type ?? ''
+				weight = rule.weight ?? 1
+				active = rule.active ?? true
+				paramsText = JSON.stringify(rule.params ?? {}, null, 2)
+			} else {
+				name = ''
+				component = 'weapon'
+				ruleType = ''
+				weight = 1
+				active = true
+				paramsText = '{\n  "min_count": 1\n}'
+			}
+		}
+	})
+
+	function parseParams(): Record<string, unknown> | null {
+		try {
+			const parsed = JSON.parse(paramsText || '{}')
+			if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+				paramsError = 'Params must be a JSON object.'
+				return null
+			}
+			paramsError = null
+			return parsed as Record<string, unknown>
+		} catch (err) {
+			paramsError = err instanceof Error ? err.message : 'Invalid JSON.'
+			return null
+		}
+	}
+
+	const canSave = $derived(name.trim().length > 0 && ruleType.length > 0 && weight >= 0)
+
+	async function handleSave() {
+		const params = parseParams()
+		if (params === null) {
+			toast.error('Fix the params JSON before saving.')
+			return
+		}
+		if (!canSave) {
+			toast.error('Name, rule type, and a non-negative weight are required.')
+			return
+		}
+
+		const payload: Partial<DifficultyRule> = {
+			name: name.trim(),
+			component,
+			rule_type: ruleType,
+			weight,
+			active,
+			params
+		}
+
+		try {
+			if (isEditing && rule) {
+				await updateMut.mutateAsync({ id: rule.id, data: payload })
+			} else {
+				await createMut.mutateAsync(payload)
+			}
+			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'rules'] })
+			toast.success(isEditing ? 'Rule updated' : 'Rule created')
+			open = false
+			onOpenChange?.(false)
+		} catch (err) {
+			toast.error(extractErrorMessage(err, 'Failed to save rule'))
+		}
+	}
+
+	let confirmDeleteOpen = $state(false)
+
+	async function handleConfirmDelete() {
+		if (!rule) return
+		try {
+			await deleteMut.mutateAsync(rule.id)
+			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'rules'] })
+			toast.success('Rule deleted')
+			confirmDeleteOpen = false
+			open = false
+			onOpenChange?.(false)
+		} catch (err) {
+			toast.error(extractErrorMessage(err, 'Failed to delete rule'))
+		}
+	}
+</script>
+
+<Dialog bind:open {onOpenChange} size="small">
+	<ModalHeader
+		{title}
+		description="Each rule contributes its weight to its component sub-score when its condition fires."
+	/>
+	<div class="modal-body">
+		<DetailItem
+			label="Name"
+			bind:value={name}
+			editable={true}
+			type="text"
+			placeholder="e.g. Grand series weapon present"
+			width="320px"
+		/>
+		<DetailItem
+			label="Component"
+			sublabel="Which side of the team this rule scores"
+			bind:value={component}
+			editable={true}
+			type="select"
+			options={componentOptions}
+		/>
+		<DetailItem
+			label="Rule type"
+			sublabel="Available types are defined in the API"
+			bind:value={ruleType}
+			editable={true}
+			type="select"
+			options={ruleTypeOptions}
+			placeholder="Select a rule type"
+		/>
+		<DetailItem
+			label="Weight"
+			sublabel="Contribution to the component sub-score when the rule fires"
+			bind:value={weight}
+			editable={true}
+			type="number"
+			min={0}
+		/>
+		<DetailItem
+			label="Active"
+			sublabel="Inactive rules are skipped during scoring"
+			bind:value={active}
+			editable={true}
+			type="checkbox"
+		/>
+
+		<h4 class="section-header">Parameters</h4>
+		<p class="hint">Each rule type expects specific keys. See the API for the full schema.</p>
+		<textarea
+			bind:value={paramsText}
+			rows="8"
+			spellcheck="false"
+			class="params-input"
+			class:error={!!paramsError}
+		></textarea>
+		{#if paramsError}
+			<p class="params-error">{paramsError}</p>
+		{/if}
+	</div>
+	<ModalFooter
+		onCancel={() => (open = false)}
+		primaryAction={{
+			label: isSaving ? 'Saving…' : isEditing ? 'Save' : 'Create',
+			onclick: handleSave,
+			disabled: isSaving || isDeleting || !canSave
+		}}
+	>
+		{#snippet left()}
+			{#if isEditing}
+				<Button
+					variant="destructive-ghost"
+					size="small"
+					onclick={() => (confirmDeleteOpen = true)}
+					disabled={isDeleting || isSaving}
+				>
+					{isDeleting ? 'Deleting…' : 'Delete'}
+				</Button>
+			{/if}
+		{/snippet}
+	</ModalFooter>
+</Dialog>
+
+<ConfirmDialog
+	bind:open={confirmDeleteOpen}
+	title="Delete rule?"
+	message={`"${rule?.name ?? ''}" will be removed and stop contributing to the score.`}
+	confirmLabel="Delete"
+	loading={isDeleting}
+	onconfirm={handleConfirmDelete}
+/>
+
+<style lang="scss">
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+	@use '$src/themes/layout' as layout;
+
+	.modal-body {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+		padding: spacing.$unit-2x;
+		padding-top: 0;
+		max-height: 70vh;
+		overflow-y: auto;
+	}
+
+	.section-header {
+		margin: spacing.$unit 0 0 0;
+		font-size: typography.$font-regular;
+		font-weight: typography.$bold;
+		color: var(--text-secondary);
+	}
+
+	.hint {
+		margin: 0;
+		color: var(--text-tertiary);
+		font-size: typography.$font-small;
+	}
+
+	.params-input {
+		width: 100%;
+		min-height: 160px;
+		padding: spacing.$unit;
+		border: 1px solid var(--border-subtle);
+		border-radius: layout.$input-corner;
+		background: var(--input-bg);
+		color: var(--text-primary);
+		font: inherit;
+		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		font-size: typography.$font-small;
+		resize: vertical;
+		white-space: pre;
+
+		&:focus {
+			outline: 2px solid var(--focus-ring);
+			outline-offset: -1px;
+			border-color: transparent;
+		}
+
+		&.error {
+			border-color: var(--accent-red, #d04040);
+		}
+	}
+
+	.params-error {
+		margin: 0;
+		color: var(--accent-red, #d04040);
+		font-size: typography.$font-small;
+	}
+</style>

--- a/src/lib/features/database/difficulties/RuleModal.svelte
+++ b/src/lib/features/database/difficulties/RuleModal.svelte
@@ -10,6 +10,7 @@
 	import { difficultyAdapter, type DifficultyRule } from '$lib/api/adapters/difficulty.adapter'
 	import { difficultyQueries } from '$lib/api/queries/difficulty.queries'
 	import { extractErrorMessage } from '$lib/utils/errors'
+	import { getDifficultyComponentOptions } from '$lib/features/database/difficulties/constants'
 
 	interface Props {
 		open?: boolean
@@ -27,13 +28,7 @@
 		(ruleTypesQuery.data?.types ?? []).map((t) => ({ value: t, label: t }))
 	)
 
-	const componentOptions = [
-		{ value: 'weapon', label: 'Weapon' },
-		{ value: 'character', label: 'Character' },
-		{ value: 'summon', label: 'Summon' },
-		{ value: 'job', label: 'Job' },
-		{ value: 'accessory', label: 'Accessory' }
-	]
+	const componentOptions = $derived(getDifficultyComponentOptions())
 
 	// Form state
 	let name = $state('')

--- a/src/lib/features/database/difficulties/RuleModal.svelte
+++ b/src/lib/features/database/difficulties/RuleModal.svelte
@@ -119,8 +119,8 @@
 			} else {
 				await createMut.mutateAsync(payload)
 			}
-			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'rules'] })
-			toast.success(isEditing ? 'Rule updated' : 'Rule created')
+			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
+			toast.success(isEditing ? 'Rule change staged' : 'Rule creation staged')
 			open = false
 			onOpenChange?.(false)
 		} catch (err) {
@@ -134,8 +134,8 @@
 		if (!rule) return
 		try {
 			await deleteMut.mutateAsync(rule.id)
-			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'rules'] })
-			toast.success('Rule deleted')
+			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
+			toast.success('Rule deletion staged')
 			confirmDeleteOpen = false
 			open = false
 			onOpenChange?.(false)

--- a/src/lib/features/database/difficulties/RuleModal.svelte
+++ b/src/lib/features/database/difficulties/RuleModal.svelte
@@ -66,7 +66,7 @@
 			if (rule) {
 				name = rule.name ?? ''
 				component = rule.component ?? 'weapon'
-				ruleType = rule.rule_type ?? ''
+				ruleType = rule.ruleType ?? ''
 				weight = rule.weight ?? 1
 				active = rule.active ?? true
 				paramsText = JSON.stringify(rule.params ?? {}, null, 2)
@@ -112,7 +112,7 @@
 		const payload: Partial<DifficultyRule> = {
 			name: name.trim(),
 			component,
-			rule_type: ruleType,
+			ruleType,
 			weight,
 			active,
 			params

--- a/src/lib/features/database/difficulties/RuleRow.svelte
+++ b/src/lib/features/database/difficulties/RuleRow.svelte
@@ -15,7 +15,7 @@
 	<button class="rule-row interactive" {onclick} class:inactive={!rule.active}>
 		<div class="primary">
 			<span class="name">{rule.name}</span>
-			<span class="rule-type">{rule.rule_type}</span>
+			<span class="rule-type">{rule.ruleType}</span>
 		</div>
 		<div class="meta">
 			<span class="component-pill" data-component={rule.component}>{rule.component}</span>
@@ -29,7 +29,7 @@
 	<div class="rule-row" class:inactive={!rule.active}>
 		<div class="primary">
 			<span class="name">{rule.name}</span>
-			<span class="rule-type">{rule.rule_type}</span>
+			<span class="rule-type">{rule.ruleType}</span>
 		</div>
 		<div class="meta">
 			<span class="component-pill" data-component={rule.component}>{rule.component}</span>

--- a/src/lib/features/database/difficulties/RuleRow.svelte
+++ b/src/lib/features/database/difficulties/RuleRow.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+	import type { DifficultyRule } from '$lib/api/adapters/difficulty.adapter'
+
+	interface Props {
+		rule: DifficultyRule
+		onclick?: () => void
+	}
+
+	let { rule, onclick }: Props = $props()
+
+	const interactive = $derived(!!onclick)
+</script>
+
+{#if interactive}
+	<button class="rule-row interactive" {onclick} class:inactive={!rule.active}>
+		<div class="primary">
+			<span class="name">{rule.name}</span>
+			<span class="rule-type">{rule.rule_type}</span>
+		</div>
+		<div class="meta">
+			<span class="component-pill" data-component={rule.component}>{rule.component}</span>
+			<span class="weight">×{rule.weight}</span>
+			{#if !rule.active}
+				<span class="status-pill">Inactive</span>
+			{/if}
+		</div>
+	</button>
+{:else}
+	<div class="rule-row" class:inactive={!rule.active}>
+		<div class="primary">
+			<span class="name">{rule.name}</span>
+			<span class="rule-type">{rule.rule_type}</span>
+		</div>
+		<div class="meta">
+			<span class="component-pill" data-component={rule.component}>{rule.component}</span>
+			<span class="weight">×{rule.weight}</span>
+		</div>
+	</div>
+{/if}
+
+<style lang="scss">
+	@use '$src/themes/layout' as layout;
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+
+	.rule-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: spacing.$unit-2x;
+		padding: calc(spacing.$unit * 1.5) spacing.$unit;
+		border: none;
+		background: none;
+		width: 100%;
+		text-align: left;
+		font-family: inherit;
+		color: var(--text-primary);
+
+		&.inactive {
+			opacity: 0.55;
+		}
+
+		.primary {
+			display: flex;
+			flex-direction: column;
+			gap: spacing.$unit-fourth;
+			min-width: 0;
+		}
+
+		.name {
+			font-size: typography.$font-regular;
+			color: var(--text-primary);
+			font-weight: typography.$medium;
+		}
+
+		.rule-type {
+			font-size: typography.$font-small;
+			color: var(--text-tertiary);
+			font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		}
+
+		.meta {
+			display: flex;
+			align-items: center;
+			gap: spacing.$unit;
+			flex-shrink: 0;
+		}
+
+		.component-pill {
+			padding: spacing.$unit-fourth spacing.$unit;
+			border-radius: layout.$full-corner;
+			background: var(--input-bg);
+			color: var(--text-secondary);
+			font-size: typography.$font-small;
+			text-transform: capitalize;
+		}
+
+		.weight {
+			font-size: typography.$font-small;
+			color: var(--text-secondary);
+			font-variant-numeric: tabular-nums;
+			min-width: 40px;
+			text-align: right;
+		}
+
+		.status-pill {
+			padding: spacing.$unit-fourth spacing.$unit;
+			border-radius: layout.$full-corner;
+			background: var(--button-bg);
+			color: var(--text-tertiary);
+			font-size: typography.$font-tiny;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+		}
+
+		&.interactive {
+			cursor: pointer;
+			border-radius: layout.$item-corner;
+			margin-left: -8px;
+			width: calc(100% + 8px);
+
+			&:hover {
+				background: var(--page-hover);
+			}
+		}
+	}
+</style>

--- a/src/lib/features/database/difficulties/RuleRow.svelte
+++ b/src/lib/features/database/difficulties/RuleRow.svelte
@@ -9,32 +9,44 @@
 	let { rule, onclick }: Props = $props()
 
 	const interactive = $derived(!!onclick)
+	const pendingLabel = $derived.by(() => {
+		switch (rule.pendingOperation) {
+			case 'create':
+				return 'New'
+			case 'destroy':
+				return 'Will delete'
+			case 'update':
+				return 'Pending'
+			default:
+				return null
+		}
+	})
 </script>
+
+{#snippet body()}
+	<div class="primary">
+		<span class="name">{rule.name}</span>
+		<span class="rule-type">{rule.ruleType}</span>
+	</div>
+	<div class="meta">
+		<span class="component-pill" data-component={rule.component}>{rule.component}</span>
+		<span class="weight">×{rule.weight}</span>
+		{#if !rule.active}
+			<span class="status-pill">Inactive</span>
+		{/if}
+		{#if pendingLabel}
+			<span class="pending-pill" data-operation={rule.pendingOperation}>{pendingLabel}</span>
+		{/if}
+	</div>
+{/snippet}
 
 {#if interactive}
 	<button class="rule-row interactive" {onclick} class:inactive={!rule.active}>
-		<div class="primary">
-			<span class="name">{rule.name}</span>
-			<span class="rule-type">{rule.ruleType}</span>
-		</div>
-		<div class="meta">
-			<span class="component-pill" data-component={rule.component}>{rule.component}</span>
-			<span class="weight">×{rule.weight}</span>
-			{#if !rule.active}
-				<span class="status-pill">Inactive</span>
-			{/if}
-		</div>
+		{@render body()}
 	</button>
 {:else}
 	<div class="rule-row" class:inactive={!rule.active}>
-		<div class="primary">
-			<span class="name">{rule.name}</span>
-			<span class="rule-type">{rule.ruleType}</span>
-		</div>
-		<div class="meta">
-			<span class="component-pill" data-component={rule.component}>{rule.component}</span>
-			<span class="weight">×{rule.weight}</span>
-		</div>
+		{@render body()}
 	</div>
 {/if}
 
@@ -111,6 +123,26 @@
 			font-size: typography.$font-tiny;
 			text-transform: uppercase;
 			letter-spacing: 0.05em;
+		}
+
+		.pending-pill {
+			padding: spacing.$unit-fourth spacing.$unit;
+			border-radius: layout.$full-corner;
+			background: var(--accent-yellow, var(--input-bg));
+			color: var(--text-primary);
+			font-size: typography.$font-tiny;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+
+			&[data-operation='destroy'] {
+				background: var(--danger-bg-subtle);
+				color: var(--danger);
+			}
+
+			&[data-operation='create'] {
+				background: var(--accent-green, var(--input-bg));
+				color: var(--text-primary);
+			}
 		}
 
 		&.interactive {

--- a/src/lib/features/database/difficulties/TierIcon.svelte
+++ b/src/lib/features/database/difficulties/TierIcon.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { getTierIconUrl } from '$lib/utils/difficulty'
+
+	interface Props {
+		imageKey?: string | null | undefined
+		/** Direct image URL override; takes precedence over imageKey (used for upload previews) */
+		src?: string | null | undefined
+		/** Fallback color swatch when no image is present */
+		color?: string | null | undefined
+		name?: string
+		/** Outer rounded-rect container size in px */
+		size?: number
+		/** Image size in px; defaults to the container size (image fills) */
+		imageSize?: number
+	}
+
+	let { imageKey, src, color, name = '', size = 32, imageSize }: Props = $props()
+
+	const url = $derived(src ?? getTierIconUrl(imageKey))
+	const containerStyle = $derived(
+		url
+			? `width: ${size}px; height: ${size}px;`
+			: `width: ${size}px; height: ${size}px; background: ${color || 'var(--placeholder-bg)'};`
+	)
+	const imgSizePx = $derived(imageSize ?? size)
+	const imageStyle = $derived(`width: ${imgSizePx}px; height: ${imgSizePx}px;`)
+</script>
+
+<span class="tier-icon" style={containerStyle} aria-hidden={!name}>
+	{#if url}
+		<img src={url} alt={name} style={imageStyle} />
+	{/if}
+</span>
+
+<style lang="scss">
+	@use '$src/themes/layout' as layout;
+
+	.tier-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 50%;
+		overflow: hidden;
+		flex-shrink: 0;
+		border: 1px solid var(--border-subtle);
+
+		img {
+			object-fit: contain;
+		}
+	}
+</style>

--- a/src/lib/features/database/difficulties/TierModal.svelte
+++ b/src/lib/features/database/difficulties/TierModal.svelte
@@ -10,6 +10,10 @@
 	import { difficultyAdapter } from '$lib/api/adapters/difficulty.adapter'
 	import type { DifficultyTier } from '$lib/types/api/party'
 	import { extractErrorMessage } from '$lib/utils/errors'
+	import TierIcon from '$lib/features/database/difficulties/TierIcon.svelte'
+
+	const ICON_MAX_DIMENSION = 128
+	const ICON_MAX_BYTES = 256 * 1024
 
 	interface Props {
 		open?: boolean
@@ -30,6 +34,13 @@
 	let minScore = $state<number>(0)
 	let maxScore = $state<number>(100)
 	let sortOrder = $state<number>(0)
+	let iconFile = $state<File | null>(null)
+	let iconPreview = $state<string | null>(null)
+	let iconError = $state<string | null>(null)
+	let iconInputRef: HTMLInputElement | undefined = $state(undefined)
+	let isUploadingIcon = $state(false)
+	// Tracks intent to clear an existing tier.imageKey without uploading a new one.
+	let removeIcon = $state(false)
 
 	const queryClient = useQueryClient()
 
@@ -49,6 +60,10 @@
 
 	$effect(() => {
 		if (open) {
+			iconFile = null
+			iconPreview = null
+			iconError = null
+			removeIcon = false
 			if (tier) {
 				name = tier.name ?? ''
 				slug = tier.slug ?? ''
@@ -69,8 +84,71 @@
 		}
 	})
 
+	function openIconPicker() {
+		iconInputRef?.click()
+	}
+
+	async function readDataUrl(file: File): Promise<string> {
+		return new Promise((resolve, reject) => {
+			const reader = new FileReader()
+			reader.onload = () => resolve(reader.result as string)
+			reader.onerror = () => reject(reader.error)
+			reader.readAsDataURL(file)
+		})
+	}
+
+	async function checkDimensions(dataUrl: string): Promise<{ width: number; height: number }> {
+		return new Promise((resolve, reject) => {
+			const img = new Image()
+			img.onload = () => resolve({ width: img.width, height: img.height })
+			img.onerror = () => reject(new Error('Could not decode image'))
+			img.src = dataUrl
+		})
+	}
+
+	async function handleIconSelect(e: Event) {
+		iconError = null
+		const input = e.target as HTMLInputElement
+		const file = input.files?.[0]
+		if (!file) return
+
+		if (file.type !== 'image/png') {
+			iconError = 'Icon must be a PNG.'
+			input.value = ''
+			return
+		}
+		if (file.size > ICON_MAX_BYTES) {
+			iconError = 'Icon must be 256KB or smaller.'
+			input.value = ''
+			return
+		}
+
+		const dataUrl = await readDataUrl(file)
+		const { width, height } = await checkDimensions(dataUrl)
+		if (width > ICON_MAX_DIMENSION || height > ICON_MAX_DIMENSION) {
+			iconError = `Icon must be ${ICON_MAX_DIMENSION}x${ICON_MAX_DIMENSION} or smaller.`
+			input.value = ''
+			return
+		}
+
+		iconFile = file
+		iconPreview = dataUrl
+		removeIcon = false
+	}
+
+	function clearIcon() {
+		iconFile = null
+		iconPreview = null
+		iconError = null
+		if (iconInputRef) iconInputRef.value = ''
+	}
+
+	function toggleRemoveIcon() {
+		removeIcon = !removeIcon
+	}
+
 	function buildPayload(): Partial<DifficultyTier> {
-		return {
+		const payload: Partial<DifficultyTier> = {
 			name: name.trim(),
 			slug: slug.trim(),
 			color,
@@ -79,6 +157,10 @@
 			maxScore,
 			sortOrder
 		}
+		// Clearing an existing icon is expressed as imageKey: null; uploading a
+		// new icon goes through uploadDraftImage after the draft is staged.
+		if (removeIcon && !iconFile) payload.imageKey = null
+		return payload
 	}
 
 	const canSave = $derived(
@@ -95,14 +177,40 @@
 			return
 		}
 
+		let iconUploadError: unknown = null
 		try {
-			if (isEditing && tier) {
-				await updateMut.mutateAsync({ id: tier.id, data: buildPayload() })
-			} else {
-				await createMut.mutateAsync(buildPayload())
+			const result =
+				isEditing && tier
+					? await updateMut.mutateAsync({ id: tier.id, data: buildPayload() })
+					: await createMut.mutateAsync(buildPayload())
+
+			// Image upload runs after the draft is already staged. If it fails we
+			// surface a partial-success toast and still close the modal so the
+			// staged tier shows up in the list.
+			if (iconFile && result.draft?.id) {
+				isUploadingIcon = true
+				try {
+					const dataUrl = await readDataUrl(iconFile)
+					const base64 = dataUrl.replace(/^data:[^;]+;base64,/, '')
+					await difficultyAdapter.uploadDraftImage(result.draft.id, base64, iconFile.name)
+				} catch (err) {
+					iconUploadError = err
+				} finally {
+					isUploadingIcon = false
+				}
 			}
-			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'tiers'] })
-			toast.success(isEditing ? 'Tier updated' : 'Tier created')
+
+			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
+			if (iconUploadError) {
+				toast.error(
+					extractErrorMessage(
+						iconUploadError,
+						'Tier change staged, but the icon upload failed — try Replace.'
+					)
+				)
+			} else {
+				toast.success(isEditing ? 'Tier change staged' : 'Tier creation staged')
+			}
 			open = false
 			onOpenChange?.(false)
 		} catch (err) {
@@ -116,8 +224,8 @@
 		if (!tier) return
 		try {
 			await deleteMut.mutateAsync(tier.id)
-			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'tiers'] })
-			toast.success('Tier deleted')
+			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
+			toast.success('Tier deletion staged')
 			confirmDeleteOpen = false
 			open = false
 			onOpenChange?.(false)
@@ -151,6 +259,43 @@
 			<div class="color-control">
 				<input type="color" bind:value={color} aria-label="Tier color" class="color-input" />
 				<span class="color-value">{color}</span>
+			</div>
+		</DetailItem>
+		<DetailItem
+			label="Icon"
+			sublabel="Optional. PNG, 128×128 or smaller, 256KB max. Shown next to the tier name."
+			editable={true}
+		>
+			<div class="icon-control">
+				<TierIcon
+					imageKey={removeIcon ? null : tier?.imageKey}
+					src={iconPreview}
+					{color}
+					{name}
+					size={40}
+				/>
+				<div class="icon-actions">
+					<Button variant="ghost" size="small" onclick={openIconPicker}>
+						{iconPreview || (tier?.imageKey && !removeIcon) ? 'Replace' : 'Upload'}
+					</Button>
+					{#if iconPreview}
+						<Button variant="ghost" size="small" onclick={clearIcon}>Cancel</Button>
+					{:else if tier?.imageKey}
+						<Button variant="ghost" size="small" onclick={toggleRemoveIcon}>
+							{removeIcon ? 'Undo' : 'Remove'}
+						</Button>
+					{/if}
+				</div>
+				<input
+					bind:this={iconInputRef}
+					type="file"
+					accept="image/png"
+					onchange={handleIconSelect}
+					class="icon-input-hidden"
+				/>
+				{#if iconError}
+					<p class="icon-error">{iconError}</p>
+				{/if}
 			</div>
 		</DetailItem>
 		<DetailItem
@@ -190,9 +335,9 @@
 	<ModalFooter
 		onCancel={() => (open = false)}
 		primaryAction={{
-			label: isSaving ? 'Saving…' : isEditing ? 'Save' : 'Create',
+			label: isSaving || isUploadingIcon ? 'Saving…' : isEditing ? 'Save' : 'Create',
 			onclick: handleSave,
-			disabled: isSaving || isDeleting || !canSave
+			disabled: isSaving || isUploadingIcon || isDeleting || !canSave
 		}}
 	>
 		{#snippet left()}
@@ -270,6 +415,29 @@
 		font-size: typography.$font-small;
 		color: var(--text-secondary);
 		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+	}
+
+	.icon-control {
+		display: flex;
+		align-items: center;
+		gap: spacing.$unit;
+		flex-wrap: wrap;
+	}
+
+	.icon-actions {
+		display: flex;
+		gap: spacing.$unit-half;
+	}
+
+	.icon-input-hidden {
+		display: none;
+	}
+
+	.icon-error {
+		flex-basis: 100%;
+		margin: 0;
+		color: var(--danger);
+		font-size: typography.$font-small;
 	}
 
 	.description-input {

--- a/src/lib/features/database/difficulties/TierModal.svelte
+++ b/src/lib/features/database/difficulties/TierModal.svelte
@@ -1,0 +1,291 @@
+<script lang="ts">
+	import { createMutation, useQueryClient } from '@tanstack/svelte-query'
+	import { toast } from 'svelte-sonner'
+	import Dialog from '$lib/components/ui/Dialog.svelte'
+	import ModalHeader from '$lib/components/ui/ModalHeader.svelte'
+	import ModalFooter from '$lib/components/ui/ModalFooter.svelte'
+	import ConfirmDialog from '$lib/components/ui/ConfirmDialog.svelte'
+	import DetailItem from '$lib/components/ui/DetailItem.svelte'
+	import Button from '$lib/components/ui/Button.svelte'
+	import { difficultyAdapter } from '$lib/api/adapters/difficulty.adapter'
+	import type { DifficultyTier } from '$lib/types/api/party'
+	import { extractErrorMessage } from '$lib/utils/errors'
+
+	interface Props {
+		open?: boolean
+		tier?: DifficultyTier | null
+		onOpenChange?: (open: boolean) => void
+	}
+
+	let { open = $bindable(false), tier = null, onOpenChange }: Props = $props()
+
+	const isEditing = $derived(!!tier)
+	const title = $derived(isEditing ? 'Edit Difficulty Tier' : 'New Difficulty Tier')
+
+	// Form state
+	let name = $state('')
+	let slug = $state('')
+	let color = $state('#86C5A8')
+	let description = $state('')
+	let minScore = $state<number>(0)
+	let maxScore = $state<number>(100)
+	let sortOrder = $state<number>(0)
+
+	const queryClient = useQueryClient()
+
+	const createMut = createMutation(() => ({
+		mutationFn: (data: Partial<DifficultyTier>) => difficultyAdapter.createTier(data)
+	}))
+	const updateMut = createMutation(() => ({
+		mutationFn: (input: { id: string; data: Partial<DifficultyTier> }) =>
+			difficultyAdapter.updateTier(input.id, input.data)
+	}))
+	const deleteMut = createMutation(() => ({
+		mutationFn: (id: string) => difficultyAdapter.deleteTier(id)
+	}))
+
+	const isSaving = $derived(createMut.isPending || updateMut.isPending)
+	const isDeleting = $derived(deleteMut.isPending)
+
+	$effect(() => {
+		if (open) {
+			if (tier) {
+				name = tier.name ?? ''
+				slug = tier.slug ?? ''
+				color = tier.color ?? '#86C5A8'
+				description = tier.description ?? ''
+				minScore = tier.min_score ?? 0
+				maxScore = tier.max_score ?? 100
+				sortOrder = tier.sort_order ?? 0
+			} else {
+				name = ''
+				slug = ''
+				color = '#86C5A8'
+				description = ''
+				minScore = 0
+				maxScore = 100
+				sortOrder = 0
+			}
+		}
+	})
+
+	function buildPayload(): Partial<DifficultyTier> {
+		return {
+			name: name.trim(),
+			slug: slug.trim(),
+			color,
+			description: description.trim() || undefined,
+			min_score: minScore,
+			max_score: maxScore,
+			sort_order: sortOrder
+		}
+	}
+
+	const canSave = $derived(
+		name.trim().length > 0 &&
+			slug.trim().length > 0 &&
+			maxScore > minScore &&
+			minScore >= 0 &&
+			maxScore <= 100
+	)
+
+	async function handleSave() {
+		if (!canSave) {
+			toast.error('Name, slug, and a valid 0–100 range are required.')
+			return
+		}
+
+		try {
+			if (isEditing && tier) {
+				await updateMut.mutateAsync({ id: tier.id, data: buildPayload() })
+			} else {
+				await createMut.mutateAsync(buildPayload())
+			}
+			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'tiers'] })
+			toast.success(isEditing ? 'Tier updated' : 'Tier created')
+			open = false
+			onOpenChange?.(false)
+		} catch (err) {
+			toast.error(extractErrorMessage(err, 'Failed to save tier'))
+		}
+	}
+
+	let confirmDeleteOpen = $state(false)
+
+	async function handleConfirmDelete() {
+		if (!tier) return
+		try {
+			await deleteMut.mutateAsync(tier.id)
+			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'tiers'] })
+			toast.success('Tier deleted')
+			confirmDeleteOpen = false
+			open = false
+			onOpenChange?.(false)
+		} catch (err) {
+			toast.error(extractErrorMessage(err, 'Failed to delete tier'))
+		}
+	}
+</script>
+
+<Dialog bind:open {onOpenChange}>
+	<ModalHeader {title} description="Score ranges determine which tier a party falls into." />
+	<div class="modal-body">
+		<DetailItem
+			label="Name"
+			bind:value={name}
+			editable={true}
+			type="text"
+			placeholder="e.g. Endgame"
+			width="280px"
+		/>
+		<DetailItem
+			label="Slug"
+			sublabel="Used in URLs and the filter param"
+			bind:value={slug}
+			editable={true}
+			type="text"
+			placeholder="endgame"
+			width="280px"
+		/>
+		<DetailItem label="Color" editable={true}>
+			<div class="color-control">
+				<input type="color" bind:value={color} aria-label="Tier color" class="color-input" />
+				<span class="color-value">{color}</span>
+			</div>
+		</DetailItem>
+		<DetailItem
+			label="Sort Order"
+			sublabel="Lower values appear first in lists"
+			bind:value={sortOrder}
+			editable={true}
+			type="number"
+		/>
+		<h4 class="section-header">Score range</h4>
+		<DetailItem
+			label="Min score"
+			bind:value={minScore}
+			editable={true}
+			type="number"
+			min={0}
+			max={100}
+		/>
+		<DetailItem
+			label="Max score"
+			bind:value={maxScore}
+			editable={true}
+			type="number"
+			min={0}
+			max={100}
+		/>
+		<h4 class="section-header">Description</h4>
+		<DetailItem label="Notes" editable={true}>
+			<textarea
+				bind:value={description}
+				placeholder="Optional description shown to editors"
+				rows="3"
+				class="description-input"
+			></textarea>
+		</DetailItem>
+	</div>
+	<ModalFooter
+		onCancel={() => (open = false)}
+		primaryAction={{
+			label: isSaving ? 'Saving…' : isEditing ? 'Save' : 'Create',
+			onclick: handleSave,
+			disabled: isSaving || isDeleting || !canSave
+		}}
+	>
+		{#snippet left()}
+			{#if isEditing}
+				<Button
+					variant="destructive-ghost"
+					size="small"
+					onclick={() => (confirmDeleteOpen = true)}
+					disabled={isDeleting || isSaving}
+				>
+					{isDeleting ? 'Deleting…' : 'Delete'}
+				</Button>
+			{/if}
+		{/snippet}
+	</ModalFooter>
+</Dialog>
+
+<ConfirmDialog
+	bind:open={confirmDeleteOpen}
+	title="Delete tier?"
+	message={`Parties currently assigned to "${tier?.name ?? ''}" will be reset to no tier until the next score sweep.`}
+	confirmLabel="Delete"
+	loading={isDeleting}
+	onconfirm={handleConfirmDelete}
+/>
+
+<style lang="scss">
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+	@use '$src/themes/layout' as layout;
+
+	.modal-body {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+		padding: spacing.$unit-2x;
+		padding-top: 0;
+		max-height: 60vh;
+		overflow-y: auto;
+	}
+
+	.section-header {
+		margin: spacing.$unit 0 0 0;
+		font-size: typography.$font-regular;
+		font-weight: typography.$bold;
+		color: var(--text-secondary);
+	}
+
+	.color-control {
+		display: flex;
+		align-items: center;
+		gap: spacing.$unit;
+	}
+
+	.color-input {
+		width: 42px;
+		height: 32px;
+		padding: 0;
+		border: 1px solid var(--border-subtle);
+		border-radius: layout.$item-corner-small;
+		background: transparent;
+		cursor: pointer;
+
+		&::-webkit-color-swatch-wrapper {
+			padding: 2px;
+		}
+
+		&::-webkit-color-swatch {
+			border-radius: 3px;
+			border: none;
+		}
+	}
+
+	.color-value {
+		font-size: typography.$font-small;
+		color: var(--text-secondary);
+		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+	}
+
+	.description-input {
+		width: 320px;
+		padding: spacing.$unit;
+		border: 1px solid var(--border-subtle);
+		border-radius: layout.$input-corner;
+		background: var(--input-bg);
+		color: var(--text-primary);
+		font: inherit;
+		resize: vertical;
+
+		&:focus {
+			outline: 2px solid var(--focus-ring);
+			outline-offset: -1px;
+			border-color: transparent;
+		}
+	}
+</style>

--- a/src/lib/features/database/difficulties/TierModal.svelte
+++ b/src/lib/features/database/difficulties/TierModal.svelte
@@ -54,9 +54,9 @@
 				slug = tier.slug ?? ''
 				color = tier.color ?? '#86C5A8'
 				description = tier.description ?? ''
-				minScore = tier.min_score ?? 0
-				maxScore = tier.max_score ?? 100
-				sortOrder = tier.sort_order ?? 0
+				minScore = tier.minScore ?? 0
+				maxScore = tier.maxScore ?? 100
+				sortOrder = tier.sortOrder ?? 0
 			} else {
 				name = ''
 				slug = ''
@@ -75,9 +75,9 @@
 			slug: slug.trim(),
 			color,
 			description: description.trim() || undefined,
-			min_score: minScore,
-			max_score: maxScore,
-			sort_order: sortOrder
+			minScore,
+			maxScore,
+			sortOrder
 		}
 	}
 

--- a/src/lib/features/database/difficulties/TierRow.svelte
+++ b/src/lib/features/database/difficulties/TierRow.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+	import type { DifficultyTier } from '$lib/types/api/party'
+
+	interface Props {
+		tier: DifficultyTier
+		onclick?: () => void
+	}
+
+	let { tier, onclick }: Props = $props()
+
+	const scoreRange = $derived(`${tier.min_score ?? 0}–${tier.max_score ?? 100}`)
+	const interactive = $derived(!!onclick)
+</script>
+
+{#if interactive}
+	<button class="tier-row interactive" {onclick}>
+		<span class="swatch" style:background={tier.color || 'var(--input-bg)'}></span>
+		<span class="name">{tier.name}</span>
+		<span class="slug">{tier.slug}</span>
+		<span class="range">{scoreRange}</span>
+	</button>
+{:else}
+	<div class="tier-row">
+		<span class="swatch" style:background={tier.color || 'var(--input-bg)'}></span>
+		<span class="name">{tier.name}</span>
+		<span class="slug">{tier.slug}</span>
+		<span class="range">{scoreRange}</span>
+	</div>
+{/if}
+
+<style lang="scss">
+	@use '$src/themes/layout' as layout;
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+
+	.tier-row {
+		display: grid;
+		grid-template-columns: auto 1fr auto auto;
+		align-items: center;
+		gap: spacing.$unit-2x;
+		padding: calc(spacing.$unit * 1.5) spacing.$unit;
+		border: none;
+		background: none;
+		width: 100%;
+		text-align: left;
+		font-family: inherit;
+		color: var(--text-primary);
+
+		.swatch {
+			width: 18px;
+			height: 18px;
+			border-radius: 50%;
+			border: 1px solid var(--border-subtle);
+			flex-shrink: 0;
+		}
+
+		.name {
+			font-size: typography.$font-regular;
+			color: var(--text-primary);
+			font-weight: typography.$medium;
+		}
+
+		.slug {
+			font-size: typography.$font-small;
+			color: var(--text-tertiary);
+			font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		}
+
+		.range {
+			font-size: typography.$font-small;
+			color: var(--text-secondary);
+			font-variant-numeric: tabular-nums;
+			min-width: 80px;
+			text-align: right;
+		}
+
+		&.interactive {
+			cursor: pointer;
+			border-radius: layout.$item-corner;
+			margin-left: -8px;
+			width: calc(100% + 8px);
+
+			&:hover {
+				background: var(--page-hover);
+			}
+		}
+	}
+</style>

--- a/src/lib/features/database/difficulties/TierRow.svelte
+++ b/src/lib/features/database/difficulties/TierRow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { DifficultyTier } from '$lib/types/api/party'
+	import TierIcon from '$lib/features/database/difficulties/TierIcon.svelte'
 
 	interface Props {
 		tier: DifficultyTier
@@ -10,21 +11,41 @@
 
 	const scoreRange = $derived(`${tier.minScore ?? 0}–${tier.maxScore ?? 100}`)
 	const interactive = $derived(!!onclick)
+	const pendingLabel = $derived.by(() => {
+		switch (tier.pendingOperation) {
+			case 'create':
+				return 'New'
+			case 'destroy':
+				return 'Will delete'
+			case 'update':
+				return 'Pending'
+			default:
+				return null
+		}
+	})
 </script>
 
+{#snippet rowContent()}
+	<div class="left">
+		<TierIcon imageKey={tier.imageKey} color={tier.color} name={tier.name} size={28} />
+		<span class="name-info">
+			<span class="name">{tier.name}</span>
+			<span class="slug">{tier.slug}</span>
+		</span>
+		{#if pendingLabel}
+			<span class="pending-pill" data-operation={tier.pendingOperation}>{pendingLabel}</span>
+		{/if}
+	</div>
+	<span class="range">{scoreRange}</span>
+{/snippet}
+
 {#if interactive}
-	<button class="tier-row interactive" {onclick}>
-		<span class="swatch" style:background={tier.color || 'var(--input-bg)'}></span>
-		<span class="name">{tier.name}</span>
-		<span class="slug">{tier.slug}</span>
-		<span class="range">{scoreRange}</span>
+	<button class="tier-row interactive" class:pending={!!pendingLabel} {onclick}>
+		{@render rowContent()}
 	</button>
 {:else}
-	<div class="tier-row">
-		<span class="swatch" style:background={tier.color || 'var(--input-bg)'}></span>
-		<span class="name">{tier.name}</span>
-		<span class="slug">{tier.slug}</span>
-		<span class="range">{scoreRange}</span>
+	<div class="tier-row" class:pending={!!pendingLabel}>
+		{@render rowContent()}
 	</div>
 {/if}
 
@@ -34,8 +55,8 @@
 	@use '$src/themes/typography' as typography;
 
 	.tier-row {
-		display: grid;
-		grid-template-columns: auto 1fr auto auto;
+		display: flex;
+		justify-content: space-between;
 		align-items: center;
 		gap: spacing.$unit-2x;
 		padding: calc(spacing.$unit * 1.5) spacing.$unit;
@@ -46,24 +67,28 @@
 		font-family: inherit;
 		color: var(--text-primary);
 
-		.swatch {
-			width: 18px;
-			height: 18px;
-			border-radius: 50%;
-			border: 1px solid var(--border-subtle);
-			flex-shrink: 0;
+		.left {
+			display: flex;
+			align-items: center;
+			gap: spacing.$unit;
 		}
 
-		.name {
-			font-size: typography.$font-regular;
-			color: var(--text-primary);
-			font-weight: typography.$medium;
-		}
+		.name-info {
+			display: flex;
+			flex-direction: column;
+			gap: spacing.$unit-fourth;
 
-		.slug {
-			font-size: typography.$font-small;
-			color: var(--text-tertiary);
-			font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+			.name {
+				font-size: typography.$font-regular;
+				color: var(--text-primary);
+				font-weight: typography.$medium;
+			}
+
+			.slug {
+				font-size: typography.$font-small;
+				color: var(--text-tertiary);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+			}
 		}
 
 		.range {
@@ -82,6 +107,26 @@
 
 			&:hover {
 				background: var(--page-hover);
+			}
+		}
+
+		.pending-pill {
+			padding: spacing.$unit-fourth spacing.$unit;
+			border-radius: layout.$full-corner;
+			background: var(--notice-yellow-bg);
+			color: var(--notice-yellow-text);
+			font-size: typography.$font-tiny;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+
+			&[data-operation='destroy'] {
+				background: var(--danger-bg-subtle);
+				color: var(--danger);
+			}
+
+			&[data-operation='create'] {
+				background: var(--accent-green, var(--input-bg));
+				color: var(--text-primary);
 			}
 		}
 	}

--- a/src/lib/features/database/difficulties/TierRow.svelte
+++ b/src/lib/features/database/difficulties/TierRow.svelte
@@ -8,7 +8,7 @@
 
 	let { tier, onclick }: Props = $props()
 
-	const scoreRange = $derived(`${tier.min_score ?? 0}–${tier.max_score ?? 100}`)
+	const scoreRange = $derived(`${tier.minScore ?? 0}–${tier.maxScore ?? 100}`)
 	const interactive = $derived(!!onclick)
 </script>
 

--- a/src/lib/features/database/difficulties/constants.ts
+++ b/src/lib/features/database/difficulties/constants.ts
@@ -1,0 +1,22 @@
+import * as m from '$lib/paraglide/messages'
+
+export type DifficultyComponentValue = 'weapon' | 'character' | 'summon' | 'job' | 'accessory'
+
+export interface DifficultyComponentOption {
+	value: DifficultyComponentValue
+	label: string
+}
+
+/**
+ * Component types that rules and components map to. The same five appear
+ * in the RuleModal type picker and the rules-tab filter chips.
+ */
+export function getDifficultyComponentOptions(): DifficultyComponentOption[] {
+	return [
+		{ value: 'weapon', label: m.filter_cat_weapon() },
+		{ value: 'character', label: m.filter_cat_character() },
+		{ value: 'summon', label: m.filter_cat_summon() },
+		{ value: 'job', label: m.difficulty_component_job() },
+		{ value: 'accessory', label: m.difficulty_component_accessory() }
+	]
+}

--- a/src/lib/types/api/party.ts
+++ b/src/lib/types/api/party.ts
@@ -136,13 +136,21 @@ export interface DifficultyTier {
 	description?: string
 	minScore?: number
 	maxScore?: number
+	/** Optional uploaded tier icon. Stored as an S3-style key, e.g. `images/difficulties/<id>.png` */
+	imageKey?: string | null
+	/** Editor-only metadata when the row reflects an unsaved draft */
+	pending?: boolean
+	pendingOperation?: 'create' | 'update' | 'destroy' | null
+	draftId?: string | null
 }
 
-// Embedded difficulty payload on Party
+// Embedded difficulty payload on Party. score/breakdown are null when the
+// party isn't yet scoreable (matches DifficultyPreviewResult on the editor
+// side).
 export interface PartyDifficulty {
 	tier: DifficultyTier | null
-	score: number
-	breakdown: Record<string, unknown>
+	score: number | null
+	breakdown: Record<string, unknown> | null
 	computedAt: string
 }
 

--- a/src/lib/types/api/party.ts
+++ b/src/lib/types/api/party.ts
@@ -132,10 +132,10 @@ export interface DifficultyTier {
 	slug: string
 	name: string
 	color?: string
-	sort_order: number
+	sortOrder: number
 	description?: string
-	min_score?: number
-	max_score?: number
+	minScore?: number
+	maxScore?: number
 }
 
 // Embedded difficulty payload on Party
@@ -143,7 +143,7 @@ export interface PartyDifficulty {
 	tier: DifficultyTier | null
 	score: number
 	breakdown: Record<string, unknown>
-	computed_at: string
+	computedAt: string
 }
 
 // Party from PartyBlueprint

--- a/src/lib/utils/difficulty.ts
+++ b/src/lib/utils/difficulty.ts
@@ -1,0 +1,16 @@
+/**
+ * Difficulty tier icon URL helper.
+ *
+ * Tiers store an S3-style key on the backend (e.g. `images/difficulties/<uuid>.png`,
+ * versioned with `?v=<updated_at>` to bust caches). The public icon URL is built
+ * by joining that key with the configured image base — same pattern as Role icons.
+ */
+
+import { getBasePath } from '$lib/utils/images'
+
+export function getTierIconUrl(imageKey: string | null | undefined): string | null {
+	if (!imageKey) return null
+	const base = getBasePath().replace(/\/$/, '')
+	const path = imageKey.replace(/^images\//, '').replace(/^\//, '')
+	return `${base}/${path}`
+}

--- a/src/routes/(app)/database/difficulties/+page.svelte
+++ b/src/routes/(app)/database/difficulties/+page.svelte
@@ -15,6 +15,7 @@
 	import RuleModal from '$lib/features/database/difficulties/RuleModal.svelte'
 	import ComponentsPanel from '$lib/features/database/difficulties/ComponentsPanel.svelte'
 	import PreviewPanel from '$lib/features/database/difficulties/PreviewPanel.svelte'
+	import { getDifficultyComponentOptions } from '$lib/features/database/difficulties/constants'
 
 	type Tab = 'tiers' | 'rules' | 'components' | 'preview'
 
@@ -57,14 +58,10 @@
 	const filteredRules = $derived(
 		ruleComponentFilter === 'all' ? rules : rules.filter((r) => r.component === ruleComponentFilter)
 	)
-	const componentFilters = [
-		{ value: 'all', label: 'All' },
-		{ value: 'weapon', label: 'Weapon' },
-		{ value: 'character', label: 'Character' },
-		{ value: 'summon', label: 'Summon' },
-		{ value: 'job', label: 'Job' },
-		{ value: 'accessory', label: 'Accessory' }
-	]
+	const componentFilters = $derived([
+		{ value: 'all', label: m.difficulty_component_all() },
+		...getDifficultyComponentOptions()
+	])
 </script>
 
 <PageMeta

--- a/src/routes/(app)/database/difficulties/+page.svelte
+++ b/src/routes/(app)/database/difficulties/+page.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
-	import { createQuery } from '@tanstack/svelte-query'
+	import { onMount } from 'svelte'
+	import { goto } from '$app/navigation'
+	import { page } from '$app/stores'
+	import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query'
+	import { toast } from 'svelte-sonner'
 	import PageMeta from '$lib/components/PageMeta.svelte'
 	import DatabasePageHeader from '$lib/components/database/DatabasePageHeader.svelte'
 	import SegmentedControl from '$lib/components/ui/segmented-control/SegmentedControl.svelte'
 	import Segment from '$lib/components/ui/segmented-control/Segment.svelte'
 	import Button from '$lib/components/ui/Button.svelte'
+	import ConfirmDialog from '$lib/components/ui/ConfirmDialog.svelte'
 	import * as m from '$lib/paraglide/messages'
+	import { difficultyAdapter } from '$lib/api/adapters/difficulty.adapter'
 	import { difficultyQueries } from '$lib/api/queries/difficulty.queries'
+	import { extractErrorMessage } from '$lib/utils/errors'
 	import type { DifficultyTier } from '$lib/types/api/party'
 	import type { DifficultyRule } from '$lib/api/adapters/difficulty.adapter'
 	import TierRow from '$lib/features/database/difficulties/TierRow.svelte'
@@ -15,23 +22,50 @@
 	import RuleModal from '$lib/features/database/difficulties/RuleModal.svelte'
 	import ComponentsPanel from '$lib/features/database/difficulties/ComponentsPanel.svelte'
 	import PreviewPanel from '$lib/features/database/difficulties/PreviewPanel.svelte'
+	import CommitDialog from '$lib/features/database/difficulties/CommitDialog.svelte'
+	import Notice from '$lib/components/ui/Notice.svelte'
 	import { getDifficultyComponentOptions } from '$lib/features/database/difficulties/constants'
 
 	type Tab = 'tiers' | 'rules' | 'components' | 'preview'
 
 	let activeTab = $state<Tab>('tiers')
+	let initialShortcode = $state<string | undefined>(undefined)
 
-	const tiersQuery = createQuery(() => difficultyQueries.tiers())
-	const rulesQuery = createQuery(() => difficultyQueries.rules())
+	const queryClient = useQueryClient()
+
+	const tiersQuery = createQuery(() => difficultyQueries.tiers({ withDrafts: true }))
+	const rulesQuery = createQuery(() => difficultyQueries.rules({ withDrafts: true }))
+	const diffQuery = createQuery(() => difficultyQueries.diff())
 
 	const tiers = $derived(tiersQuery.data ?? [])
 	const rules = $derived(rulesQuery.data ?? [])
+	const pendingCount = $derived(diffQuery.data?.pendingCount ?? 0)
+	const diff = $derived(diffQuery.data?.diff ?? null)
 
 	// Modal state
 	let tierModalOpen = $state(false)
 	let editingTier = $state<DifficultyTier | null>(null)
 	let ruleModalOpen = $state(false)
 	let editingRule = $state<DifficultyRule | null>(null)
+	let commitDialogOpen = $state(false)
+	let confirmDiscardOpen = $state(false)
+
+	const discardMut = createMutation(() => ({
+		mutationFn: () => difficultyAdapter.discardDrafts()
+	}))
+
+	async function handleConfirmDiscard() {
+		try {
+			const { discarded } = await discardMut.mutateAsync()
+			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
+			toast.success(
+				discarded === 1 ? 'Discarded 1 pending change' : `Discarded ${discarded} pending changes`
+			)
+			confirmDiscardOpen = false
+		} catch (err) {
+			toast.error(extractErrorMessage(err, 'Failed to discard drafts'))
+		}
+	}
 
 	function openNewTier() {
 		editingTier = null
@@ -62,6 +96,32 @@
 		{ value: 'all', label: m.difficulty_component_all() },
 		...getDifficultyComponentOptions()
 	])
+
+	const TABS: Tab[] = ['tiers', 'rules', 'components', 'preview']
+
+	onMount(() => {
+		const params = $page.url.searchParams
+		const tabParam = params.get('tab')
+		if (tabParam && (TABS as string[]).includes(tabParam)) {
+			activeTab = tabParam as Tab
+		}
+		const shortcode = params.get('shortcode')
+		if (shortcode) initialShortcode = shortcode
+	})
+
+	$effect(() => {
+		const next = new URL($page.url)
+		// Treat a missing param as the default tab so the effect doesn't loop on first mount.
+		const current = next.searchParams.get('tab') ?? 'tiers'
+		if (current === activeTab) return
+		if (activeTab === 'tiers') next.searchParams.delete('tab')
+		else next.searchParams.set('tab', activeTab)
+		goto(next.pathname + (next.search || ''), {
+			replaceState: true,
+			noScroll: true,
+			keepFocus: true
+		})
+	})
 </script>
 
 <PageMeta
@@ -73,6 +133,26 @@
 	<DatabasePageHeader title={m.party_difficulty_label()}>
 		{#snippet leftAction()}
 			<Button variant="ghost" size="small" leftIcon="chevron-left" href="/database">Back</Button>
+		{/snippet}
+		{#snippet rightAction()}
+			{#if pendingCount > 0}
+				<Button
+					variant="ghost"
+					size="small"
+					onclick={() => (confirmDiscardOpen = true)}
+					disabled={discardMut.isPending}
+				>
+					Discard
+				</Button>
+			{/if}
+			<Button
+				variant="primary"
+				size="small"
+				onclick={() => (commitDialogOpen = true)}
+				disabled={pendingCount === 0}
+			>
+				{pendingCount > 0 ? `Commit (${pendingCount})` : 'Commit'}
+			</Button>
 		{/snippet}
 	</DatabasePageHeader>
 
@@ -89,13 +169,12 @@
 		{#if activeTab === 'tiers'}
 			<section class="section">
 				<header class="section-header">
-					<div>
-						<h2>Tiers</h2>
-						<p class="section-hint">Score ranges that label each party.</p>
-					</div>
-					<Button variant="ghost" size="small" leftIcon="plus" onclick={openNewTier}>
-						New tier
-					</Button>
+					<Notice variant="gray">
+						<p>
+							Define score ranges called tiers that sort parties by how difficult they are to
+							create.
+						</p>
+					</Notice>
 				</header>
 				{#if tiersQuery.isLoading}
 					<p class="empty">Loading tiers…</p>
@@ -107,6 +186,14 @@
 						</Button>
 					</div>
 				{:else}
+					<div class="section-header-row">
+						<div class="section-count">
+							<span class="count">{tiers.length} tier{tiers.length === 1 ? '' : 's'}</span>
+						</div>
+						<Button variant="ghost" contained size="small" leftIcon="plus" onclick={openNewTier}>
+							New tier
+						</Button>
+					</div>
 					<div class="rows">
 						{#each tiers as tier (tier.id)}
 							<TierRow {tier} onclick={() => openEditTier(tier)} />
@@ -117,15 +204,12 @@
 		{:else if activeTab === 'rules'}
 			<section class="section">
 				<header class="section-header">
-					<div>
-						<h2>Rules</h2>
-						<p class="section-hint">
-							Each rule contributes its weight to its component when its condition fires.
+					<Notice variant="gray">
+						<p>
+							Define rules that contribute to the score of each component. Each rule contributes its
+							weight to its component when its condition fires.
 						</p>
-					</div>
-					<Button variant="ghost" size="small" leftIcon="plus" onclick={openNewRule}>
-						New rule
-					</Button>
+					</Notice>
 				</header>
 
 				<div class="filter-bar">
@@ -134,9 +218,6 @@
 							<Segment value={f.value}>{f.label}</Segment>
 						{/each}
 					</SegmentedControl>
-					<span class="filter-count">
-						{filteredRules.length} rule{filteredRules.length === 1 ? '' : 's'}
-					</span>
 				</div>
 
 				{#if rulesQuery.isLoading}
@@ -146,6 +227,14 @@
 						<p>No rules match this filter.</p>
 					</div>
 				{:else}
+					<div class="section-header-row">
+						<span class="filter-count">
+							{filteredRules.length} match{filteredRules.length === 1 ? '' : 'es'}
+						</span>
+						<Button variant="ghost" contained size="small" leftIcon="plus" onclick={openNewRule}>
+							New rule
+						</Button>
+					</div>
 					<div class="rows">
 						{#each filteredRules as rule (rule.id)}
 							<RuleRow {rule} onclick={() => openEditRule(rule)} />
@@ -156,25 +245,29 @@
 		{:else if activeTab === 'components'}
 			<section class="section">
 				<header class="section-header">
-					<div>
-						<h2>Components</h2>
-						<p class="section-hint">
-							Per-component weight, scoreability threshold, and on/off switch. Components are
-							seeded; you can tune their values but cannot create or destroy them.
+					<Notice variant="gray">
+						<p>
+							Define per-component weight, scoreability threshold, and on/off switch. Components are
+							used to score parties and are defined in the API.
 						</p>
-					</div>
+						<p>
+							Components are seeded; you can tune their values but cannot create or destroy them.
+						</p>
+					</Notice>
 				</header>
 				<ComponentsPanel />
 			</section>
 		{:else}
 			<section class="section">
 				<header class="section-header">
-					<div>
-						<h2>Preview</h2>
-						<p class="section-hint">Test the current ruleset against any party by shortcode.</p>
-					</div>
+					<Notice variant="gray">
+						<p>
+							Use this tool to test the current ruleset against any party by shortcode. Changes
+							won't persist until you Commit them using the button at the top.
+						</p>
+					</Notice>
 				</header>
-				<PreviewPanel />
+				<PreviewPanel {initialShortcode} />
 			</section>
 		{/if}
 	</div>
@@ -182,6 +275,18 @@
 
 <TierModal bind:open={tierModalOpen} tier={editingTier} />
 <RuleModal bind:open={ruleModalOpen} rule={editingRule} />
+<CommitDialog bind:open={commitDialogOpen} {diff} />
+
+<ConfirmDialog
+	bind:open={confirmDiscardOpen}
+	title="Discard pending changes?"
+	message={pendingCount === 1
+		? '1 pending change will be discarded. This cannot be undone.'
+		: `${pendingCount} pending changes will be discarded. This cannot be undone.`}
+	confirmLabel="Discard"
+	loading={discardMut.isPending}
+	onconfirm={handleConfirmDiscard}
+/>
 
 <style lang="scss">
 	@use '$src/themes/spacing' as spacing;
@@ -215,8 +320,7 @@
 
 	.section-header {
 		display: flex;
-		justify-content: space-between;
-		align-items: flex-start;
+		flex-direction: column;
 		gap: spacing.$unit;
 
 		h2 {
@@ -227,11 +331,33 @@
 		}
 	}
 
+	.section-header-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: spacing.$unit;
+
+		.section-count {
+			font-size: typography.$font-regular;
+			color: var(--text-secondary);
+		}
+	}
+
 	.section-hint {
-		margin: spacing.$unit-half 0 0 0;
-		color: var(--text-secondary);
-		font-size: typography.$font-small;
-		max-width: 60ch;
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+		background: var(--notice-bg);
+		padding: spacing.$unit-2x;
+		border-radius: layout.$card-corner;
+		width: 100%;
+
+		p {
+			color: var(--notice-text);
+			font-size: typography.$font-regular;
+			line-height: 1.5;
+			margin: 0;
+		}
 	}
 
 	.filter-bar {

--- a/src/routes/(app)/database/difficulties/+page.svelte
+++ b/src/routes/(app)/database/difficulties/+page.svelte
@@ -75,9 +75,7 @@
 <div class="page">
 	<DatabasePageHeader title={m.party_difficulty_label()}>
 		{#snippet leftAction()}
-			<Button variant="ghost" size="small" leftIcon="chevron-left" href="/database/weapons">
-				Back
-			</Button>
+			<Button variant="ghost" size="small" leftIcon="chevron-left" href="/database">Back</Button>
 		{/snippet}
 	</DatabasePageHeader>
 

--- a/src/routes/(app)/database/difficulties/+page.svelte
+++ b/src/routes/(app)/database/difficulties/+page.svelte
@@ -1,0 +1,700 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages'
+	import PageMeta from '$lib/components/PageMeta.svelte'
+	import Button from '$lib/components/ui/Button.svelte'
+	import Input from '$lib/components/ui/Input.svelte'
+	import Switch from '$lib/components/ui/switch/Switch.svelte'
+	import { createQuery, createMutation, useQueryClient } from '@tanstack/svelte-query'
+	import { difficultyQueries } from '$lib/api/queries/difficulty.queries'
+	import {
+		difficultyAdapter,
+		type DifficultyComponent,
+		type DifficultyRule,
+		type DifficultyPreviewResult
+	} from '$lib/api/adapters/difficulty.adapter'
+	import type { DifficultyTier } from '$lib/types/api/party'
+
+	type Tab = 'tiers' | 'rules' | 'components'
+	let activeTab = $state<Tab>('tiers')
+
+	const client = useQueryClient()
+
+	const tiersQuery = createQuery(() => difficultyQueries.tiers())
+	const componentsQuery = createQuery(() => difficultyQueries.components())
+	const rulesQuery = createQuery(() => difficultyQueries.rules())
+	const ruleTypesQuery = createQuery(() => difficultyQueries.ruleTypes())
+
+	const tiers = $derived(tiersQuery.data ?? [])
+	const components = $derived(componentsQuery.data ?? [])
+	const rules = $derived(rulesQuery.data ?? [])
+	const ruleTypes = $derived(ruleTypesQuery.data?.types ?? [])
+
+	function invalidate(scope: 'tiers' | 'components' | 'rules') {
+		const key = scope === 'tiers' ? ['difficulties', 'tiers'] : ['difficulties', scope]
+		client.invalidateQueries({ queryKey: key })
+	}
+
+	// ============ Tier mutations ============
+	const updateTier = createMutation(() => ({
+		mutationFn: (input: { id: string; data: Partial<DifficultyTier> }) =>
+			difficultyAdapter.updateTier(input.id, input.data),
+		onSuccess: () => invalidate('tiers')
+	}))
+	const createTier = createMutation(() => ({
+		mutationFn: (data: Partial<DifficultyTier>) => difficultyAdapter.createTier(data),
+		onSuccess: () => {
+			invalidate('tiers')
+			newTier = freshTier()
+		}
+	}))
+	const deleteTier = createMutation(() => ({
+		mutationFn: (id: string) => difficultyAdapter.deleteTier(id),
+		onSuccess: () => invalidate('tiers')
+	}))
+
+	// ============ Component mutations ============
+	const updateComponent = createMutation(() => ({
+		mutationFn: (input: { id: string; data: Partial<DifficultyComponent> }) =>
+			difficultyAdapter.updateComponent(input.id, input.data),
+		onSuccess: () => invalidate('components')
+	}))
+
+	// ============ Rule mutations ============
+	const updateRule = createMutation(() => ({
+		mutationFn: (input: { id: string; data: Partial<DifficultyRule> }) =>
+			difficultyAdapter.updateRule(input.id, input.data),
+		onSuccess: () => invalidate('rules')
+	}))
+	const createRule = createMutation(() => ({
+		mutationFn: (data: Partial<DifficultyRule>) => difficultyAdapter.createRule(data),
+		onSuccess: () => {
+			invalidate('rules')
+			newRule = freshRule()
+		}
+	}))
+	const deleteRule = createMutation(() => ({
+		mutationFn: (id: string) => difficultyAdapter.deleteRule(id),
+		onSuccess: () => invalidate('rules')
+	}))
+
+	// ============ Preview ============
+	let previewShortcode = $state('')
+	let previewResult = $state<DifficultyPreviewResult | null>(null)
+	let previewError = $state('')
+	let previewLoading = $state(false)
+
+	async function runPreview() {
+		previewError = ''
+		previewLoading = true
+		previewResult = null
+		try {
+			previewResult = await difficultyAdapter.preview(previewShortcode.trim())
+		} catch (err) {
+			previewError = err instanceof Error ? err.message : 'Preview failed'
+		} finally {
+			previewLoading = false
+		}
+	}
+
+	// ============ New-tier form ============
+	function freshTier(): Partial<DifficultyTier> {
+		return { name: '', slug: '', color: '#86C5A8', min_score: 0, max_score: 100, sort_order: 0 }
+	}
+	let newTier = $state<Partial<DifficultyTier>>(freshTier())
+
+	// ============ New-rule form ============
+	function freshRule(): Partial<DifficultyRule> {
+		return {
+			name: '',
+			component: 'weapon',
+			rule_type: '',
+			weight: 1,
+			active: true,
+			params: {}
+		}
+	}
+	let newRule = $state<Partial<DifficultyRule>>(freshRule())
+	let newRuleParamsRaw = $state('{}')
+
+	function setRuleParamsFromString() {
+		try {
+			newRule.params = JSON.parse(newRuleParamsRaw || '{}')
+			return true
+		} catch {
+			return false
+		}
+	}
+
+	// Per-rule edit state — track which rule is being edited and the working JSON for params
+	let editingRuleId = $state<string | null>(null)
+	let editingParamsRaw = $state('{}')
+</script>
+
+<PageMeta
+	title="Difficulties — Database"
+	description="Manage party difficulty tiers, rules, and components."
+/>
+
+<div class="page">
+	<header class="page-header">
+		<h1>{m.party_difficulty_label()}</h1>
+	</header>
+
+	<nav class="tabs">
+		<button class:active={activeTab === 'tiers'} onclick={() => (activeTab = 'tiers')}>Tiers</button
+		>
+		<button class:active={activeTab === 'rules'} onclick={() => (activeTab = 'rules')}>Rules</button
+		>
+		<button class:active={activeTab === 'components'} onclick={() => (activeTab = 'components')}>
+			Components
+		</button>
+	</nav>
+
+	<div class="content">
+		<section class="main">
+			{#if activeTab === 'tiers'}
+				<h2>Tiers</h2>
+				<table>
+					<thead>
+						<tr>
+							<th>Name</th>
+							<th>Slug</th>
+							<th>Color</th>
+							<th>Min</th>
+							<th>Max</th>
+							<th>Sort</th>
+							<th></th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each tiers as tier (tier.id)}
+							<tr>
+								<td
+									><input
+										value={tier.name}
+										oninput={(e) => (tier.name = e.currentTarget.value)}
+									/></td
+								>
+								<td
+									><input
+										value={tier.slug}
+										oninput={(e) => (tier.slug = e.currentTarget.value)}
+									/></td
+								>
+								<td>
+									<input
+										type="color"
+										value={tier.color ?? '#cccccc'}
+										oninput={(e) => (tier.color = e.currentTarget.value)}
+									/>
+								</td>
+								<td>
+									<input
+										type="number"
+										step="0.01"
+										value={tier.min_score}
+										oninput={(e) => (tier.min_score = parseFloat(e.currentTarget.value))}
+									/>
+								</td>
+								<td>
+									<input
+										type="number"
+										step="0.01"
+										value={tier.max_score}
+										oninput={(e) => (tier.max_score = parseFloat(e.currentTarget.value))}
+									/>
+								</td>
+								<td>
+									<input
+										type="number"
+										value={tier.sort_order}
+										oninput={(e) => (tier.sort_order = parseInt(e.currentTarget.value, 10))}
+									/>
+								</td>
+								<td class="actions">
+									<Button
+										size="small"
+										onclick={() =>
+											updateTier.mutate({
+												id: tier.id,
+												data: {
+													name: tier.name,
+													slug: tier.slug,
+													color: tier.color,
+													min_score: tier.min_score,
+													max_score: tier.max_score,
+													sort_order: tier.sort_order
+												}
+											})}
+									>
+										Save
+									</Button>
+									<Button
+										size="small"
+										variant="destructive"
+										onclick={() => {
+											if (confirm(`Delete tier "${tier.name}"?`)) deleteTier.mutate(tier.id)
+										}}
+									>
+										Delete
+									</Button>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+
+				<h3>New tier</h3>
+				<div class="new-row">
+					<input placeholder="Name" bind:value={newTier.name} />
+					<input placeholder="Slug" bind:value={newTier.slug} />
+					<input type="color" bind:value={newTier.color} />
+					<input type="number" placeholder="Min" bind:value={newTier.min_score} />
+					<input type="number" placeholder="Max" bind:value={newTier.max_score} />
+					<input type="number" placeholder="Sort" bind:value={newTier.sort_order} />
+					<Button onclick={() => createTier.mutate(newTier)}>Create</Button>
+				</div>
+			{:else if activeTab === 'components'}
+				<h2>Components</h2>
+				<p class="hint">
+					Per-component weights and minimum item counts. Components are seeded; you can adjust their
+					weights but cannot create/destroy them.
+				</p>
+				<table>
+					<thead>
+						<tr>
+							<th>Name</th>
+							<th>Weight</th>
+							<th>Min items</th>
+							<th>Enabled</th>
+							<th></th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each components as comp (comp.id)}
+							<tr>
+								<td><strong>{comp.name}</strong></td>
+								<td>
+									<input
+										type="number"
+										step="0.1"
+										value={comp.weight}
+										oninput={(e) => (comp.weight = parseFloat(e.currentTarget.value))}
+									/>
+								</td>
+								<td>
+									<input
+										type="number"
+										value={comp.min_count_to_score}
+										oninput={(e) => (comp.min_count_to_score = parseInt(e.currentTarget.value, 10))}
+									/>
+								</td>
+								<td>
+									<Switch checked={comp.enabled} onCheckedChange={(v) => (comp.enabled = v)} />
+								</td>
+								<td>
+									<Button
+										size="small"
+										onclick={() =>
+											updateComponent.mutate({
+												id: comp.id,
+												data: {
+													weight: comp.weight,
+													min_count_to_score: comp.min_count_to_score,
+													enabled: comp.enabled
+												}
+											})}
+									>
+										Save
+									</Button>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			{:else}
+				<h2>Rules</h2>
+				<p class="hint">
+					Each rule contributes its weight to the relevant component sub-score when it fires. Edit
+					params as JSON; available rule types are listed below.
+				</p>
+
+				<table>
+					<thead>
+						<tr>
+							<th>Name</th>
+							<th>Component</th>
+							<th>Rule type</th>
+							<th>Weight</th>
+							<th>Active</th>
+							<th>Params</th>
+							<th></th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each rules as rule (rule.id)}
+							<tr>
+								<td
+									><input
+										value={rule.name}
+										oninput={(e) => (rule.name = e.currentTarget.value)}
+									/></td
+								>
+								<td>{rule.component}</td>
+								<td>{rule.rule_type}</td>
+								<td>
+									<input
+										type="number"
+										step="0.1"
+										value={rule.weight}
+										oninput={(e) => (rule.weight = parseFloat(e.currentTarget.value))}
+									/>
+								</td>
+								<td>
+									<Switch checked={rule.active} onCheckedChange={(v) => (rule.active = v)} />
+								</td>
+								<td>
+									{#if editingRuleId === rule.id}
+										<textarea
+											rows="3"
+											value={editingParamsRaw}
+											oninput={(e) => (editingParamsRaw = e.currentTarget.value)}
+										></textarea>
+									{:else}
+										<button
+											class="link"
+											onclick={() => {
+												editingRuleId = rule.id
+												editingParamsRaw = JSON.stringify(rule.params, null, 2)
+											}}
+										>
+											Edit
+										</button>
+										<code class="params-summary">{JSON.stringify(rule.params)}</code>
+									{/if}
+								</td>
+								<td class="actions">
+									<Button
+										size="small"
+										onclick={() => {
+											const data: Partial<DifficultyRule> = {
+												name: rule.name,
+												weight: rule.weight,
+												active: rule.active
+											}
+											if (editingRuleId === rule.id) {
+												try {
+													data.params = JSON.parse(editingParamsRaw || '{}')
+												} catch {
+													alert('Invalid JSON in params')
+													return
+												}
+												editingRuleId = null
+											}
+											updateRule.mutate({ id: rule.id, data })
+										}}
+									>
+										Save
+									</Button>
+									<Button
+										size="small"
+										variant="destructive"
+										onclick={() => {
+											if (confirm(`Delete rule "${rule.name}"?`)) deleteRule.mutate(rule.id)
+										}}
+									>
+										Delete
+									</Button>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+
+				<h3>New rule</h3>
+				<div class="new-rule">
+					<label>
+						Name
+						<input bind:value={newRule.name} />
+					</label>
+					<label>
+						Component
+						<select bind:value={newRule.component}>
+							<option value="weapon">weapon</option>
+							<option value="character">character</option>
+							<option value="summon">summon</option>
+							<option value="job">job</option>
+							<option value="accessory">accessory</option>
+						</select>
+					</label>
+					<label>
+						Rule type
+						<select bind:value={newRule.rule_type}>
+							<option value="">— select —</option>
+							{#each ruleTypes as t (t)}
+								<option value={t}>{t}</option>
+							{/each}
+						</select>
+					</label>
+					<label>
+						Weight
+						<input type="number" step="0.1" bind:value={newRule.weight} />
+					</label>
+					<label>
+						Params (JSON)
+						<textarea rows="4" bind:value={newRuleParamsRaw}></textarea>
+					</label>
+					<Button
+						onclick={() => {
+							if (!setRuleParamsFromString()) {
+								alert('Invalid JSON in params')
+								return
+							}
+							createRule.mutate(newRule)
+						}}
+					>
+						Create rule
+					</Button>
+				</div>
+			{/if}
+		</section>
+
+		<aside class="preview">
+			<h2>Preview</h2>
+			<p class="hint">
+				Score a party against the current ruleset without persisting. Helpful when tuning weights or
+				testing new rules.
+			</p>
+			<Input bind:value={previewShortcode} placeholder="Party shortcode" />
+			<Button onclick={runPreview} disabled={!previewShortcode.trim() || previewLoading}>
+				{previewLoading ? 'Loading…' : 'Run preview'}
+			</Button>
+
+			{#if previewError}
+				<p class="error">{previewError}</p>
+			{/if}
+
+			{#if previewResult}
+				<div class="preview-result">
+					{#if !previewResult.scoreable}
+						<p class="warn">Party isn't scoreable yet (below the minimum item threshold).</p>
+					{:else}
+						<p>
+							<strong>{previewResult.tier?.name ?? '—'}</strong>
+							<span class="score">{previewResult.score?.toFixed(2) ?? '0'}</span>
+						</p>
+						<p class="muted">Ruleset version: {previewResult.ruleset_version}</p>
+						{#if previewResult.breakdown}
+							<details>
+								<summary>Breakdown</summary>
+								<pre>{JSON.stringify(previewResult.breakdown, null, 2)}</pre>
+							</details>
+						{/if}
+					{/if}
+				</div>
+			{/if}
+		</aside>
+	</div>
+</div>
+
+<style lang="scss">
+	@use '$src/themes/spacing' as *;
+	@use '$src/themes/typography' as *;
+	@use '$src/themes/layout' as *;
+
+	.page {
+		padding: $unit-2x;
+		display: flex;
+		flex-direction: column;
+		gap: $unit-2x;
+	}
+
+	.page-header h1 {
+		font-size: $font-large;
+		font-weight: $bold;
+	}
+
+	.tabs {
+		display: flex;
+		gap: $unit;
+		border-bottom: 1px solid var(--border-color);
+
+		button {
+			padding: $unit $unit-2x;
+			background: transparent;
+			border: none;
+			border-bottom: 2px solid transparent;
+			font: inherit;
+			color: var(--text-secondary);
+			cursor: pointer;
+
+			&.active {
+				color: var(--text-primary);
+				border-bottom-color: var(--text-primary);
+			}
+		}
+	}
+
+	.content {
+		display: grid;
+		grid-template-columns: 1fr 320px;
+		gap: $unit-2x;
+
+		@media (max-width: 1024px) {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.main h2 {
+		margin-top: 0;
+		margin-bottom: $unit;
+	}
+
+	.main h3 {
+		margin-top: $unit-2x;
+		margin-bottom: $unit;
+	}
+
+	.hint {
+		color: var(--text-secondary);
+		margin-bottom: $unit-2x;
+		font-size: $font-small;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+
+		th,
+		td {
+			text-align: left;
+			padding: $unit-half $unit;
+			border-bottom: 1px solid var(--border-color);
+			font-size: $font-small;
+			vertical-align: middle;
+		}
+
+		input,
+		textarea,
+		select {
+			width: 100%;
+			padding: $unit-half;
+			border: 1px solid var(--border-color);
+			border-radius: $item-corner-small;
+			background: var(--input-bg);
+			color: var(--text-primary);
+			font: inherit;
+		}
+
+		input[type='number'] {
+			width: 80px;
+		}
+
+		.actions {
+			display: flex;
+			gap: $unit-half;
+			white-space: nowrap;
+		}
+
+		.params-summary {
+			display: block;
+			max-width: 320px;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			color: var(--text-secondary);
+			font-size: 0.75em;
+		}
+
+		.link {
+			background: transparent;
+			border: none;
+			color: var(--accent-color, #4a90e2);
+			cursor: pointer;
+			padding: 0;
+			margin-right: $unit;
+		}
+	}
+
+	.new-row {
+		display: flex;
+		gap: $unit;
+		align-items: center;
+		flex-wrap: wrap;
+
+		input {
+			padding: $unit-half;
+			border: 1px solid var(--border-color);
+			border-radius: $item-corner-small;
+			background: var(--input-bg);
+		}
+	}
+
+	.new-rule {
+		display: flex;
+		flex-direction: column;
+		gap: $unit;
+		max-width: 600px;
+
+		label {
+			display: flex;
+			flex-direction: column;
+			gap: $unit-half;
+			font-size: $font-small;
+
+			input,
+			select,
+			textarea {
+				padding: $unit-half;
+				border: 1px solid var(--border-color);
+				border-radius: $item-corner-small;
+				background: var(--input-bg);
+				color: var(--text-primary);
+				font: inherit;
+			}
+		}
+	}
+
+	.preview {
+		display: flex;
+		flex-direction: column;
+		gap: $unit;
+		padding: $unit-2x;
+		background: var(--card-bg);
+		border-radius: $card-corner;
+		align-self: start;
+
+		h2 {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
+	}
+
+	.preview-result {
+		.score {
+			margin-left: $unit;
+			color: var(--text-secondary);
+		}
+
+		pre {
+			background: var(--input-bg);
+			padding: $unit;
+			border-radius: $item-corner-small;
+			overflow-x: auto;
+			font-size: 0.75em;
+		}
+	}
+
+	.warn {
+		color: var(--warning-text, #b86b00);
+	}
+
+	.error {
+		color: var(--error-text, #b00020);
+	}
+
+	.muted {
+		color: var(--text-secondary);
+		font-size: $font-small;
+	}
+</style>

--- a/src/routes/(app)/database/difficulties/+page.svelte
+++ b/src/routes/(app)/database/difficulties/+page.svelte
@@ -1,133 +1,70 @@
 <script lang="ts">
-	import * as m from '$lib/paraglide/messages'
+	import { createQuery } from '@tanstack/svelte-query'
 	import PageMeta from '$lib/components/PageMeta.svelte'
+	import DatabasePageHeader from '$lib/components/database/DatabasePageHeader.svelte'
+	import SegmentedControl from '$lib/components/ui/segmented-control/SegmentedControl.svelte'
+	import Segment from '$lib/components/ui/segmented-control/Segment.svelte'
 	import Button from '$lib/components/ui/Button.svelte'
-	import Input from '$lib/components/ui/Input.svelte'
-	import Switch from '$lib/components/ui/switch/Switch.svelte'
-	import { createQuery, createMutation, useQueryClient } from '@tanstack/svelte-query'
+	import * as m from '$lib/paraglide/messages'
 	import { difficultyQueries } from '$lib/api/queries/difficulty.queries'
-	import {
-		difficultyAdapter,
-		type DifficultyComponent,
-		type DifficultyRule,
-		type DifficultyPreviewResult
-	} from '$lib/api/adapters/difficulty.adapter'
 	import type { DifficultyTier } from '$lib/types/api/party'
+	import type { DifficultyRule } from '$lib/api/adapters/difficulty.adapter'
+	import TierRow from '$lib/features/database/difficulties/TierRow.svelte'
+	import TierModal from '$lib/features/database/difficulties/TierModal.svelte'
+	import RuleRow from '$lib/features/database/difficulties/RuleRow.svelte'
+	import RuleModal from '$lib/features/database/difficulties/RuleModal.svelte'
+	import ComponentsPanel from '$lib/features/database/difficulties/ComponentsPanel.svelte'
+	import PreviewPanel from '$lib/features/database/difficulties/PreviewPanel.svelte'
 
-	type Tab = 'tiers' | 'rules' | 'components'
+	type Tab = 'tiers' | 'rules' | 'components' | 'preview'
+
 	let activeTab = $state<Tab>('tiers')
 
-	const client = useQueryClient()
-
 	const tiersQuery = createQuery(() => difficultyQueries.tiers())
-	const componentsQuery = createQuery(() => difficultyQueries.components())
 	const rulesQuery = createQuery(() => difficultyQueries.rules())
-	const ruleTypesQuery = createQuery(() => difficultyQueries.ruleTypes())
 
 	const tiers = $derived(tiersQuery.data ?? [])
-	const components = $derived(componentsQuery.data ?? [])
 	const rules = $derived(rulesQuery.data ?? [])
-	const ruleTypes = $derived(ruleTypesQuery.data?.types ?? [])
 
-	function invalidate(scope: 'tiers' | 'components' | 'rules') {
-		const key = scope === 'tiers' ? ['difficulties', 'tiers'] : ['difficulties', scope]
-		client.invalidateQueries({ queryKey: key })
+	// Modal state
+	let tierModalOpen = $state(false)
+	let editingTier = $state<DifficultyTier | null>(null)
+	let ruleModalOpen = $state(false)
+	let editingRule = $state<DifficultyRule | null>(null)
+
+	function openNewTier() {
+		editingTier = null
+		tierModalOpen = true
 	}
 
-	// ============ Tier mutations ============
-	const updateTier = createMutation(() => ({
-		mutationFn: (input: { id: string; data: Partial<DifficultyTier> }) =>
-			difficultyAdapter.updateTier(input.id, input.data),
-		onSuccess: () => invalidate('tiers')
-	}))
-	const createTier = createMutation(() => ({
-		mutationFn: (data: Partial<DifficultyTier>) => difficultyAdapter.createTier(data),
-		onSuccess: () => {
-			invalidate('tiers')
-			newTier = freshTier()
-		}
-	}))
-	const deleteTier = createMutation(() => ({
-		mutationFn: (id: string) => difficultyAdapter.deleteTier(id),
-		onSuccess: () => invalidate('tiers')
-	}))
-
-	// ============ Component mutations ============
-	const updateComponent = createMutation(() => ({
-		mutationFn: (input: { id: string; data: Partial<DifficultyComponent> }) =>
-			difficultyAdapter.updateComponent(input.id, input.data),
-		onSuccess: () => invalidate('components')
-	}))
-
-	// ============ Rule mutations ============
-	const updateRule = createMutation(() => ({
-		mutationFn: (input: { id: string; data: Partial<DifficultyRule> }) =>
-			difficultyAdapter.updateRule(input.id, input.data),
-		onSuccess: () => invalidate('rules')
-	}))
-	const createRule = createMutation(() => ({
-		mutationFn: (data: Partial<DifficultyRule>) => difficultyAdapter.createRule(data),
-		onSuccess: () => {
-			invalidate('rules')
-			newRule = freshRule()
-		}
-	}))
-	const deleteRule = createMutation(() => ({
-		mutationFn: (id: string) => difficultyAdapter.deleteRule(id),
-		onSuccess: () => invalidate('rules')
-	}))
-
-	// ============ Preview ============
-	let previewShortcode = $state('')
-	let previewResult = $state<DifficultyPreviewResult | null>(null)
-	let previewError = $state('')
-	let previewLoading = $state(false)
-
-	async function runPreview() {
-		previewError = ''
-		previewLoading = true
-		previewResult = null
-		try {
-			previewResult = await difficultyAdapter.preview(previewShortcode.trim())
-		} catch (err) {
-			previewError = err instanceof Error ? err.message : 'Preview failed'
-		} finally {
-			previewLoading = false
-		}
+	function openEditTier(tier: DifficultyTier) {
+		editingTier = tier
+		tierModalOpen = true
 	}
 
-	// ============ New-tier form ============
-	function freshTier(): Partial<DifficultyTier> {
-		return { name: '', slug: '', color: '#86C5A8', min_score: 0, max_score: 100, sort_order: 0 }
-	}
-	let newTier = $state<Partial<DifficultyTier>>(freshTier())
-
-	// ============ New-rule form ============
-	function freshRule(): Partial<DifficultyRule> {
-		return {
-			name: '',
-			component: 'weapon',
-			rule_type: '',
-			weight: 1,
-			active: true,
-			params: {}
-		}
-	}
-	let newRule = $state<Partial<DifficultyRule>>(freshRule())
-	let newRuleParamsRaw = $state('{}')
-
-	function setRuleParamsFromString() {
-		try {
-			newRule.params = JSON.parse(newRuleParamsRaw || '{}')
-			return true
-		} catch {
-			return false
-		}
+	function openNewRule() {
+		editingRule = null
+		ruleModalOpen = true
 	}
 
-	// Per-rule edit state — track which rule is being edited and the working JSON for params
-	let editingRuleId = $state<string | null>(null)
-	let editingParamsRaw = $state('{}')
+	function openEditRule(rule: DifficultyRule) {
+		editingRule = rule
+		ruleModalOpen = true
+	}
+
+	// Filter chips for the rules list
+	let ruleComponentFilter = $state<string>('all')
+	const filteredRules = $derived(
+		ruleComponentFilter === 'all' ? rules : rules.filter((r) => r.component === ruleComponentFilter)
+	)
+	const componentFilters = [
+		{ value: 'all', label: 'All' },
+		{ value: 'weapon', label: 'Weapon' },
+		{ value: 'character', label: 'Character' },
+		{ value: 'summon', label: 'Summon' },
+		{ value: 'job', label: 'Job' },
+		{ value: 'accessory', label: 'Accessory' }
+	]
 </script>
 
 <PageMeta
@@ -136,565 +73,206 @@
 />
 
 <div class="page">
-	<header class="page-header">
-		<h1>{m.party_difficulty_label()}</h1>
-	</header>
+	<DatabasePageHeader title={m.party_difficulty_label()}>
+		{#snippet leftAction()}
+			<Button variant="ghost" size="small" leftIcon="chevron-left" href="/database/weapons">
+				Back
+			</Button>
+		{/snippet}
+	</DatabasePageHeader>
 
-	<nav class="tabs">
-		<button class:active={activeTab === 'tiers'} onclick={() => (activeTab = 'tiers')}>Tiers</button
-		>
-		<button class:active={activeTab === 'rules'} onclick={() => (activeTab = 'rules')}>Rules</button
-		>
-		<button class:active={activeTab === 'components'} onclick={() => (activeTab = 'components')}>
-			Components
-		</button>
-	</nav>
+	<div class="tab-bar">
+		<SegmentedControl bind:value={activeTab} size="small" variant="background">
+			<Segment value="tiers">Tiers</Segment>
+			<Segment value="rules">Rules</Segment>
+			<Segment value="components">Components</Segment>
+			<Segment value="preview">Preview</Segment>
+		</SegmentedControl>
+	</div>
 
 	<div class="content">
-		<section class="main">
-			{#if activeTab === 'tiers'}
-				<h2>Tiers</h2>
-				<table>
-					<thead>
-						<tr>
-							<th>Name</th>
-							<th>Slug</th>
-							<th>Color</th>
-							<th>Min</th>
-							<th>Max</th>
-							<th>Sort</th>
-							<th></th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each tiers as tier (tier.id)}
-							<tr>
-								<td
-									><input
-										value={tier.name}
-										oninput={(e) => (tier.name = e.currentTarget.value)}
-									/></td
-								>
-								<td
-									><input
-										value={tier.slug}
-										oninput={(e) => (tier.slug = e.currentTarget.value)}
-									/></td
-								>
-								<td>
-									<input
-										type="color"
-										value={tier.color ?? '#cccccc'}
-										oninput={(e) => (tier.color = e.currentTarget.value)}
-									/>
-								</td>
-								<td>
-									<input
-										type="number"
-										step="0.01"
-										value={tier.min_score}
-										oninput={(e) => (tier.min_score = parseFloat(e.currentTarget.value))}
-									/>
-								</td>
-								<td>
-									<input
-										type="number"
-										step="0.01"
-										value={tier.max_score}
-										oninput={(e) => (tier.max_score = parseFloat(e.currentTarget.value))}
-									/>
-								</td>
-								<td>
-									<input
-										type="number"
-										value={tier.sort_order}
-										oninput={(e) => (tier.sort_order = parseInt(e.currentTarget.value, 10))}
-									/>
-								</td>
-								<td class="actions">
-									<Button
-										size="small"
-										onclick={() =>
-											updateTier.mutate({
-												id: tier.id,
-												data: {
-													name: tier.name,
-													slug: tier.slug,
-													color: tier.color,
-													min_score: tier.min_score,
-													max_score: tier.max_score,
-													sort_order: tier.sort_order
-												}
-											})}
-									>
-										Save
-									</Button>
-									<Button
-										size="small"
-										variant="destructive"
-										onclick={() => {
-											if (confirm(`Delete tier "${tier.name}"?`)) deleteTier.mutate(tier.id)
-										}}
-									>
-										Delete
-									</Button>
-								</td>
-							</tr>
-						{/each}
-					</tbody>
-				</table>
-
-				<h3>New tier</h3>
-				<div class="new-row">
-					<input placeholder="Name" bind:value={newTier.name} />
-					<input placeholder="Slug" bind:value={newTier.slug} />
-					<input type="color" bind:value={newTier.color} />
-					<input type="number" placeholder="Min" bind:value={newTier.min_score} />
-					<input type="number" placeholder="Max" bind:value={newTier.max_score} />
-					<input type="number" placeholder="Sort" bind:value={newTier.sort_order} />
-					<Button onclick={() => createTier.mutate(newTier)}>Create</Button>
-				</div>
-			{:else if activeTab === 'components'}
-				<h2>Components</h2>
-				<p class="hint">
-					Per-component weights and minimum item counts. Components are seeded; you can adjust their
-					weights but cannot create/destroy them.
-				</p>
-				<table>
-					<thead>
-						<tr>
-							<th>Name</th>
-							<th>Weight</th>
-							<th>Min items</th>
-							<th>Enabled</th>
-							<th></th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each components as comp (comp.id)}
-							<tr>
-								<td><strong>{comp.name}</strong></td>
-								<td>
-									<input
-										type="number"
-										step="0.1"
-										value={comp.weight}
-										oninput={(e) => (comp.weight = parseFloat(e.currentTarget.value))}
-									/>
-								</td>
-								<td>
-									<input
-										type="number"
-										value={comp.min_count_to_score}
-										oninput={(e) => (comp.min_count_to_score = parseInt(e.currentTarget.value, 10))}
-									/>
-								</td>
-								<td>
-									<Switch checked={comp.enabled} onCheckedChange={(v) => (comp.enabled = v)} />
-								</td>
-								<td>
-									<Button
-										size="small"
-										onclick={() =>
-											updateComponent.mutate({
-												id: comp.id,
-												data: {
-													weight: comp.weight,
-													min_count_to_score: comp.min_count_to_score,
-													enabled: comp.enabled
-												}
-											})}
-									>
-										Save
-									</Button>
-								</td>
-							</tr>
-						{/each}
-					</tbody>
-				</table>
-			{:else}
-				<h2>Rules</h2>
-				<p class="hint">
-					Each rule contributes its weight to the relevant component sub-score when it fires. Edit
-					params as JSON; available rule types are listed below.
-				</p>
-
-				<table>
-					<thead>
-						<tr>
-							<th>Name</th>
-							<th>Component</th>
-							<th>Rule type</th>
-							<th>Weight</th>
-							<th>Active</th>
-							<th>Params</th>
-							<th></th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each rules as rule (rule.id)}
-							<tr>
-								<td
-									><input
-										value={rule.name}
-										oninput={(e) => (rule.name = e.currentTarget.value)}
-									/></td
-								>
-								<td>{rule.component}</td>
-								<td>{rule.rule_type}</td>
-								<td>
-									<input
-										type="number"
-										step="0.1"
-										value={rule.weight}
-										oninput={(e) => (rule.weight = parseFloat(e.currentTarget.value))}
-									/>
-								</td>
-								<td>
-									<Switch checked={rule.active} onCheckedChange={(v) => (rule.active = v)} />
-								</td>
-								<td>
-									{#if editingRuleId === rule.id}
-										<textarea
-											rows="3"
-											value={editingParamsRaw}
-											oninput={(e) => (editingParamsRaw = e.currentTarget.value)}
-										></textarea>
-									{:else}
-										<button
-											class="link"
-											onclick={() => {
-												editingRuleId = rule.id
-												editingParamsRaw = JSON.stringify(rule.params, null, 2)
-											}}
-										>
-											Edit
-										</button>
-										<code class="params-summary">{JSON.stringify(rule.params)}</code>
-									{/if}
-								</td>
-								<td class="actions">
-									<Button
-										size="small"
-										onclick={() => {
-											const data: Partial<DifficultyRule> = {
-												name: rule.name,
-												weight: rule.weight,
-												active: rule.active
-											}
-											if (editingRuleId === rule.id) {
-												try {
-													data.params = JSON.parse(editingParamsRaw || '{}')
-												} catch {
-													alert('Invalid JSON in params')
-													return
-												}
-												editingRuleId = null
-											}
-											updateRule.mutate({ id: rule.id, data })
-										}}
-									>
-										Save
-									</Button>
-									<Button
-										size="small"
-										variant="destructive"
-										onclick={() => {
-											if (confirm(`Delete rule "${rule.name}"?`)) deleteRule.mutate(rule.id)
-										}}
-									>
-										Delete
-									</Button>
-								</td>
-							</tr>
-						{/each}
-					</tbody>
-				</table>
-
-				<h3>New rule</h3>
-				<div class="new-rule">
-					<label>
-						Name
-						<input bind:value={newRule.name} />
-					</label>
-					<label>
-						Component
-						<select bind:value={newRule.component}>
-							<option value="weapon">weapon</option>
-							<option value="character">character</option>
-							<option value="summon">summon</option>
-							<option value="job">job</option>
-							<option value="accessory">accessory</option>
-						</select>
-					</label>
-					<label>
-						Rule type
-						<select bind:value={newRule.rule_type}>
-							<option value="">— select —</option>
-							{#each ruleTypes as t (t)}
-								<option value={t}>{t}</option>
-							{/each}
-						</select>
-					</label>
-					<label>
-						Weight
-						<input type="number" step="0.1" bind:value={newRule.weight} />
-					</label>
-					<label>
-						Params (JSON)
-						<textarea rows="4" bind:value={newRuleParamsRaw}></textarea>
-					</label>
-					<Button
-						onclick={() => {
-							if (!setRuleParamsFromString()) {
-								alert('Invalid JSON in params')
-								return
-							}
-							createRule.mutate(newRule)
-						}}
-					>
-						Create rule
+		{#if activeTab === 'tiers'}
+			<section class="section">
+				<header class="section-header">
+					<div>
+						<h2>Tiers</h2>
+						<p class="section-hint">Score ranges that label each party.</p>
+					</div>
+					<Button variant="ghost" size="small" leftIcon="plus" onclick={openNewTier}>
+						New tier
 					</Button>
-				</div>
-			{/if}
-		</section>
-
-		<aside class="preview">
-			<h2>Preview</h2>
-			<p class="hint">
-				Score a party against the current ruleset without persisting. Helpful when tuning weights or
-				testing new rules.
-			</p>
-			<Input bind:value={previewShortcode} placeholder="Party shortcode" />
-			<Button onclick={runPreview} disabled={!previewShortcode.trim() || previewLoading}>
-				{previewLoading ? 'Loading…' : 'Run preview'}
-			</Button>
-
-			{#if previewError}
-				<p class="error">{previewError}</p>
-			{/if}
-
-			{#if previewResult}
-				<div class="preview-result">
-					{#if !previewResult.scoreable}
-						<p class="warn">Party isn't scoreable yet (below the minimum item threshold).</p>
-					{:else}
-						<p>
-							<strong>{previewResult.tier?.name ?? '—'}</strong>
-							<span class="score">{previewResult.score?.toFixed(2) ?? '0'}</span>
+				</header>
+				{#if tiersQuery.isLoading}
+					<p class="empty">Loading tiers…</p>
+				{:else if tiers.length === 0}
+					<div class="empty-state">
+						<p>No tiers yet.</p>
+						<Button variant="primary" size="small" onclick={openNewTier}>
+							Create the first tier
+						</Button>
+					</div>
+				{:else}
+					<div class="rows">
+						{#each tiers as tier (tier.id)}
+							<TierRow {tier} onclick={() => openEditTier(tier)} />
+						{/each}
+					</div>
+				{/if}
+			</section>
+		{:else if activeTab === 'rules'}
+			<section class="section">
+				<header class="section-header">
+					<div>
+						<h2>Rules</h2>
+						<p class="section-hint">
+							Each rule contributes its weight to its component when its condition fires.
 						</p>
-						<p class="muted">Ruleset version: {previewResult.ruleset_version}</p>
-						{#if previewResult.breakdown}
-							<details>
-								<summary>Breakdown</summary>
-								<pre>{JSON.stringify(previewResult.breakdown, null, 2)}</pre>
-							</details>
-						{/if}
-					{/if}
+					</div>
+					<Button variant="ghost" size="small" leftIcon="plus" onclick={openNewRule}>
+						New rule
+					</Button>
+				</header>
+
+				<div class="filter-bar">
+					<SegmentedControl bind:value={ruleComponentFilter} size="xsmall" variant="background">
+						{#each componentFilters as f (f.value)}
+							<Segment value={f.value}>{f.label}</Segment>
+						{/each}
+					</SegmentedControl>
+					<span class="filter-count">
+						{filteredRules.length} rule{filteredRules.length === 1 ? '' : 's'}
+					</span>
 				</div>
-			{/if}
-		</aside>
+
+				{#if rulesQuery.isLoading}
+					<p class="empty">Loading rules…</p>
+				{:else if filteredRules.length === 0}
+					<div class="empty-state">
+						<p>No rules match this filter.</p>
+					</div>
+				{:else}
+					<div class="rows">
+						{#each filteredRules as rule (rule.id)}
+							<RuleRow {rule} onclick={() => openEditRule(rule)} />
+						{/each}
+					</div>
+				{/if}
+			</section>
+		{:else if activeTab === 'components'}
+			<section class="section">
+				<header class="section-header">
+					<div>
+						<h2>Components</h2>
+						<p class="section-hint">
+							Per-component weight, scoreability threshold, and on/off switch. Components are
+							seeded; you can tune their values but cannot create or destroy them.
+						</p>
+					</div>
+				</header>
+				<ComponentsPanel />
+			</section>
+		{:else}
+			<section class="section">
+				<header class="section-header">
+					<div>
+						<h2>Preview</h2>
+						<p class="section-hint">Test the current ruleset against any party by shortcode.</p>
+					</div>
+				</header>
+				<PreviewPanel />
+			</section>
+		{/if}
 	</div>
 </div>
 
+<TierModal bind:open={tierModalOpen} tier={editingTier} />
+<RuleModal bind:open={ruleModalOpen} rule={editingRule} />
+
 <style lang="scss">
-	@use '$src/themes/spacing' as *;
-	@use '$src/themes/typography' as *;
-	@use '$src/themes/layout' as *;
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+	@use '$src/themes/layout' as layout;
 
 	.page {
-		padding: $unit-2x;
-		display: flex;
-		flex-direction: column;
-		gap: $unit-2x;
+		background: var(--card-bg);
+		border-radius: layout.$page-corner;
+		box-shadow: var(--shadow-sm);
 	}
 
-	.page-header h1 {
-		font-size: $font-large;
-		font-weight: $bold;
-	}
-
-	.tabs {
+	.tab-bar {
 		display: flex;
-		gap: $unit;
-		border-bottom: 1px solid var(--border-color);
-
-		button {
-			padding: $unit $unit-2x;
-			background: transparent;
-			border: none;
-			border-bottom: 2px solid transparent;
-			font: inherit;
-			color: var(--text-secondary);
-			cursor: pointer;
-
-			&.active {
-				color: var(--text-primary);
-				border-bottom-color: var(--text-primary);
-			}
-		}
+		justify-content: center;
+		padding: 0 spacing.$unit-2x spacing.$unit-2x;
 	}
 
 	.content {
-		display: grid;
-		grid-template-columns: 1fr 320px;
-		gap: $unit-2x;
-
-		@media (max-width: 1024px) {
-			grid-template-columns: 1fr;
-		}
-	}
-
-	.main h2 {
-		margin-top: 0;
-		margin-bottom: $unit;
-	}
-
-	.main h3 {
-		margin-top: $unit-2x;
-		margin-bottom: $unit;
-	}
-
-	.hint {
-		color: var(--text-secondary);
-		margin-bottom: $unit-2x;
-		font-size: $font-small;
-	}
-
-	table {
-		width: 100%;
-		border-collapse: collapse;
-
-		th,
-		td {
-			text-align: left;
-			padding: $unit-half $unit;
-			border-bottom: 1px solid var(--border-color);
-			font-size: $font-small;
-			vertical-align: middle;
-		}
-
-		input,
-		textarea,
-		select {
-			width: 100%;
-			padding: $unit-half;
-			border: 1px solid var(--border-color);
-			border-radius: $item-corner-small;
-			background: var(--input-bg);
-			color: var(--text-primary);
-			font: inherit;
-		}
-
-		input[type='number'] {
-			width: 80px;
-		}
-
-		.actions {
-			display: flex;
-			gap: $unit-half;
-			white-space: nowrap;
-		}
-
-		.params-summary {
-			display: block;
-			max-width: 320px;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			white-space: nowrap;
-			color: var(--text-secondary);
-			font-size: 0.75em;
-		}
-
-		.link {
-			background: transparent;
-			border: none;
-			color: var(--accent-color, #4a90e2);
-			cursor: pointer;
-			padding: 0;
-			margin-right: $unit;
-		}
-	}
-
-	.new-row {
-		display: flex;
-		gap: $unit;
-		align-items: center;
-		flex-wrap: wrap;
-
-		input {
-			padding: $unit-half;
-			border: 1px solid var(--border-color);
-			border-radius: $item-corner-small;
-			background: var(--input-bg);
-		}
-	}
-
-	.new-rule {
 		display: flex;
 		flex-direction: column;
-		gap: $unit;
-		max-width: 600px;
-
-		label {
-			display: flex;
-			flex-direction: column;
-			gap: $unit-half;
-			font-size: $font-small;
-
-			input,
-			select,
-			textarea {
-				padding: $unit-half;
-				border: 1px solid var(--border-color);
-				border-radius: $item-corner-small;
-				background: var(--input-bg);
-				color: var(--text-primary);
-				font: inherit;
-			}
-		}
+		gap: spacing.$unit-2x;
+		padding: 0 spacing.$unit-2x spacing.$unit-2x;
 	}
 
-	.preview {
+	.section {
 		display: flex;
 		flex-direction: column;
-		gap: $unit;
-		padding: $unit-2x;
-		background: var(--card-bg);
-		border-radius: $card-corner;
-		align-self: start;
+		gap: spacing.$unit-2x;
+	}
+
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: spacing.$unit;
 
 		h2 {
-			margin-top: 0;
-			margin-bottom: 0;
+			margin: 0;
+			font-size: typography.$font-medium;
+			font-weight: typography.$bold;
+			color: var(--text-primary);
 		}
 	}
 
-	.preview-result {
-		.score {
-			margin-left: $unit;
-			color: var(--text-secondary);
-		}
-
-		pre {
-			background: var(--input-bg);
-			padding: $unit;
-			border-radius: $item-corner-small;
-			overflow-x: auto;
-			font-size: 0.75em;
-		}
-	}
-
-	.warn {
-		color: var(--warning-text, #b86b00);
-	}
-
-	.error {
-		color: var(--error-text, #b00020);
-	}
-
-	.muted {
+	.section-hint {
+		margin: spacing.$unit-half 0 0 0;
 		color: var(--text-secondary);
-		font-size: $font-small;
+		font-size: typography.$font-small;
+		max-width: 60ch;
+	}
+
+	.filter-bar {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: spacing.$unit;
+	}
+
+	.filter-count {
+		font-size: typography.$font-small;
+		color: var(--text-tertiary);
+	}
+
+	.rows {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-half;
+	}
+
+	.empty {
+		color: var(--text-secondary);
+		text-align: center;
+		padding: spacing.$unit-4x;
+	}
+
+	.empty-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: spacing.$unit-2x;
+		padding: spacing.$unit-4x;
+		color: var(--text-secondary);
+
+		p {
+			margin: 0;
+		}
 	}
 </style>

--- a/src/routes/(app)/teams/[id]/[[tab=tab]]/+page.svelte
+++ b/src/routes/(app)/teams/[id]/[[tab=tab]]/+page.svelte
@@ -75,6 +75,7 @@
 		authUserAvatar={data.currentUser
 			? { picture: data.currentUser.picture, element: data.currentUser.element }
 			: undefined}
+		isEditor={(data.account?.role ?? 0) >= 7}
 		{initialTab}
 	/>
 {:else}

--- a/src/themes/_colors.scss
+++ b/src/themes/_colors.scss
@@ -69,6 +69,8 @@ $accent--blue--light: #275dc5;
 $accent--blue--light--focus: #0c398d;
 $accent--blue--dark: #6195f4;
 $accent--blue--dark--focus: #275dc5;
+$accent--blue--120: #d6e3f8;
+$accent--blue--00: #061e4c;
 
 $accent--yellow--light: #c89d39;
 $accent--yellow--dark: #f9cc64;
@@ -85,6 +87,7 @@ $accent--yellow--70: #d1aa4f;
 $accent--yellow--80: #deb351;
 $accent--yellow--90: #e6bd5e;
 $accent--yellow--100: #f9cc64;
+$accent--yellow--120: #fcf0c2;
 
 $selected--item--bg--dark: #f9cc645d;
 $selected--item--bg--dark--hover: #fcc33f81;
@@ -216,23 +219,81 @@ $placeholder--bound--bg--light--hover: $grey-75;
 $placeholder--bound--bg--dark--hover: $grey-20;
 
 // Color Definitions: Notices
-$notice--bg--light: $accent--yellow--100;
-$notice--bg--dark: $accent--yellow--00;
 
-$notice--text--light: $accent--yellow--20;
-$notice--text--dark: $accent--yellow--100;
+// Yellow
+$notice--yellow--bg--light: $accent--yellow--120;
+$notice--yellow--bg--dark: $accent--yellow--00;
 
-$notice--button--bg--light: $accent--yellow--80;
-$notice--button--bg--dark: $accent--yellow--20;
+$notice--yellow--text--light: $accent--yellow--20;
+$notice--yellow--text--dark: $accent--yellow--100;
 
-$notice--button--bg--light--hover: $accent--yellow--70;
-$notice--button--bg--dark--hover: $accent--yellow--10;
+$notice--yellow--button--bg--light: $accent--yellow--80;
+$notice--yellow--button--bg--dark: $accent--yellow--20;
 
-$notice--button--text--light: $accent--yellow--10;
-$notice--button--text--dark: $accent--yellow--90;
+$notice--yellow--button--bg--light--hover: $accent--yellow--70;
+$notice--yellow--button--bg--dark--hover: $accent--yellow--10;
 
-$notice--button--text--light--hover: $accent--yellow--00;
-$notice--button--text--dark--hover: $accent--yellow--100;
+$notice--yellow--button--bg--light--disabled: $accent--yellow--80;
+$notice--yellow--button--bg--dark--disabled: $accent--yellow--20;
+
+$notice--yellow--button--text--light: $accent--yellow--10;
+$notice--yellow--button--text--dark: $accent--yellow--90;
+
+$notice--yellow--button--text--light--hover: $accent--yellow--00;
+$notice--yellow--button--text--dark--hover: $accent--yellow--100;
+
+$notice--yellow--button--text--light--disabled: $accent--yellow--00;
+$notice--yellow--button--text--dark--disabled: $accent--yellow--100;
+
+// Blue
+$notice--blue--bg--light: $accent--blue--120;
+$notice--blue--bg--dark: $accent--blue--00;
+
+$notice--blue--text--light: $accent--blue--light--focus;
+$notice--blue--text--dark: $accent--blue--dark;
+
+$notice--blue--button--bg--light: $accent--blue--light;
+$notice--blue--button--bg--dark: $accent--blue--dark;
+
+$notice--blue--button--bg--light--hover: $accent--blue--light--focus;
+$notice--blue--button--bg--dark--hover: $accent--blue--dark--focus;
+
+$notice--blue--button--text--light: $accent--blue--120;
+$notice--blue--button--text--dark: $accent--blue--00;
+
+$notice--blue--button--text--light--hover: $accent--blue--120;
+$notice--blue--button--text--dark--hover: $accent--blue--00;
+
+$notice--blue--button--text--light--disabled: $accent--blue--120;
+$notice--blue--button--text--dark--disabled: $accent--blue--00;
+
+$notice--blue--button--bg--light--disabled: $accent--blue--light--focus;
+$notice--blue--button--bg--dark--disabled: $accent--blue--dark--focus;
+
+// Grey
+$notice--grey--bg--light: $grey-90;
+$notice--grey--bg--dark: $grey-10;
+
+$notice--grey--text--light: $grey-50;
+$notice--grey--text--dark: $grey-80;
+
+$notice--grey--button--bg--light: $grey-100;
+$notice--grey--button--bg--dark: $grey-20;
+
+$notice--grey--button--bg--light--hover: $grey-100;
+$notice--grey--button--bg--dark--hover: $grey-20;
+
+$notice--grey--button--text--light: $grey-50;
+$notice--grey--button--text--dark: $grey-80;
+
+$notice--grey--button--text--light--hover: $grey-50;
+$notice--grey--button--text--dark--hover: $grey-80;
+
+$notice--grey--button--text--light--disabled: $grey-50;
+$notice--grey--button--text--dark--disabled: $grey-80;
+
+$notice--grey--button--bg--light--disabled: $grey-100;
+$notice--grey--button--bg--dark--disabled: $grey-20;
 
 // Color Definitions: Button
 $button--bg--light: $grey-85;

--- a/src/themes/themes.scss
+++ b/src/themes/themes.scss
@@ -123,14 +123,35 @@
 	--placeholder-bound-bg: #{colors.$placeholder--bound--bg--light};
 	--placeholder-bound-bg-hover: #{colors.$placeholder--bound--bg--light--hover};
 
-	// Light - Notices
-	--notice-bg: #{colors.$notice--bg--light};
-	--notice-text: #{colors.$notice--text--light};
+	// Light - Notices (Yellow)
+	--notice-yellow-bg: #{colors.$notice--yellow--bg--light};
+	--notice-yellow-text: #{colors.$notice--yellow--text--light};
+	--notice-yellow-button-bg: #{colors.$notice--yellow--button--bg--light};
+	--notice-yellow-button-bg-hover: #{colors.$notice--yellow--button--bg--light--hover};
+	--notice-yellow-button-text: #{colors.$notice--yellow--button--text--light};
+	--notice-yellow-button-text-hover: #{colors.$notice--yellow--button--text--light--hover};
+	--notice-yellow-button-text-disabled: #{colors.$notice--yellow--button--text--light--disabled};
+	--notice-yellow-button-bg-disabled: #{colors.$notice--yellow--button--bg--light--disabled};
 
-	--notice-button-bg: #{colors.$notice--button--bg--light};
-	--notice-button-bg-hover: #{colors.$notice--button--bg--light--hover};
-	--notice-button-text: #{colors.$notice--button--text--light};
-	--notice-button-text-hover: #{colors.$notice--button--text--light--hover};
+	// Light - Notices (Blue)
+	--notice-blue-bg: #{colors.$notice--blue--bg--light};
+	--notice-blue-text: #{colors.$notice--blue--text--light};
+	--notice-blue-button-bg: #{colors.$notice--blue--button--bg--light};
+	--notice-blue-button-bg-hover: #{colors.$notice--blue--button--bg--light--hover};
+	--notice-blue-button-text: #{colors.$notice--blue--button--text--light};
+	--notice-blue-button-text-hover: #{colors.$notice--blue--button--text--light--hover};
+	--notice-blue-button-text-disabled: #{colors.$notice--blue--button--text--light--disabled};
+	--notice-blue-button-bg-disabled: #{colors.$notice--blue--button--bg--light--disabled};
+
+	// Light - Notices (Grey)
+	--notice-grey-bg: #{colors.$notice--grey--bg--light};
+	--notice-grey-text: #{colors.$notice--grey--text--light};
+	--notice-grey-button-bg: #{colors.$notice--grey--button--bg--light};
+	--notice-grey-button-bg-hover: #{colors.$notice--grey--button--bg--light--hover};
+	--notice-grey-button-text: #{colors.$notice--grey--button--text--light};
+	--notice-grey-button-text-hover: #{colors.$notice--grey--button--text--light--hover};
+	--notice-grey-button-text-disabled: #{colors.$notice--grey--button--text--light--disabled};
+	--notice-grey-button-bg-disabled: #{colors.$notice--grey--button--bg--light--disabled};
 
 	// Light - Buttons
 	--button-bg: #{colors.$button--bg--light};
@@ -484,8 +505,8 @@
 	--toast-success-text: #2e7d32;
 	--toast-error-bg: #{colors.$error--bg--light};
 	--toast-error-text: #{colors.$error};
-	--toast-warning-bg: #{colors.$notice--bg--light};
-	--toast-warning-text: #{colors.$notice--text--light};
+	--toast-warning-bg: #{colors.$notice--yellow--bg--light};
+	--toast-warning-text: #{colors.$notice--yellow--text--light};
 	--toast-info-bg: #e3f2fd;
 	--toast-info-text: #1565c0;
 
@@ -613,14 +634,35 @@ html[data-theme='dark'] {
 	--placeholder-bound-bg: #{colors.$placeholder--bound--bg--dark};
 	--placeholder-bound-bg-hover: #{colors.$placeholder--bound--bg--dark--hover};
 
-	// Dark - Notices
-	--notice-bg: #{colors.$notice--bg--dark};
-	--notice-text: #{colors.$notice--text--dark};
+	// Dark - Notices (Yellow)
+	--notice-yellow-bg: #{colors.$notice--yellow--bg--dark};
+	--notice-yellow-text: #{colors.$notice--yellow--text--dark};
+	--notice-yellow-button-bg: #{colors.$notice--yellow--button--bg--dark};
+	--notice-yellow-button-bg-hover: #{colors.$notice--yellow--button--bg--dark--hover};
+	--notice-yellow-button-text: #{colors.$notice--yellow--button--text--dark};
+	--notice-yellow-button-text-hover: #{colors.$notice--yellow--button--text--dark--hover};
+	--notice-yellow-button-text-disabled: #{colors.$notice--yellow--button--text--dark--disabled};
+	--notice-yellow-button-bg-disabled: #{colors.$notice--yellow--button--bg--dark--disabled};
 
-	--notice-button-bg: #{colors.$notice--button--bg--dark};
-	--notice-button-bg-hover: #{colors.$notice--button--bg--dark--hover};
-	--notice-button-text: #{colors.$notice--button--text--dark};
-	--notice-button-text-hover: #{colors.$notice--button--text--dark--hover};
+	// Dark - Notices (Blue)
+	--notice-blue-bg: #{colors.$notice--blue--bg--dark};
+	--notice-blue-text: #{colors.$notice--blue--text--dark};
+	--notice-blue-button-bg: #{colors.$notice--blue--button--bg--dark};
+	--notice-blue-button-bg-hover: #{colors.$notice--blue--button--bg--dark--hover};
+	--notice-blue-button-text: #{colors.$notice--blue--button--text--dark};
+	--notice-blue-button-text-hover: #{colors.$notice--blue--button--text--dark--hover};
+	--notice-blue-button-text-disabled: #{colors.$notice--blue--button--text--dark--disabled};
+	--notice-blue-button-bg-disabled: #{colors.$notice--blue--button--bg--dark--disabled};
+
+	// Dark - Notices (Grey)
+	--notice-grey-bg: #{colors.$notice--grey--bg--dark};
+	--notice-grey-text: #{colors.$notice--grey--text--dark};
+	--notice-grey-button-bg: #{colors.$notice--grey--button--bg--dark};
+	--notice-grey-button-bg-hover: #{colors.$notice--grey--button--bg--dark--hover};
+	--notice-grey-button-text: #{colors.$notice--grey--button--text--dark};
+	--notice-grey-button-text-hover: #{colors.$notice--grey--button--text--dark--hover};
+	--notice-grey-button-text-disabled: #{colors.$notice--grey--button--text--dark--disabled};
+	--notice-grey-button-bg-disabled: #{colors.$notice--grey--button--bg--dark--disabled};
 
 	// Dark - Buttons
 	--button-bg: #{colors.$button--bg--dark};
@@ -974,8 +1016,8 @@ html[data-theme='dark'] {
 	--toast-success-text: #66bb6a;
 	--toast-error-bg: #{colors.$error--bg--dark};
 	--toast-error-text: #{colors.$error};
-	--toast-warning-bg: #{colors.$notice--bg--dark};
-	--toast-warning-text: #{colors.$notice--text--dark};
+	--toast-warning-bg: #{colors.$notice--yellow--bg--dark};
+	--toast-warning-text: #{colors.$notice--yellow--text--dark};
 	--toast-info-bg: #0d2744;
 	--toast-info-text: #64b5f6;
 


### PR DESCRIPTION
## Summary

Stacked on #848. Adds an editor-only page at `/database/difficulties` for managing tiers, rules, and components, plus a preview-by-shortcode panel.

- Three-tab layout (Tiers / Rules / Components) with inline editing of every field
- Rule params editor uses a JSON textarea — opt-in per-row via Edit/Save
- New rule form with rule-type dropdown sourced from `GET /difficulty_rules/types`
- Sidebar runs the new `POST /difficulty_previews` endpoint and shows score + tier + breakdown without persisting
- Linked from the Database nav dropdown alongside other taxonomy editors
- Page is protected by the existing database `+layout.server.ts` role >= 7 redirect

## Test plan

- [ ] Edit a tier's color/score range, save, reload — change persists
- [ ] Edit a rule's weight, save — score recomputes on next sweep / next party edit
- [ ] Toggle a rule's `active` flag and confirm it stops contributing in preview
- [ ] Edit a component's weight; preview reflects the new weighting
- [ ] Run preview against a known shortcode; tier matches the badge on the actual party page
- [ ] Confirm a non-editor user cannot access the page (redirected to `/`)