### PR TITLE
add staged-edit + commit dialog to the difficulty editor

### DIFF
--- a/src/lib/api/adapters/difficulty.adapter.ts
+++ b/src/lib/api/adapters/difficulty.adapter.ts
@@ -286,6 +286,24 @@ export class DifficultyAdapter extends BaseAdapter {
 			body: JSON.stringify({ note })
 		})
 	}
+
+	/**
+	 * Uploads a tier icon to the draft's S3 staging area. The image survives
+	 * there until commit (which promotes it to the canonical key) or discard
+	 * (which removes it). Pass the bare base64 — no `data:image/png;base64,` prefix.
+	 */
+	async uploadDraftImage(
+		draftId: string,
+		base64Image: string,
+		filename?: string,
+		options?: RequestOptions
+	): Promise<DifficultyDraft> {
+		return this.request<DifficultyDraft>(`/difficulty_drafts/${draftId}/upload_image`, {
+			...options,
+			method: 'POST',
+			body: JSON.stringify({ image: base64Image, filename })
+		})
+	}
 }
 
 export const difficultyAdapter = new DifficultyAdapter(DEFAULT_ADAPTER_CONFIG)

--- a/src/lib/api/adapters/difficulty.adapter.ts
+++ b/src/lib/api/adapters/difficulty.adapter.ts
@@ -3,7 +3,13 @@ import { DEFAULT_ADAPTER_CONFIG } from './config'
 import type { RequestOptions } from './types'
 import type { DifficultyTier } from '$lib/types/api/party'
 
-export interface DifficultyRule {
+export interface PendingMeta {
+	pending?: boolean
+	pendingOperation?: 'create' | 'update' | 'destroy' | null
+	draftId?: string | null
+}
+
+export interface DifficultyRule extends PendingMeta {
 	id: string
 	name: string
 	description?: string | null
@@ -16,7 +22,7 @@ export interface DifficultyRule {
 	updatedAt?: string
 }
 
-export interface DifficultyComponent {
+export interface DifficultyComponent extends PendingMeta {
 	id: string
 	name: string
 	weight: number
@@ -36,6 +42,49 @@ export interface DifficultyPreviewResult {
 	tier: DifficultyTier | null
 	breakdown: Record<string, unknown> | null
 	rulesetVersion: number
+	withDrafts?: boolean
+}
+
+export type DraftOperation = 'create' | 'update' | 'destroy'
+export type DraftTargetType = 'Difficulty' | 'DifficultyRule' | 'DifficultyComponent'
+
+export interface DifficultyDraft {
+	id: string
+	targetType: DraftTargetType
+	targetId: string | null
+	operation: DraftOperation
+	attributes: Record<string, unknown>
+	createdAt?: string
+	updatedAt?: string
+}
+
+export interface DraftSection {
+	creates: Array<{ draftId: string; attributes: Record<string, unknown> }>
+	updates: Array<{
+		draftId: string
+		targetId: string
+		label: string
+		changes: Record<string, { old: unknown; new: unknown }>
+	}>
+	destroys: Array<{
+		draftId: string
+		targetId: string
+		label: string
+		snapshot: Record<string, unknown>
+	}>
+}
+
+export interface DifficultyDiff {
+	tiers: DraftSection
+	rules: DraftSection
+	components: DraftSection
+}
+
+export interface CommitResult {
+	rulesetVersionAfter: number
+	committedAt: string
+	note: string | null
+	changeLogId: string
 }
 
 export interface DifficultyRuleTypes {
@@ -51,15 +100,16 @@ export interface DifficultyRuleTypes {
 export class DifficultyAdapter extends BaseAdapter {
 	// ==================== Tiers (public read) ====================
 
-	async listTiers(options?: RequestOptions): Promise<DifficultyTier[]> {
-		return this.request<DifficultyTier[]>('/difficulties', options)
+	async listTiers(options?: RequestOptions & { withDrafts?: boolean }): Promise<DifficultyTier[]> {
+		const query = options?.withDrafts ? { with_drafts: true } : undefined
+		return this.request<DifficultyTier[]>('/difficulties', { ...options, query })
 	}
 
 	async createTier(
 		input: Partial<DifficultyTier>,
 		options?: RequestOptions
-	): Promise<DifficultyTier> {
-		const response = await this.request<DifficultyTier>('/difficulties', {
+	): Promise<{ draft: DifficultyDraft }> {
+		const response = await this.request<{ draft: DifficultyDraft }>('/difficulties', {
 			...options,
 			method: 'POST',
 			body: JSON.stringify({ difficulty: input })
@@ -72,8 +122,8 @@ export class DifficultyAdapter extends BaseAdapter {
 		id: string,
 		input: Partial<DifficultyTier>,
 		options?: RequestOptions
-	): Promise<DifficultyTier> {
-		const response = await this.request<DifficultyTier>(`/difficulties/${id}`, {
+	): Promise<{ draft: DifficultyDraft }> {
+		const response = await this.request<{ draft: DifficultyDraft }>(`/difficulties/${id}`, {
 			...options,
 			method: 'PUT',
 			body: JSON.stringify({ difficulty: input })
@@ -92,20 +142,26 @@ export class DifficultyAdapter extends BaseAdapter {
 
 	// ==================== Components (editor only) ====================
 
-	async listComponents(options?: RequestOptions): Promise<DifficultyComponent[]> {
-		return this.request<DifficultyComponent[]>('/difficulty_components', options)
+	async listComponents(
+		options?: RequestOptions & { withDrafts?: boolean }
+	): Promise<DifficultyComponent[]> {
+		const query = options?.withDrafts ? { with_drafts: true } : undefined
+		return this.request<DifficultyComponent[]>('/difficulty_components', { ...options, query })
 	}
 
 	async updateComponent(
 		idOrName: string,
 		input: Partial<DifficultyComponent>,
 		options?: RequestOptions
-	): Promise<DifficultyComponent> {
-		const response = await this.request<DifficultyComponent>(`/difficulty_components/${idOrName}`, {
-			...options,
-			method: 'PUT',
-			body: JSON.stringify({ difficulty_component: input })
-		})
+	): Promise<{ draft: DifficultyDraft }> {
+		const response = await this.request<{ draft: DifficultyDraft }>(
+			`/difficulty_components/${idOrName}`,
+			{
+				...options,
+				method: 'PUT',
+				body: JSON.stringify({ difficulty_component: input })
+			}
+		)
 		this.clearCache('/difficulty_components')
 		return response
 	}
@@ -113,12 +169,13 @@ export class DifficultyAdapter extends BaseAdapter {
 	// ==================== Rules (editor only) ====================
 
 	async listRules(
-		filters?: { component?: string; active?: boolean },
+		filters?: { component?: string; active?: boolean; withDrafts?: boolean },
 		options?: RequestOptions
 	): Promise<DifficultyRule[]> {
 		const query: Record<string, string | boolean> = {}
 		if (filters?.component) query.component = filters.component
 		if (filters?.active !== undefined) query.active = filters.active
+		if (filters?.withDrafts) query.with_drafts = true
 		return this.request<DifficultyRule[]>('/difficulty_rules', {
 			...options,
 			query: Object.keys(query).length > 0 ? query : undefined
@@ -132,8 +189,8 @@ export class DifficultyAdapter extends BaseAdapter {
 	async createRule(
 		input: Partial<DifficultyRule>,
 		options?: RequestOptions
-	): Promise<DifficultyRule> {
-		const response = await this.request<DifficultyRule>('/difficulty_rules', {
+	): Promise<{ draft: DifficultyDraft }> {
+		const response = await this.request<{ draft: DifficultyDraft }>('/difficulty_rules', {
 			...options,
 			method: 'POST',
 			body: JSON.stringify({ difficulty_rule: input })
@@ -146,8 +203,8 @@ export class DifficultyAdapter extends BaseAdapter {
 		id: string,
 		input: Partial<DifficultyRule>,
 		options?: RequestOptions
-	): Promise<DifficultyRule> {
-		const response = await this.request<DifficultyRule>(`/difficulty_rules/${id}`, {
+	): Promise<{ draft: DifficultyDraft }> {
+		const response = await this.request<{ draft: DifficultyDraft }>(`/difficulty_rules/${id}`, {
 			...options,
 			method: 'PUT',
 			body: JSON.stringify({ difficulty_rule: input })
@@ -171,6 +228,51 @@ export class DifficultyAdapter extends BaseAdapter {
 			...options,
 			method: 'POST',
 			body: JSON.stringify({ shortcode })
+		})
+	}
+
+	// ==================== Drafts (editor only) ====================
+
+	async listDrafts(options?: RequestOptions): Promise<{
+		drafts: DifficultyDraft[]
+		pendingCount: number
+	}> {
+		return this.request('/difficulty_drafts', options)
+	}
+
+	async getDiff(options?: RequestOptions): Promise<{ diff: DifficultyDiff; pendingCount: number }> {
+		return this.request('/difficulty_drafts/diff', options)
+	}
+
+	async stageDraft(
+		input: {
+			targetType: DraftTargetType
+			targetId: string | null
+			operation: DraftOperation
+			attributes: Record<string, unknown>
+		},
+		options?: RequestOptions
+	): Promise<DifficultyDraft> {
+		return this.request<DifficultyDraft>('/difficulty_drafts', {
+			...options,
+			method: 'POST',
+			body: JSON.stringify({ draft: input })
+		})
+	}
+
+	async deleteDraft(id: string, options?: RequestOptions): Promise<void> {
+		await this.request<void>(`/difficulty_drafts/${id}`, { ...options, method: 'DELETE' })
+	}
+
+	async discardDrafts(options?: RequestOptions): Promise<{ discarded: number }> {
+		return this.request('/difficulty_drafts/all', { ...options, method: 'DELETE' })
+	}
+
+	async commitDrafts(note: string, options?: RequestOptions): Promise<CommitResult> {
+		return this.request<CommitResult>('/difficulty_drafts/commit', {
+			...options,
+			method: 'POST',
+			body: JSON.stringify({ note })
 		})
 	}
 }

--- a/src/lib/api/adapters/difficulty.adapter.ts
+++ b/src/lib/api/adapters/difficulty.adapter.ts
@@ -96,6 +96,12 @@ export interface DifficultyRuleTypes {
  * Adapter for the party difficulty scoring system.
  *
  * Editor endpoints (rules, components, preview) require role >= 7.
+ *
+ * Editor mutations (the create/update/delete methods on tiers, rules,
+ * components) stage a draft on the server rather than persisting
+ * immediately. Drafts become live only when the editor commits via
+ * `commitDrafts()`. The `{ draft }` return value reflects the staged
+ * draft, not the saved entity.
  */
 export class DifficultyAdapter extends BaseAdapter {
 	// ==================== Tiers (public read) ====================
@@ -105,6 +111,7 @@ export class DifficultyAdapter extends BaseAdapter {
 		return this.request<DifficultyTier[]>('/difficulties', { ...options, query })
 	}
 
+	/** Stages a new tier; pending until `commitDrafts()` is called. */
 	async createTier(
 		input: Partial<DifficultyTier>,
 		options?: RequestOptions
@@ -118,6 +125,7 @@ export class DifficultyAdapter extends BaseAdapter {
 		return response
 	}
 
+	/** Stages an edit to an existing tier; pending until `commitDrafts()`. */
 	async updateTier(
 		id: string,
 		input: Partial<DifficultyTier>,
@@ -149,6 +157,7 @@ export class DifficultyAdapter extends BaseAdapter {
 		return this.request<DifficultyComponent[]>('/difficulty_components', { ...options, query })
 	}
 
+	/** Stages an edit to a component; pending until `commitDrafts()`. */
 	async updateComponent(
 		idOrName: string,
 		input: Partial<DifficultyComponent>,
@@ -186,6 +195,7 @@ export class DifficultyAdapter extends BaseAdapter {
 		return this.request<DifficultyRuleTypes>('/difficulty_rules/types', options)
 	}
 
+	/** Stages a new rule; pending until `commitDrafts()`. */
 	async createRule(
 		input: Partial<DifficultyRule>,
 		options?: RequestOptions
@@ -199,6 +209,7 @@ export class DifficultyAdapter extends BaseAdapter {
 		return response
 	}
 
+	/** Stages an edit to an existing rule; pending until `commitDrafts()`. */
 	async updateRule(
 		id: string,
 		input: Partial<DifficultyRule>,

--- a/src/lib/api/queries/difficulty.queries.ts
+++ b/src/lib/api/queries/difficulty.queries.ts
@@ -10,26 +10,31 @@
 import { queryOptions } from '@tanstack/svelte-query'
 import { difficultyAdapter } from '$lib/api/adapters/difficulty.adapter'
 
+interface RuleFilters {
+	component?: string
+	active?: boolean
+}
+
 export const difficultyQueries = {
 	/**
-	 * List all difficulty tiers (public)
+	 * List all difficulty tiers. When `withDrafts: true`, the current editor's
+	 * staged changes are merged in.
 	 */
-	tiers: () =>
+	tiers: (opts: { withDrafts?: boolean } = {}) =>
 		queryOptions({
-			queryKey: ['difficulties', 'tiers'] as const,
-			queryFn: () => difficultyAdapter.listTiers(),
-			staleTime: 1000 * 60 * 30, // 30 minutes
-			gcTime: 1000 * 60 * 60 // 1 hour
+			queryKey: ['difficulties', 'tiers', { withDrafts: !!opts.withDrafts }] as const,
+			queryFn: () => difficultyAdapter.listTiers({ withDrafts: opts.withDrafts }),
+			staleTime: opts.withDrafts ? 0 : 1000 * 60 * 30
 		}),
 
 	/**
 	 * List all difficulty rules (editor only)
 	 */
-	rules: (filters?: { component?: string; active?: boolean }) =>
+	rules: (filters: RuleFilters & { withDrafts?: boolean } = {}) =>
 		queryOptions({
 			queryKey: ['difficulties', 'rules', filters] as const,
 			queryFn: () => difficultyAdapter.listRules(filters),
-			staleTime: 1000 * 60 // 1 minute (changes frequently in editor)
+			staleTime: 1000 * 60
 		}),
 
 	/**
@@ -39,16 +44,26 @@ export const difficultyQueries = {
 		queryOptions({
 			queryKey: ['difficulties', 'rule_types'] as const,
 			queryFn: () => difficultyAdapter.getRuleTypes(),
-			staleTime: 1000 * 60 * 60 * 24 // 1 day - rule types rarely change
+			staleTime: 1000 * 60 * 60 * 24
 		}),
 
 	/**
 	 * List components (editor only)
 	 */
-	components: () =>
+	components: (opts: { withDrafts?: boolean } = {}) =>
 		queryOptions({
-			queryKey: ['difficulties', 'components'] as const,
-			queryFn: () => difficultyAdapter.listComponents(),
-			staleTime: 1000 * 60 // 1 minute
+			queryKey: ['difficulties', 'components', { withDrafts: !!opts.withDrafts }] as const,
+			queryFn: () => difficultyAdapter.listComponents({ withDrafts: opts.withDrafts }),
+			staleTime: 1000 * 60
+		}),
+
+	/**
+	 * Current editor's draft diff (drives the Commit button + dialog).
+	 */
+	diff: () =>
+		queryOptions({
+			queryKey: ['difficulties', 'diff'] as const,
+			queryFn: () => difficultyAdapter.getDiff(),
+			staleTime: 0
 		})
 }

--- a/src/lib/components/party/Party.svelte
+++ b/src/lib/components/party/Party.svelte
@@ -58,6 +58,8 @@
 		isNew?: boolean
 		ensurePartyExists?: () => Promise<{ id: string; shortcode: string }>
 		initialCollectionSourceUsername?: string
+		/** When true, the difficulty tier chip becomes a link to the editor preview */
+		isEditor?: boolean
 	}
 
 	let {
@@ -69,7 +71,8 @@
 		initialTab,
 		isNew = false,
 		ensurePartyExists,
-		initialCollectionSourceUsername
+		initialCollectionSourceUsername,
+		isEditor = false
 	}: Props = $props()
 
 	// Default empty party
@@ -448,6 +451,7 @@
 				{authUser}
 				{activeCollectionUser}
 				onSwitchCollectionUser={handleSwitchCollectionUser}
+				{isEditor}
 			>
 				{#snippet menu()}
 					{#if !isNew}

--- a/src/lib/components/party/info/DescriptionTile.svelte
+++ b/src/lib/components/party/info/DescriptionTile.svelte
@@ -57,6 +57,10 @@
 		summonCount?: number | null
 		// Computed difficulty assignment (null when not yet scoreable)
 		difficulty?: PartyDifficulty | null
+		/** Party shortcode, used to build the editor preview link */
+		shortcode?: string
+		/** When true, the difficulty tier chip becomes a link to the editor preview */
+		isEditor?: boolean
 	}
 
 	let {
@@ -84,8 +88,14 @@
 		buttonCount,
 		chainCount,
 		summonCount,
-		difficulty
+		difficulty,
+		shortcode,
+		isEditor = false
 	}: Props = $props()
+
+	const difficultyPreviewHref = $derived(
+		shortcode ? `/database/difficulties?tab=preview&shortcode=${shortcode}` : null
+	)
 
 	const showCollectionSwitcher = $derived(
 		!!authUser?.username &&
@@ -420,9 +430,21 @@
 						score: difficulty.score.toFixed(0)
 					})}
 				>
-					<span class="token difficulty" style:background={difficulty.tier.color || undefined}>
-						{difficulty.tier.name}
-					</span>
+					{#if isEditor && difficultyPreviewHref}
+						<a
+							class="token difficulty editor-link"
+							style:background={difficulty.tier.color || undefined}
+							href={difficultyPreviewHref}
+							target="_blank"
+							rel="noopener"
+						>
+							{difficulty.tier.name}
+						</a>
+					{:else}
+						<span class="token difficulty" style:background={difficulty.tier.color || undefined}>
+							{difficulty.tier.name}
+						</span>
+					{/if}
 				</Tooltip>
 			{/if}
 			{#if solo}
@@ -710,6 +732,23 @@
 
 		&.difficulty {
 			color: #1a1a1a;
+		}
+
+		&.editor-link {
+			text-decoration: none;
+			cursor: pointer;
+			transition:
+				opacity 120ms ease,
+				transform 120ms ease;
+
+			&:hover {
+				opacity: 0.85;
+			}
+
+			&:focus-visible {
+				outline: 2px solid var(--focus-ring);
+				outline-offset: 2px;
+			}
 		}
 
 		&.chargeAttack.on {

--- a/src/lib/components/party/info/DescriptionTile.svelte
+++ b/src/lib/components/party/info/DescriptionTile.svelte
@@ -429,7 +429,7 @@
 				<Tooltip
 					content={m.party_difficulty_tooltip({
 						tier: difficulty.tier.name,
-						score: difficulty.score.toFixed(0)
+						score: difficulty.score?.toFixed(0) ?? '—'
 					})}
 				>
 					{#if isEditor && difficultyPreviewHref}

--- a/src/lib/components/party/info/DescriptionTile.svelte
+++ b/src/lib/components/party/info/DescriptionTile.svelte
@@ -94,7 +94,9 @@
 	}: Props = $props()
 
 	const difficultyPreviewHref = $derived(
-		shortcode ? `/database/difficulties?tab=preview&shortcode=${shortcode}` : null
+		shortcode
+			? `/database/difficulties?tab=preview&shortcode=${encodeURIComponent(shortcode)}`
+			: null
 	)
 
 	const showCollectionSwitcher = $derived(

--- a/src/lib/components/party/info/PartyInfoGrid.svelte
+++ b/src/lib/components/party/info/PartyInfoGrid.svelte
@@ -29,6 +29,7 @@
 		authUser?: AvatarUser | null
 		activeCollectionUser?: 'viewer' | 'source'
 		onSwitchCollectionUser?: (target: 'viewer' | 'source') => void
+		isEditor?: boolean
 	}
 
 	let {
@@ -41,7 +42,8 @@
 		menu,
 		authUser,
 		activeCollectionUser,
-		onSwitchCollectionUser
+		onSwitchCollectionUser,
+		isEditor = false
 	}: Props = $props()
 
 	// Check if data exists for each tile
@@ -111,6 +113,8 @@
 			chainCount={party.chainCount}
 			summonCount={party.summonCount}
 			difficulty={party.difficulty}
+			shortcode={party.shortcode}
+			{isEditor}
 		/>
 	</div>
 

--- a/src/lib/components/ui/Notice.svelte
+++ b/src/lib/components/ui/Notice.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte'
 
-	type Variant = 'blue' | 'yellow' | 'red' | 'wind' | 'fire' | 'water' | 'earth' | 'light' | 'dark'
+	type Variant =
+		| 'gray'
+		| 'blue'
+		| 'yellow'
+		| 'red'
+		| 'wind'
+		| 'fire'
+		| 'water'
+		| 'earth'
+		| 'light'
+		| 'dark'
 
 	interface Props {
 		variant?: Variant
@@ -9,7 +19,7 @@
 		children: Snippet
 	}
 
-	let { variant = 'blue', icon, children }: Props = $props()
+	let { variant = 'gray', icon, children }: Props = $props()
 
 	const elementVariants = ['wind', 'fire', 'water', 'earth', 'light', 'dark']
 	const isElement = $derived(elementVariants.includes(variant))
@@ -21,9 +31,9 @@
 			{@render icon()}
 		</span>
 	{/if}
-	<span class="notice-text">
+	<div class="notice-text">
 		{@render children()}
-	</span>
+	</div>
 </div>
 
 <style lang="scss">
@@ -40,25 +50,43 @@
 		font-size: $font-small;
 	}
 
+	.notice-text {
+		display: flex;
+		flex-direction: column;
+		gap: $unit;
+		font-size: $font-regular;
+		line-height: 1.5;
+		margin: 0;
+
+		:global(p) {
+			margin: 0;
+		}
+	}
+
 	.notice-icon {
 		display: flex;
 		flex-shrink: 0;
 	}
 
 	// Fixed color variants
+	.gray {
+		background: var(--notice-grey-bg);
+		color: var(--notice-grey-text);
+	}
+
 	.blue {
-		background: var(--blue-subtle);
-		color: var(--accent-blue);
+		background: var(--notice-blue-bg);
+		color: var(--notice-blue-text);
 	}
 
 	.yellow {
-		background: rgba(209, 137, 58, 0.15);
-		color: var(--accent-yellow);
+		background: var(--notice-yellow-bg);
+		color: var(--notice-yellow-text);
 	}
 
 	.red {
-		background: rgba(220, 53, 53, 0.15);
-		color: var(--red);
+		background: var(--notice-red-bg);
+		color: var(--notice-red-text);
 	}
 
 	// Element variants

--- a/src/lib/features/database/difficulties/CommitDialog.svelte
+++ b/src/lib/features/database/difficulties/CommitDialog.svelte
@@ -1,0 +1,341 @@
+<script lang="ts">
+	import { createMutation, useQueryClient } from '@tanstack/svelte-query'
+	import { toast } from 'svelte-sonner'
+	import Dialog from '$lib/components/ui/Dialog.svelte'
+	import ModalHeader from '$lib/components/ui/ModalHeader.svelte'
+	import ModalFooter from '$lib/components/ui/ModalFooter.svelte'
+	import { authStore } from '$lib/stores/auth.store.svelte'
+	import { getAvatarSrc } from '$lib/utils/avatar'
+	import { difficultyAdapter, type DifficultyDiff } from '$lib/api/adapters/difficulty.adapter'
+	import { extractErrorMessage } from '$lib/utils/errors'
+
+	interface Props {
+		open?: boolean
+		diff: DifficultyDiff | null
+		onCommitted?: () => void
+	}
+
+	let { open = $bindable(false), diff, onCommitted }: Props = $props()
+
+	let note = $state('')
+	const queryClient = useQueryClient()
+
+	const commitMut = createMutation(() => ({
+		mutationFn: (n: string) => difficultyAdapter.commitDrafts(n)
+	}))
+
+	$effect(() => {
+		if (open) note = ''
+	})
+
+	const totalChanges = $derived.by(() => {
+		if (!diff) return 0
+		return (
+			diff.tiers.creates.length +
+			diff.tiers.updates.length +
+			diff.tiers.destroys.length +
+			diff.rules.creates.length +
+			diff.rules.updates.length +
+			diff.rules.destroys.length +
+			diff.components.creates.length +
+			diff.components.updates.length +
+			diff.components.destroys.length
+		)
+	})
+
+	const sections = $derived.by(() => {
+		if (!diff) return []
+		return [
+			{ key: 'tiers', label: 'Tiers', data: diff.tiers },
+			{ key: 'rules', label: 'Rules', data: diff.rules },
+			{ key: 'components', label: 'Components', data: diff.components }
+		].filter((s) => s.data.creates.length + s.data.updates.length + s.data.destroys.length > 0)
+	})
+
+	async function handleSubmit() {
+		try {
+			await commitMut.mutateAsync(note.trim())
+			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
+			toast.success('Changes committed')
+			open = false
+			onCommitted?.()
+		} catch (err) {
+			toast.error(extractErrorMessage(err, 'Commit failed'))
+		}
+	}
+
+	function summarizeAttributes(attrs: Record<string, unknown>): string {
+		const entries = Object.entries(attrs).slice(0, 4)
+		return entries.map(([k, v]) => `${k}: ${stringify(v)}`).join(', ')
+	}
+
+	function stringify(value: unknown): string {
+		if (value == null) return '—'
+		if (typeof value === 'object') return JSON.stringify(value)
+		return String(value)
+	}
+
+	const avatarSrc = $derived(getAvatarSrc(authStore.user?.avatarUrl))
+</script>
+
+<Dialog bind:open size="small">
+	<ModalHeader
+		title="Commit difficulty changes"
+		description={totalChanges === 1
+			? '1 change will go live for everyone.'
+			: `${totalChanges} changes will go live for everyone.`}
+	/>
+
+	<div class="commit-body">
+		<div class="author">
+			<img class="avatar" src={avatarSrc} alt="" />
+			<span class="username">{authStore.user?.username ?? 'You'}</span>
+		</div>
+
+		{#if sections.length === 0}
+			<p class="empty">No pending changes.</p>
+		{/if}
+
+		{#each sections as section (section.key)}
+			<details class="section" open>
+				<summary>
+					<span class="section-label">{section.label}</span>
+					<span class="section-count">
+						{section.data.creates.length +
+							section.data.updates.length +
+							section.data.destroys.length}
+					</span>
+				</summary>
+				<ul class="entries">
+					{#each section.data.creates as entry (entry.draftId)}
+						<li class="entry create">
+							<span class="entry-op">New</span>
+							<span class="entry-label">{summarizeAttributes(entry.attributes)}</span>
+						</li>
+					{/each}
+					{#each section.data.updates as entry (entry.draftId)}
+						<li class="entry update">
+							<span class="entry-op">Edit</span>
+							<div class="entry-detail">
+								<span class="entry-label">{entry.label}</span>
+								<ul class="changes">
+									{#each Object.entries(entry.changes) as [field, change] (field)}
+										<li>
+											<span class="field-name">{field}</span>
+											<span class="from">{stringify(change.old)}</span>
+											<span class="arrow">→</span>
+											<span class="to">{stringify(change.new)}</span>
+										</li>
+									{/each}
+								</ul>
+							</div>
+						</li>
+					{/each}
+					{#each section.data.destroys as entry (entry.draftId)}
+						<li class="entry destroy">
+							<span class="entry-op">Delete</span>
+							<span class="entry-label">{entry.label}</span>
+						</li>
+					{/each}
+				</ul>
+			</details>
+		{/each}
+
+		<label class="note-label">
+			<span>Note (optional)</span>
+			<textarea
+				bind:value={note}
+				rows="3"
+				placeholder="What's the intent of this change?"
+				class="note-input"
+			></textarea>
+		</label>
+	</div>
+
+	<ModalFooter
+		onCancel={() => (open = false)}
+		primaryAction={{
+			label: commitMut.isPending ? 'Committing…' : 'Commit',
+			onclick: handleSubmit,
+			disabled: commitMut.isPending || totalChanges === 0
+		}}
+	/>
+</Dialog>
+
+<style lang="scss">
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+	@use '$src/themes/layout' as layout;
+
+	.commit-body {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-2x;
+		padding: 0 spacing.$unit-2x spacing.$unit-2x;
+		max-height: 60vh;
+		overflow-y: auto;
+	}
+
+	.author {
+		display: flex;
+		align-items: center;
+		gap: spacing.$unit;
+
+		.avatar {
+			width: spacing.$unit-4x;
+			height: spacing.$unit-4x;
+			border-radius: 50%;
+			background: var(--input-bg);
+		}
+
+		.username {
+			color: var(--text-primary);
+			font-weight: typography.$medium;
+		}
+	}
+
+	.empty {
+		color: var(--text-secondary);
+		margin: 0;
+	}
+
+	.section {
+		border: 1px solid var(--border-subtle);
+		border-radius: layout.$item-corner;
+		padding: spacing.$unit;
+
+		summary {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			cursor: pointer;
+			padding: spacing.$unit-half spacing.$unit;
+			list-style: none;
+
+			&::-webkit-details-marker {
+				display: none;
+			}
+		}
+
+		.section-label {
+			font-weight: typography.$bold;
+			color: var(--text-primary);
+		}
+
+		.section-count {
+			font-size: typography.$font-small;
+			color: var(--text-tertiary);
+		}
+	}
+
+	.entries {
+		list-style: none;
+		padding: 0;
+		margin: spacing.$unit 0 0 0;
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+	}
+
+	.entry {
+		display: flex;
+		align-items: flex-start;
+		gap: spacing.$unit;
+		padding: spacing.$unit;
+		background: var(--input-bg);
+		border-radius: layout.$item-corner;
+
+		.entry-op {
+			padding: spacing.$unit-fourth spacing.$unit;
+			border-radius: layout.$full-corner;
+			font-size: typography.$font-tiny;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+			background: var(--accent-yellow, var(--card-bg));
+			color: var(--text-primary);
+			flex-shrink: 0;
+		}
+
+		&.create .entry-op {
+			background: var(--accent-green, var(--input-bg));
+		}
+
+		&.destroy .entry-op {
+			background: var(--danger-bg-subtle);
+			color: var(--danger);
+		}
+
+		.entry-detail {
+			display: flex;
+			flex-direction: column;
+			gap: spacing.$unit-half;
+			min-width: 0;
+		}
+
+		.entry-label {
+			color: var(--text-primary);
+			font-weight: typography.$medium;
+		}
+	}
+
+	.changes {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-fourth;
+
+		li {
+			display: flex;
+			align-items: center;
+			flex-wrap: wrap;
+			gap: spacing.$unit-half;
+			font-size: typography.$font-small;
+			color: var(--text-secondary);
+
+			.field-name {
+				color: var(--text-tertiary);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+			}
+
+			.from {
+				color: var(--text-tertiary);
+				text-decoration: line-through;
+			}
+
+			.arrow {
+				color: var(--text-tertiary);
+			}
+
+			.to {
+				color: var(--text-primary);
+				font-weight: typography.$medium;
+			}
+		}
+	}
+
+	.note-label {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-half;
+		font-size: typography.$font-small;
+		color: var(--text-secondary);
+	}
+
+	.note-input {
+		padding: spacing.$unit;
+		border: 1px solid var(--border-subtle);
+		border-radius: layout.$input-corner;
+		background: var(--input-bg);
+		color: var(--text-primary);
+		font: inherit;
+		resize: vertical;
+
+		&:focus {
+			outline: 2px solid var(--focus-ring);
+			outline-offset: -1px;
+			border-color: transparent;
+		}
+	}
+</style>

--- a/src/lib/features/database/difficulties/ComponentsPanel.svelte
+++ b/src/lib/features/database/difficulties/ComponentsPanel.svelte
@@ -71,7 +71,7 @@
 							: Number(draft.targetMax)
 				}
 			})
-			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'components'] })
+			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
 			toast.success(`Saved ${comp.name}`)
 		} catch (err) {
 			toast.error(extractErrorMessage(err, `Failed to save ${comp.name}`))

--- a/src/lib/features/database/difficulties/ComponentsPanel.svelte
+++ b/src/lib/features/database/difficulties/ComponentsPanel.svelte
@@ -72,7 +72,7 @@
 				}
 			})
 			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
-			toast.success(`Saved ${comp.name}`)
+			toast.success(`${comp.name} change staged`)
 		} catch (err) {
 			toast.error(extractErrorMessage(err, `Failed to save ${comp.name}`))
 		}

--- a/src/lib/features/database/difficulties/PreviewPanel.svelte
+++ b/src/lib/features/database/difficulties/PreviewPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte'
 	import Input from '$lib/components/ui/Input.svelte'
 	import Button from '$lib/components/ui/Button.svelte'
 	import {
@@ -7,10 +8,20 @@
 	} from '$lib/api/adapters/difficulty.adapter'
 	import { extractErrorMessage } from '$lib/utils/errors'
 
-	let shortcode = $state('')
+	interface Props {
+		initialShortcode?: string
+	}
+
+	let { initialShortcode }: Props = $props()
+
+	let shortcode = $state(initialShortcode ?? '')
 	let result = $state<DifficultyPreviewResult | null>(null)
 	let error = $state<string | null>(null)
 	let loading = $state(false)
+
+	onMount(() => {
+		if (initialShortcode && initialShortcode.trim()) runPreview()
+	})
 
 	async function runPreview() {
 		const code = shortcode.trim()
@@ -69,10 +80,6 @@
 </script>
 
 <div class="preview-panel">
-	<p class="hint">
-		Score a real party against the current ruleset without persisting. Useful when tuning weights.
-	</p>
-
 	<div class="input-row">
 		<div class="input-wrapper">
 			<Input
@@ -84,7 +91,12 @@
 				onkeydown={handleKey}
 			/>
 		</div>
-		<Button variant="primary" onclick={runPreview} disabled={loading || !shortcode.trim()}>
+		<Button
+			variant="primary"
+			size="regular"
+			onclick={runPreview}
+			disabled={loading || !shortcode.trim()}
+		>
 			{loading ? 'Running…' : 'Run preview'}
 		</Button>
 	</div>

--- a/src/lib/features/database/difficulties/PreviewPanel.svelte
+++ b/src/lib/features/database/difficulties/PreviewPanel.svelte
@@ -93,7 +93,7 @@
 		</div>
 		<Button
 			variant="primary"
-			size="regular"
+			size="medium"
 			onclick={runPreview}
 			disabled={loading || !shortcode.trim()}
 		>

--- a/src/lib/features/database/difficulties/RuleModal.svelte
+++ b/src/lib/features/database/difficulties/RuleModal.svelte
@@ -125,7 +125,7 @@
 				await createMut.mutateAsync(payload)
 			}
 			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
-			toast.success(isEditing ? 'Rule updated' : 'Rule created')
+			toast.success(isEditing ? 'Rule change staged' : 'Rule creation staged')
 			open = false
 			onOpenChange?.(false)
 		} catch (err) {
@@ -140,7 +140,7 @@
 		try {
 			await deleteMut.mutateAsync(rule.id)
 			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
-			toast.success('Rule deleted')
+			toast.success('Rule deletion staged')
 			confirmDeleteOpen = false
 			open = false
 			onOpenChange?.(false)

--- a/src/lib/features/database/difficulties/RuleModal.svelte
+++ b/src/lib/features/database/difficulties/RuleModal.svelte
@@ -124,7 +124,7 @@
 			} else {
 				await createMut.mutateAsync(payload)
 			}
-			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'rules'] })
+			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
 			toast.success(isEditing ? 'Rule updated' : 'Rule created')
 			open = false
 			onOpenChange?.(false)
@@ -139,7 +139,7 @@
 		if (!rule) return
 		try {
 			await deleteMut.mutateAsync(rule.id)
-			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'rules'] })
+			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
 			toast.success('Rule deleted')
 			confirmDeleteOpen = false
 			open = false

--- a/src/lib/features/database/difficulties/RuleRow.svelte
+++ b/src/lib/features/database/difficulties/RuleRow.svelte
@@ -9,32 +9,44 @@
 	let { rule, onclick }: Props = $props()
 
 	const interactive = $derived(!!onclick)
+	const pendingLabel = $derived.by(() => {
+		switch (rule.pendingOperation) {
+			case 'create':
+				return 'New'
+			case 'destroy':
+				return 'Will delete'
+			case 'update':
+				return 'Pending'
+			default:
+				return null
+		}
+	})
 </script>
+
+{#snippet body()}
+	<div class="primary">
+		<span class="name">{rule.name}</span>
+		<span class="rule-type">{rule.ruleType}</span>
+	</div>
+	<div class="meta">
+		<span class="component-pill" data-component={rule.component}>{rule.component}</span>
+		<span class="weight">×{rule.weight}</span>
+		{#if !rule.active}
+			<span class="status-pill">Inactive</span>
+		{/if}
+		{#if pendingLabel}
+			<span class="pending-pill" data-operation={rule.pendingOperation}>{pendingLabel}</span>
+		{/if}
+	</div>
+{/snippet}
 
 {#if interactive}
 	<button class="rule-row interactive" {onclick} class:inactive={!rule.active}>
-		<div class="primary">
-			<span class="name">{rule.name}</span>
-			<span class="rule-type">{rule.ruleType}</span>
-		</div>
-		<div class="meta">
-			<span class="component-pill" data-component={rule.component}>{rule.component}</span>
-			<span class="weight">×{rule.weight}</span>
-			{#if !rule.active}
-				<span class="status-pill">Inactive</span>
-			{/if}
-		</div>
+		{@render body()}
 	</button>
 {:else}
 	<div class="rule-row" class:inactive={!rule.active}>
-		<div class="primary">
-			<span class="name">{rule.name}</span>
-			<span class="rule-type">{rule.ruleType}</span>
-		</div>
-		<div class="meta">
-			<span class="component-pill" data-component={rule.component}>{rule.component}</span>
-			<span class="weight">×{rule.weight}</span>
-		</div>
+		{@render body()}
 	</div>
 {/if}
 
@@ -111,6 +123,26 @@
 			font-size: typography.$font-tiny;
 			text-transform: uppercase;
 			letter-spacing: 0.05em;
+		}
+
+		.pending-pill {
+			padding: spacing.$unit-fourth spacing.$unit;
+			border-radius: layout.$full-corner;
+			background: var(--accent-yellow, var(--input-bg));
+			color: var(--text-primary);
+			font-size: typography.$font-tiny;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+
+			&[data-operation='destroy'] {
+				background: var(--danger-bg-subtle);
+				color: var(--danger);
+			}
+
+			&[data-operation='create'] {
+				background: var(--accent-green, var(--input-bg));
+				color: var(--text-primary);
+			}
 		}
 
 		&.interactive {

--- a/src/lib/features/database/difficulties/TierIcon.svelte
+++ b/src/lib/features/database/difficulties/TierIcon.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { getTierIconUrl } from '$lib/utils/difficulty'
+
+	interface Props {
+		imageKey?: string | null | undefined
+		/** Direct image URL override; takes precedence over imageKey (used for upload previews) */
+		src?: string | null | undefined
+		/** Fallback color swatch when no image is present */
+		color?: string | null | undefined
+		name?: string
+		/** Outer rounded-rect container size in px */
+		size?: number
+		/** Image size in px; defaults to the container size (image fills) */
+		imageSize?: number
+	}
+
+	let { imageKey, src, color, name = '', size = 32, imageSize }: Props = $props()
+
+	const url = $derived(src ?? getTierIconUrl(imageKey))
+	const containerStyle = $derived(
+		url
+			? `width: ${size}px; height: ${size}px;`
+			: `width: ${size}px; height: ${size}px; background: ${color || 'var(--placeholder-bg)'};`
+	)
+	const imgSizePx = $derived(imageSize ?? size)
+	const imageStyle = $derived(`width: ${imgSizePx}px; height: ${imgSizePx}px;`)
+</script>
+
+<span class="tier-icon" style={containerStyle} aria-hidden={!name}>
+	{#if url}
+		<img src={url} alt={name} style={imageStyle} />
+	{/if}
+</span>
+
+<style lang="scss">
+	@use '$src/themes/layout' as layout;
+
+	.tier-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 50%;
+		overflow: hidden;
+		flex-shrink: 0;
+		border: 1px solid var(--border-subtle);
+
+		img {
+			object-fit: contain;
+		}
+	}
+</style>

--- a/src/lib/features/database/difficulties/TierModal.svelte
+++ b/src/lib/features/database/difficulties/TierModal.svelte
@@ -102,7 +102,7 @@
 				await createMut.mutateAsync(buildPayload())
 			}
 			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
-			toast.success(isEditing ? 'Tier updated' : 'Tier created')
+			toast.success(isEditing ? 'Tier change staged' : 'Tier creation staged')
 			open = false
 			onOpenChange?.(false)
 		} catch (err) {
@@ -117,7 +117,7 @@
 		try {
 			await deleteMut.mutateAsync(tier.id)
 			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
-			toast.success('Tier deleted')
+			toast.success('Tier deletion staged')
 			confirmDeleteOpen = false
 			open = false
 			onOpenChange?.(false)

--- a/src/lib/features/database/difficulties/TierModal.svelte
+++ b/src/lib/features/database/difficulties/TierModal.svelte
@@ -10,6 +10,10 @@
 	import { difficultyAdapter } from '$lib/api/adapters/difficulty.adapter'
 	import type { DifficultyTier } from '$lib/types/api/party'
 	import { extractErrorMessage } from '$lib/utils/errors'
+	import TierIcon from '$lib/features/database/difficulties/TierIcon.svelte'
+
+	const ICON_MAX_DIMENSION = 128
+	const ICON_MAX_BYTES = 256 * 1024
 
 	interface Props {
 		open?: boolean
@@ -30,6 +34,13 @@
 	let minScore = $state<number>(0)
 	let maxScore = $state<number>(100)
 	let sortOrder = $state<number>(0)
+	let iconFile = $state<File | null>(null)
+	let iconPreview = $state<string | null>(null)
+	let iconError = $state<string | null>(null)
+	let iconInputRef: HTMLInputElement | undefined = $state(undefined)
+	let isUploadingIcon = $state(false)
+	// Tracks intent to clear an existing tier.imageKey without uploading a new one.
+	let removeIcon = $state(false)
 
 	const queryClient = useQueryClient()
 
@@ -49,6 +60,10 @@
 
 	$effect(() => {
 		if (open) {
+			iconFile = null
+			iconPreview = null
+			iconError = null
+			removeIcon = false
 			if (tier) {
 				name = tier.name ?? ''
 				slug = tier.slug ?? ''
@@ -69,8 +84,71 @@
 		}
 	})
 
+	function openIconPicker() {
+		iconInputRef?.click()
+	}
+
+	async function readDataUrl(file: File): Promise<string> {
+		return new Promise((resolve, reject) => {
+			const reader = new FileReader()
+			reader.onload = () => resolve(reader.result as string)
+			reader.onerror = () => reject(reader.error)
+			reader.readAsDataURL(file)
+		})
+	}
+
+	async function checkDimensions(dataUrl: string): Promise<{ width: number; height: number }> {
+		return new Promise((resolve, reject) => {
+			const img = new Image()
+			img.onload = () => resolve({ width: img.width, height: img.height })
+			img.onerror = () => reject(new Error('Could not decode image'))
+			img.src = dataUrl
+		})
+	}
+
+	async function handleIconSelect(e: Event) {
+		iconError = null
+		const input = e.target as HTMLInputElement
+		const file = input.files?.[0]
+		if (!file) return
+
+		if (file.type !== 'image/png') {
+			iconError = 'Icon must be a PNG.'
+			input.value = ''
+			return
+		}
+		if (file.size > ICON_MAX_BYTES) {
+			iconError = 'Icon must be 256KB or smaller.'
+			input.value = ''
+			return
+		}
+
+		const dataUrl = await readDataUrl(file)
+		const { width, height } = await checkDimensions(dataUrl)
+		if (width > ICON_MAX_DIMENSION || height > ICON_MAX_DIMENSION) {
+			iconError = `Icon must be ${ICON_MAX_DIMENSION}x${ICON_MAX_DIMENSION} or smaller.`
+			input.value = ''
+			return
+		}
+
+		iconFile = file
+		iconPreview = dataUrl
+		removeIcon = false
+	}
+
+	function clearIcon() {
+		iconFile = null
+		iconPreview = null
+		iconError = null
+		if (iconInputRef) iconInputRef.value = ''
+	}
+
+	function toggleRemoveIcon() {
+		removeIcon = !removeIcon
+	}
+
 	function buildPayload(): Partial<DifficultyTier> {
-		return {
+		const payload: Partial<DifficultyTier> = {
 			name: name.trim(),
 			slug: slug.trim(),
 			color,
@@ -79,6 +157,10 @@
 			maxScore,
 			sortOrder
 		}
+		// Clearing an existing icon is expressed as imageKey: null; uploading a
+		// new icon goes through uploadDraftImage after the draft is staged.
+		if (removeIcon && !iconFile) payload.imageKey = null
+		return payload
 	}
 
 	const canSave = $derived(
@@ -95,14 +177,40 @@
 			return
 		}
 
+		let iconUploadError: unknown = null
 		try {
-			if (isEditing && tier) {
-				await updateMut.mutateAsync({ id: tier.id, data: buildPayload() })
-			} else {
-				await createMut.mutateAsync(buildPayload())
+			const result =
+				isEditing && tier
+					? await updateMut.mutateAsync({ id: tier.id, data: buildPayload() })
+					: await createMut.mutateAsync(buildPayload())
+
+			// Image upload runs after the draft is already staged. If it fails we
+			// surface a partial-success toast and still close the modal so the
+			// staged tier shows up in the list.
+			if (iconFile && result.draft?.id) {
+				isUploadingIcon = true
+				try {
+					const dataUrl = await readDataUrl(iconFile)
+					const base64 = dataUrl.replace(/^data:[^;]+;base64,/, '')
+					await difficultyAdapter.uploadDraftImage(result.draft.id, base64, iconFile.name)
+				} catch (err) {
+					iconUploadError = err
+				} finally {
+					isUploadingIcon = false
+				}
 			}
+
 			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
-			toast.success(isEditing ? 'Tier change staged' : 'Tier creation staged')
+			if (iconUploadError) {
+				toast.error(
+					extractErrorMessage(
+						iconUploadError,
+						'Tier change staged, but the icon upload failed — try Replace.'
+					)
+				)
+			} else {
+				toast.success(isEditing ? 'Tier change staged' : 'Tier creation staged')
+			}
 			open = false
 			onOpenChange?.(false)
 		} catch (err) {
@@ -154,6 +262,43 @@
 			</div>
 		</DetailItem>
 		<DetailItem
+			label="Icon"
+			sublabel="Optional. PNG, 128×128 or smaller, 256KB max. Shown next to the tier name."
+			editable={true}
+		>
+			<div class="icon-control">
+				<TierIcon
+					imageKey={removeIcon ? null : tier?.imageKey}
+					src={iconPreview}
+					{color}
+					{name}
+					size={40}
+				/>
+				<div class="icon-actions">
+					<Button variant="ghost" size="small" onclick={openIconPicker}>
+						{iconPreview || (tier?.imageKey && !removeIcon) ? 'Replace' : 'Upload'}
+					</Button>
+					{#if iconPreview}
+						<Button variant="ghost" size="small" onclick={clearIcon}>Cancel</Button>
+					{:else if tier?.imageKey}
+						<Button variant="ghost" size="small" onclick={toggleRemoveIcon}>
+							{removeIcon ? 'Undo' : 'Remove'}
+						</Button>
+					{/if}
+				</div>
+				<input
+					bind:this={iconInputRef}
+					type="file"
+					accept="image/png"
+					onchange={handleIconSelect}
+					class="icon-input-hidden"
+				/>
+				{#if iconError}
+					<p class="icon-error">{iconError}</p>
+				{/if}
+			</div>
+		</DetailItem>
+		<DetailItem
 			label="Sort Order"
 			sublabel="Lower values appear first in lists"
 			bind:value={sortOrder}
@@ -190,9 +335,9 @@
 	<ModalFooter
 		onCancel={() => (open = false)}
 		primaryAction={{
-			label: isSaving ? 'Saving…' : isEditing ? 'Save' : 'Create',
+			label: isSaving || isUploadingIcon ? 'Saving…' : isEditing ? 'Save' : 'Create',
 			onclick: handleSave,
-			disabled: isSaving || isDeleting || !canSave
+			disabled: isSaving || isUploadingIcon || isDeleting || !canSave
 		}}
 	>
 		{#snippet left()}
@@ -270,6 +415,29 @@
 		font-size: typography.$font-small;
 		color: var(--text-secondary);
 		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+	}
+
+	.icon-control {
+		display: flex;
+		align-items: center;
+		gap: spacing.$unit;
+		flex-wrap: wrap;
+	}
+
+	.icon-actions {
+		display: flex;
+		gap: spacing.$unit-half;
+	}
+
+	.icon-input-hidden {
+		display: none;
+	}
+
+	.icon-error {
+		flex-basis: 100%;
+		margin: 0;
+		color: var(--danger);
+		font-size: typography.$font-small;
 	}
 
 	.description-input {

--- a/src/lib/features/database/difficulties/TierModal.svelte
+++ b/src/lib/features/database/difficulties/TierModal.svelte
@@ -101,7 +101,7 @@
 			} else {
 				await createMut.mutateAsync(buildPayload())
 			}
-			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'tiers'] })
+			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
 			toast.success(isEditing ? 'Tier updated' : 'Tier created')
 			open = false
 			onOpenChange?.(false)
@@ -116,7 +116,7 @@
 		if (!tier) return
 		try {
 			await deleteMut.mutateAsync(tier.id)
-			await queryClient.invalidateQueries({ queryKey: ['difficulties', 'tiers'] })
+			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
 			toast.success('Tier deleted')
 			confirmDeleteOpen = false
 			open = false

--- a/src/lib/features/database/difficulties/TierRow.svelte
+++ b/src/lib/features/database/difficulties/TierRow.svelte
@@ -10,21 +10,41 @@
 
 	const scoreRange = $derived(`${tier.minScore ?? 0}–${tier.maxScore ?? 100}`)
 	const interactive = $derived(!!onclick)
+	const pendingLabel = $derived.by(() => {
+		switch (tier.pendingOperation) {
+			case 'create':
+				return 'New'
+			case 'destroy':
+				return 'Will delete'
+			case 'update':
+				return 'Pending'
+			default:
+				return null
+		}
+	})
 </script>
 
-{#if interactive}
-	<button class="tier-row interactive" {onclick}>
+{#snippet rowContent()}
+	<div class="left">
 		<span class="swatch" style:background={tier.color || 'var(--input-bg)'}></span>
-		<span class="name">{tier.name}</span>
-		<span class="slug">{tier.slug}</span>
-		<span class="range">{scoreRange}</span>
+		<span class="name-info">
+			<span class="name">{tier.name}</span>
+			<span class="slug">{tier.slug}</span>
+		</span>
+		{#if pendingLabel}
+			<span class="pending-pill" data-operation={tier.pendingOperation}>{pendingLabel}</span>
+		{/if}
+	</div>
+	<span class="range">{scoreRange}</span>
+{/snippet}
+
+{#if interactive}
+	<button class="tier-row interactive" class:pending={!!pendingLabel} {onclick}>
+		{@render rowContent()}
 	</button>
 {:else}
-	<div class="tier-row">
-		<span class="swatch" style:background={tier.color || 'var(--input-bg)'}></span>
-		<span class="name">{tier.name}</span>
-		<span class="slug">{tier.slug}</span>
-		<span class="range">{scoreRange}</span>
+	<div class="tier-row" class:pending={!!pendingLabel}>
+		{@render rowContent()}
 	</div>
 {/if}
 
@@ -34,8 +54,8 @@
 	@use '$src/themes/typography' as typography;
 
 	.tier-row {
-		display: grid;
-		grid-template-columns: auto 1fr auto auto;
+		display: flex;
+		justify-content: space-between;
 		align-items: center;
 		gap: spacing.$unit-2x;
 		padding: calc(spacing.$unit * 1.5) spacing.$unit;
@@ -46,6 +66,12 @@
 		font-family: inherit;
 		color: var(--text-primary);
 
+		.left {
+			display: flex;
+			align-items: center;
+			gap: spacing.$unit;
+		}
+
 		.swatch {
 			width: 18px;
 			height: 18px;
@@ -54,16 +80,22 @@
 			flex-shrink: 0;
 		}
 
-		.name {
-			font-size: typography.$font-regular;
-			color: var(--text-primary);
-			font-weight: typography.$medium;
-		}
+		.name-info {
+			display: flex;
+			flex-direction: column;
+			gap: spacing.$unit-fourth;
 
-		.slug {
-			font-size: typography.$font-small;
-			color: var(--text-tertiary);
-			font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+			.name {
+				font-size: typography.$font-regular;
+				color: var(--text-primary);
+				font-weight: typography.$medium;
+			}
+
+			.slug {
+				font-size: typography.$font-small;
+				color: var(--text-tertiary);
+				font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+			}
 		}
 
 		.range {
@@ -82,6 +114,26 @@
 
 			&:hover {
 				background: var(--page-hover);
+			}
+		}
+
+		.pending-pill {
+			padding: spacing.$unit-fourth spacing.$unit;
+			border-radius: layout.$full-corner;
+			background: var(--notice-yellow-bg);
+			color: var(--notice-yellow-text);
+			font-size: typography.$font-tiny;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+
+			&[data-operation='destroy'] {
+				background: var(--danger-bg-subtle);
+				color: var(--danger);
+			}
+
+			&[data-operation='create'] {
+				background: var(--accent-green, var(--input-bg));
+				color: var(--text-primary);
 			}
 		}
 	}

--- a/src/lib/features/database/difficulties/TierRow.svelte
+++ b/src/lib/features/database/difficulties/TierRow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { DifficultyTier } from '$lib/types/api/party'
+	import TierIcon from '$lib/features/database/difficulties/TierIcon.svelte'
 
 	interface Props {
 		tier: DifficultyTier
@@ -26,7 +27,7 @@
 
 {#snippet rowContent()}
 	<div class="left">
-		<span class="swatch" style:background={tier.color || 'var(--input-bg)'}></span>
+		<TierIcon imageKey={tier.imageKey} color={tier.color} name={tier.name} size={28} />
 		<span class="name-info">
 			<span class="name">{tier.name}</span>
 			<span class="slug">{tier.slug}</span>
@@ -70,14 +71,6 @@
 			display: flex;
 			align-items: center;
 			gap: spacing.$unit;
-		}
-
-		.swatch {
-			width: 18px;
-			height: 18px;
-			border-radius: 50%;
-			border: 1px solid var(--border-subtle);
-			flex-shrink: 0;
 		}
 
 		.name-info {

--- a/src/lib/types/api/party.ts
+++ b/src/lib/types/api/party.ts
@@ -136,17 +136,21 @@ export interface DifficultyTier {
 	description?: string
 	minScore?: number
 	maxScore?: number
+	/** Optional uploaded tier icon. Stored as an S3-style key, e.g. `images/difficulties/<id>.png` */
+	imageKey?: string | null
 	/** Editor-only metadata when the row reflects an unsaved draft */
 	pending?: boolean
 	pendingOperation?: 'create' | 'update' | 'destroy' | null
 	draftId?: string | null
 }
 
-// Embedded difficulty payload on Party
+// Embedded difficulty payload on Party. score/breakdown are null when the
+// party isn't yet scoreable (matches DifficultyPreviewResult on the editor
+// side).
 export interface PartyDifficulty {
 	tier: DifficultyTier | null
-	score: number
-	breakdown: Record<string, unknown>
+	score: number | null
+	breakdown: Record<string, unknown> | null
 	computedAt: string
 }
 

--- a/src/lib/types/api/party.ts
+++ b/src/lib/types/api/party.ts
@@ -136,6 +136,10 @@ export interface DifficultyTier {
 	description?: string
 	minScore?: number
 	maxScore?: number
+	/** Editor-only metadata when the row reflects an unsaved draft */
+	pending?: boolean
+	pendingOperation?: 'create' | 'update' | 'destroy' | null
+	draftId?: string | null
 }
 
 // Embedded difficulty payload on Party

--- a/src/lib/utils/difficulty.ts
+++ b/src/lib/utils/difficulty.ts
@@ -1,0 +1,16 @@
+/**
+ * Difficulty tier icon URL helper.
+ *
+ * Tiers store an S3-style key on the backend (e.g. `images/difficulties/<uuid>.png`,
+ * versioned with `?v=<updated_at>` to bust caches). The public icon URL is built
+ * by joining that key with the configured image base — same pattern as Role icons.
+ */
+
+import { getBasePath } from '$lib/utils/images'
+
+export function getTierIconUrl(imageKey: string | null | undefined): string | null {
+	if (!imageKey) return null
+	const base = getBasePath().replace(/\/$/, '')
+	const path = imageKey.replace(/^images\//, '').replace(/^\//, '')
+	return `${base}/${path}`
+}

--- a/src/routes/(app)/database/difficulties/+page.svelte
+++ b/src/routes/(app)/database/difficulties/+page.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
-	import { createQuery } from '@tanstack/svelte-query'
+	import { onMount } from 'svelte'
+	import { goto } from '$app/navigation'
+	import { page } from '$app/stores'
+	import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query'
+	import { toast } from 'svelte-sonner'
 	import PageMeta from '$lib/components/PageMeta.svelte'
 	import DatabasePageHeader from '$lib/components/database/DatabasePageHeader.svelte'
 	import SegmentedControl from '$lib/components/ui/segmented-control/SegmentedControl.svelte'
 	import Segment from '$lib/components/ui/segmented-control/Segment.svelte'
 	import Button from '$lib/components/ui/Button.svelte'
+	import ConfirmDialog from '$lib/components/ui/ConfirmDialog.svelte'
 	import * as m from '$lib/paraglide/messages'
+	import { difficultyAdapter } from '$lib/api/adapters/difficulty.adapter'
 	import { difficultyQueries } from '$lib/api/queries/difficulty.queries'
+	import { extractErrorMessage } from '$lib/utils/errors'
 	import type { DifficultyTier } from '$lib/types/api/party'
 	import type { DifficultyRule } from '$lib/api/adapters/difficulty.adapter'
 	import TierRow from '$lib/features/database/difficulties/TierRow.svelte'
@@ -15,22 +22,49 @@
 	import RuleModal from '$lib/features/database/difficulties/RuleModal.svelte'
 	import ComponentsPanel from '$lib/features/database/difficulties/ComponentsPanel.svelte'
 	import PreviewPanel from '$lib/features/database/difficulties/PreviewPanel.svelte'
+	import CommitDialog from '$lib/features/database/difficulties/CommitDialog.svelte'
+	import Notice from '$lib/components/ui/Notice.svelte'
 
 	type Tab = 'tiers' | 'rules' | 'components' | 'preview'
 
 	let activeTab = $state<Tab>('tiers')
+	let initialShortcode = $state<string | undefined>(undefined)
 
-	const tiersQuery = createQuery(() => difficultyQueries.tiers())
-	const rulesQuery = createQuery(() => difficultyQueries.rules())
+	const queryClient = useQueryClient()
+
+	const tiersQuery = createQuery(() => difficultyQueries.tiers({ withDrafts: true }))
+	const rulesQuery = createQuery(() => difficultyQueries.rules({ withDrafts: true }))
+	const diffQuery = createQuery(() => difficultyQueries.diff())
 
 	const tiers = $derived(tiersQuery.data ?? [])
 	const rules = $derived(rulesQuery.data ?? [])
+	const pendingCount = $derived(diffQuery.data?.pendingCount ?? 0)
+	const diff = $derived(diffQuery.data?.diff ?? null)
 
 	// Modal state
 	let tierModalOpen = $state(false)
 	let editingTier = $state<DifficultyTier | null>(null)
 	let ruleModalOpen = $state(false)
 	let editingRule = $state<DifficultyRule | null>(null)
+	let commitDialogOpen = $state(false)
+	let confirmDiscardOpen = $state(false)
+
+	const discardMut = createMutation(() => ({
+		mutationFn: () => difficultyAdapter.discardDrafts()
+	}))
+
+	async function handleConfirmDiscard() {
+		try {
+			const { discarded } = await discardMut.mutateAsync()
+			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
+			toast.success(
+				discarded === 1 ? 'Discarded 1 pending change' : `Discarded ${discarded} pending changes`
+			)
+			confirmDiscardOpen = false
+		} catch (err) {
+			toast.error(extractErrorMessage(err, 'Failed to discard drafts'))
+		}
+	}
 
 	function openNewTier() {
 		editingTier = null
@@ -65,6 +99,32 @@
 		{ value: 'job', label: 'Job' },
 		{ value: 'accessory', label: 'Accessory' }
 	]
+
+	const TABS: Tab[] = ['tiers', 'rules', 'components', 'preview']
+
+	onMount(() => {
+		const params = $page.url.searchParams
+		const tabParam = params.get('tab')
+		if (tabParam && (TABS as string[]).includes(tabParam)) {
+			activeTab = tabParam as Tab
+		}
+		const shortcode = params.get('shortcode')
+		if (shortcode) initialShortcode = shortcode
+	})
+
+	$effect(() => {
+		const next = new URL($page.url)
+		// Treat a missing param as the default tab so the effect doesn't loop on first mount.
+		const current = next.searchParams.get('tab') ?? 'tiers'
+		if (current === activeTab) return
+		if (activeTab === 'tiers') next.searchParams.delete('tab')
+		else next.searchParams.set('tab', activeTab)
+		goto(next.pathname + (next.search || ''), {
+			replaceState: true,
+			noScroll: true,
+			keepFocus: true
+		})
+	})
 </script>
 
 <PageMeta
@@ -77,6 +137,26 @@
 		{#snippet leftAction()}
 			<Button variant="ghost" size="small" leftIcon="chevron-left" href="/database/weapons">
 				Back
+			</Button>
+		{/snippet}
+		{#snippet rightAction()}
+			{#if pendingCount > 0}
+				<Button
+					variant="ghost"
+					size="small"
+					onclick={() => (confirmDiscardOpen = true)}
+					disabled={discardMut.isPending}
+				>
+					Discard
+				</Button>
+			{/if}
+			<Button
+				variant="primary"
+				size="small"
+				onclick={() => (commitDialogOpen = true)}
+				disabled={pendingCount === 0}
+			>
+				{pendingCount > 0 ? `Commit (${pendingCount})` : 'Commit'}
 			</Button>
 		{/snippet}
 	</DatabasePageHeader>
@@ -94,13 +174,12 @@
 		{#if activeTab === 'tiers'}
 			<section class="section">
 				<header class="section-header">
-					<div>
-						<h2>Tiers</h2>
-						<p class="section-hint">Score ranges that label each party.</p>
-					</div>
-					<Button variant="ghost" size="small" leftIcon="plus" onclick={openNewTier}>
-						New tier
-					</Button>
+					<Notice variant="gray">
+						<p>
+							Define score ranges called tiers that sort parties by how difficult they are to
+							create.
+						</p>
+					</Notice>
 				</header>
 				{#if tiersQuery.isLoading}
 					<p class="empty">Loading tiers…</p>
@@ -112,6 +191,14 @@
 						</Button>
 					</div>
 				{:else}
+					<div class="section-header-row">
+						<div class="section-count">
+							<span class="count">{tiers.length} tier{tiers.length === 1 ? '' : 's'}</span>
+						</div>
+						<Button variant="ghost" contained size="small" leftIcon="plus" onclick={openNewTier}>
+							New tier
+						</Button>
+					</div>
 					<div class="rows">
 						{#each tiers as tier (tier.id)}
 							<TierRow {tier} onclick={() => openEditTier(tier)} />
@@ -122,15 +209,12 @@
 		{:else if activeTab === 'rules'}
 			<section class="section">
 				<header class="section-header">
-					<div>
-						<h2>Rules</h2>
-						<p class="section-hint">
-							Each rule contributes its weight to its component when its condition fires.
+					<Notice variant="gray">
+						<p>
+							Define rules that contribute to the score of each component. Each rule contributes its
+							weight to its component when its condition fires.
 						</p>
-					</div>
-					<Button variant="ghost" size="small" leftIcon="plus" onclick={openNewRule}>
-						New rule
-					</Button>
+					</Notice>
 				</header>
 
 				<div class="filter-bar">
@@ -139,9 +223,6 @@
 							<Segment value={f.value}>{f.label}</Segment>
 						{/each}
 					</SegmentedControl>
-					<span class="filter-count">
-						{filteredRules.length} rule{filteredRules.length === 1 ? '' : 's'}
-					</span>
 				</div>
 
 				{#if rulesQuery.isLoading}
@@ -151,6 +232,14 @@
 						<p>No rules match this filter.</p>
 					</div>
 				{:else}
+					<div class="section-header-row">
+						<span class="filter-count">
+							{filteredRules.length} match{filteredRules.length === 1 ? '' : 'es'}
+						</span>
+						<Button variant="ghost" contained size="small" leftIcon="plus" onclick={openNewRule}>
+							New rule
+						</Button>
+					</div>
 					<div class="rows">
 						{#each filteredRules as rule (rule.id)}
 							<RuleRow {rule} onclick={() => openEditRule(rule)} />
@@ -161,25 +250,29 @@
 		{:else if activeTab === 'components'}
 			<section class="section">
 				<header class="section-header">
-					<div>
-						<h2>Components</h2>
-						<p class="section-hint">
-							Per-component weight, scoreability threshold, and on/off switch. Components are
-							seeded; you can tune their values but cannot create or destroy them.
+					<Notice variant="gray">
+						<p>
+							Define per-component weight, scoreability threshold, and on/off switch. Components are
+							used to score parties and are defined in the API.
 						</p>
-					</div>
+						<p>
+							Components are seeded; you can tune their values but cannot create or destroy them.
+						</p>
+					</Notice>
 				</header>
 				<ComponentsPanel />
 			</section>
 		{:else}
 			<section class="section">
 				<header class="section-header">
-					<div>
-						<h2>Preview</h2>
-						<p class="section-hint">Test the current ruleset against any party by shortcode.</p>
-					</div>
+					<Notice variant="gray">
+						<p>
+							Use this tool to test the current ruleset against any party by shortcode. Changes
+							won't persist until you Commit them using the button at the top.
+						</p>
+					</Notice>
 				</header>
-				<PreviewPanel />
+				<PreviewPanel {initialShortcode} />
 			</section>
 		{/if}
 	</div>
@@ -187,6 +280,18 @@
 
 <TierModal bind:open={tierModalOpen} tier={editingTier} />
 <RuleModal bind:open={ruleModalOpen} rule={editingRule} />
+<CommitDialog bind:open={commitDialogOpen} {diff} />
+
+<ConfirmDialog
+	bind:open={confirmDiscardOpen}
+	title="Discard pending changes?"
+	message={pendingCount === 1
+		? '1 pending change will be discarded. This cannot be undone.'
+		: `${pendingCount} pending changes will be discarded. This cannot be undone.`}
+	confirmLabel="Discard"
+	loading={discardMut.isPending}
+	onconfirm={handleConfirmDiscard}
+/>
 
 <style lang="scss">
 	@use '$src/themes/spacing' as spacing;
@@ -220,8 +325,7 @@
 
 	.section-header {
 		display: flex;
-		justify-content: space-between;
-		align-items: flex-start;
+		flex-direction: column;
 		gap: spacing.$unit;
 
 		h2 {
@@ -232,11 +336,33 @@
 		}
 	}
 
+	.section-header-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: spacing.$unit;
+
+		.section-count {
+			font-size: typography.$font-regular;
+			color: var(--text-secondary);
+		}
+	}
+
 	.section-hint {
-		margin: spacing.$unit-half 0 0 0;
-		color: var(--text-secondary);
-		font-size: typography.$font-small;
-		max-width: 60ch;
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+		background: var(--notice-bg);
+		padding: spacing.$unit-2x;
+		border-radius: layout.$card-corner;
+		width: 100%;
+
+		p {
+			color: var(--notice-text);
+			font-size: typography.$font-regular;
+			line-height: 1.5;
+			margin: 0;
+		}
 	}
 
 	.filter-bar {

--- a/src/routes/(app)/teams/[id]/[[tab=tab]]/+page.svelte
+++ b/src/routes/(app)/teams/[id]/[[tab=tab]]/+page.svelte
@@ -75,6 +75,7 @@
 		authUserAvatar={data.currentUser
 			? { picture: data.currentUser.picture, element: data.currentUser.element }
 			: undefined}
+		isEditor={(data.account?.role ?? 0) >= 7}
 		{initialTab}
 	/>
 {:else}

--- a/src/themes/_colors.scss
+++ b/src/themes/_colors.scss
@@ -85,6 +85,7 @@ $accent--yellow--70: #d1aa4f;
 $accent--yellow--80: #deb351;
 $accent--yellow--90: #e6bd5e;
 $accent--yellow--100: #f9cc64;
+$accent--yellow--120: #fcf0c2;
 
 $selected--item--bg--dark: #f9cc645d;
 $selected--item--bg--dark--hover: #fcc33f81;
@@ -216,23 +217,81 @@ $placeholder--bound--bg--light--hover: $grey-75;
 $placeholder--bound--bg--dark--hover: $grey-20;
 
 // Color Definitions: Notices
-$notice--bg--light: $accent--yellow--100;
-$notice--bg--dark: $accent--yellow--00;
 
-$notice--text--light: $accent--yellow--20;
-$notice--text--dark: $accent--yellow--100;
+// Yellow
+$notice--yellow--bg--light: $accent--yellow--120;
+$notice--yellow--bg--dark: $accent--yellow--00;
 
-$notice--button--bg--light: $accent--yellow--80;
-$notice--button--bg--dark: $accent--yellow--20;
+$notice--yellow--text--light: $accent--yellow--20;
+$notice--yellow--text--dark: $accent--yellow--100;
 
-$notice--button--bg--light--hover: $accent--yellow--70;
-$notice--button--bg--dark--hover: $accent--yellow--10;
+$notice--yellow--button--bg--light: $accent--yellow--80;
+$notice--yellow--button--bg--dark: $accent--yellow--20;
 
-$notice--button--text--light: $accent--yellow--10;
-$notice--button--text--dark: $accent--yellow--90;
+$notice--yellow--button--bg--light--hover: $accent--yellow--70;
+$notice--yellow--button--bg--dark--hover: $accent--yellow--10;
 
-$notice--button--text--light--hover: $accent--yellow--00;
-$notice--button--text--dark--hover: $accent--yellow--100;
+$notice--yellow--button--bg--light--disabled: $accent--yellow--80;
+$notice--yellow--button--bg--dark--disabled: $accent--yellow--20;
+
+$notice--yellow--button--text--light: $accent--yellow--10;
+$notice--yellow--button--text--dark: $accent--yellow--90;
+
+$notice--yellow--button--text--light--hover: $accent--yellow--00;
+$notice--yellow--button--text--dark--hover: $accent--yellow--100;
+
+$notice--yellow--button--text--light--disabled: $accent--yellow--00;
+$notice--yellow--button--text--dark--disabled: $accent--yellow--100;
+
+// Blue
+$notice--blue--bg--light: $accent--blue--light;
+$notice--blue--bg--dark: $accent--blue--dark;
+
+$notice--blue--text--light: $accent--blue--light;
+$notice--blue--text--dark: $accent--blue--dark;
+
+$notice--blue--button--bg--light: $accent--blue--light;
+$notice--blue--button--bg--dark: $accent--blue--dark;
+
+$notice--blue--button--bg--light--hover: $accent--blue--light--focus;
+$notice--blue--button--bg--dark--hover: $accent--blue--dark--focus;
+
+$notice--blue--button--text--light: $accent--blue--light;
+$notice--blue--button--text--dark: $accent--blue--dark;
+
+$notice--blue--button--text--light--hover: $accent--blue--light--focus;
+$notice--blue--button--text--dark--hover: $accent--blue--dark--focus;
+
+$notice--blue--button--text--light--disabled: $accent--blue--light--focus;
+$notice--blue--button--text--dark--disabled: $accent--blue--dark--focus;
+
+$notice--blue--button--bg--light--disabled: $accent--blue--light--focus;
+$notice--blue--button--bg--dark--disabled: $accent--blue--dark--focus;
+
+// Grey
+$notice--grey--bg--light: $grey-90;
+$notice--grey--bg--dark: $grey-10;
+
+$notice--grey--text--light: $grey-50;
+$notice--grey--text--dark: $grey-80;
+
+$notice--grey--button--bg--light: $grey-100;
+$notice--grey--button--bg--dark: $grey-20;
+
+$notice--grey--button--bg--light--hover: $grey-100;
+$notice--grey--button--bg--dark--hover: $grey-20;
+
+$notice--grey--button--text--light: $grey-50;
+$notice--grey--button--text--dark: $grey-80;
+
+$notice--grey--button--text--light--hover: $grey-50;
+$notice--grey--button--text--dark--hover: $grey-80;
+
+$notice--grey--button--text--light--disabled: $grey-50;
+$notice--grey--button--text--dark--disabled: $grey-80;
+
+$notice--grey--button--bg--light--disabled: $grey-100;
+$notice--grey--button--bg--dark--disabled: $grey-20;
 
 // Color Definitions: Button
 $button--bg--light: $grey-85;

--- a/src/themes/_colors.scss
+++ b/src/themes/_colors.scss
@@ -69,6 +69,8 @@ $accent--blue--light: #275dc5;
 $accent--blue--light--focus: #0c398d;
 $accent--blue--dark: #6195f4;
 $accent--blue--dark--focus: #275dc5;
+$accent--blue--120: #d6e3f8;
+$accent--blue--00: #061e4c;
 
 $accent--yellow--light: #c89d39;
 $accent--yellow--dark: #f9cc64;
@@ -244,10 +246,10 @@ $notice--yellow--button--text--light--disabled: $accent--yellow--00;
 $notice--yellow--button--text--dark--disabled: $accent--yellow--100;
 
 // Blue
-$notice--blue--bg--light: $accent--blue--light;
-$notice--blue--bg--dark: $accent--blue--dark;
+$notice--blue--bg--light: $accent--blue--120;
+$notice--blue--bg--dark: $accent--blue--00;
 
-$notice--blue--text--light: $accent--blue--light;
+$notice--blue--text--light: $accent--blue--light--focus;
 $notice--blue--text--dark: $accent--blue--dark;
 
 $notice--blue--button--bg--light: $accent--blue--light;
@@ -256,14 +258,14 @@ $notice--blue--button--bg--dark: $accent--blue--dark;
 $notice--blue--button--bg--light--hover: $accent--blue--light--focus;
 $notice--blue--button--bg--dark--hover: $accent--blue--dark--focus;
 
-$notice--blue--button--text--light: $accent--blue--light;
-$notice--blue--button--text--dark: $accent--blue--dark;
+$notice--blue--button--text--light: $accent--blue--120;
+$notice--blue--button--text--dark: $accent--blue--00;
 
-$notice--blue--button--text--light--hover: $accent--blue--light--focus;
-$notice--blue--button--text--dark--hover: $accent--blue--dark--focus;
+$notice--blue--button--text--light--hover: $accent--blue--120;
+$notice--blue--button--text--dark--hover: $accent--blue--00;
 
-$notice--blue--button--text--light--disabled: $accent--blue--light--focus;
-$notice--blue--button--text--dark--disabled: $accent--blue--dark--focus;
+$notice--blue--button--text--light--disabled: $accent--blue--120;
+$notice--blue--button--text--dark--disabled: $accent--blue--00;
 
 $notice--blue--button--bg--light--disabled: $accent--blue--light--focus;
 $notice--blue--button--bg--dark--disabled: $accent--blue--dark--focus;

--- a/src/themes/themes.scss
+++ b/src/themes/themes.scss
@@ -123,14 +123,35 @@
 	--placeholder-bound-bg: #{colors.$placeholder--bound--bg--light};
 	--placeholder-bound-bg-hover: #{colors.$placeholder--bound--bg--light--hover};
 
-	// Light - Notices
-	--notice-bg: #{colors.$notice--bg--light};
-	--notice-text: #{colors.$notice--text--light};
+	// Light - Notices (Yellow)
+	--notice-yellow-bg: #{colors.$notice--yellow--bg--light};
+	--notice-yellow-text: #{colors.$notice--yellow--text--light};
+	--notice-yellow-button-bg: #{colors.$notice--yellow--button--bg--light};
+	--notice-yellow-button-bg-hover: #{colors.$notice--yellow--button--bg--light--hover};
+	--notice-yellow-button-text: #{colors.$notice--yellow--button--text--light};
+	--notice-yellow-button-text-hover: #{colors.$notice--yellow--button--text--light--hover};
+	--notice-yellow-button-text-disabled: #{colors.$notice--yellow--button--text--light--disabled};
+	--notice-yellow-button-bg-disabled: #{colors.$notice--yellow--button--bg--light--disabled};
 
-	--notice-button-bg: #{colors.$notice--button--bg--light};
-	--notice-button-bg-hover: #{colors.$notice--button--bg--light--hover};
-	--notice-button-text: #{colors.$notice--button--text--light};
-	--notice-button-text-hover: #{colors.$notice--button--text--light--hover};
+	// Light - Notices (Blue)
+	--notice-blue-bg: #{colors.$notice--blue--bg--light};
+	--notice-blue-text: #{colors.$notice--blue--text--light};
+	--notice-blue-button-bg: #{colors.$notice--blue--button--bg--light};
+	--notice-blue-button-bg-hover: #{colors.$notice--blue--button--bg--light--hover};
+	--notice-blue-button-text: #{colors.$notice--blue--button--text--light};
+	--notice-blue-button-text-hover: #{colors.$notice--blue--button--text--light--hover};
+	--notice-blue-button-text-disabled: #{colors.$notice--blue--button--text--light--disabled};
+	--notice-blue-button-bg-disabled: #{colors.$notice--blue--button--bg--light--disabled};
+
+	// Light - Notices (Grey)
+	--notice-grey-bg: #{colors.$notice--grey--bg--light};
+	--notice-grey-text: #{colors.$notice--grey--text--light};
+	--notice-grey-button-bg: #{colors.$notice--grey--button--bg--light};
+	--notice-grey-button-bg-hover: #{colors.$notice--grey--button--bg--light--hover};
+	--notice-grey-button-text: #{colors.$notice--grey--button--text--light};
+	--notice-grey-button-text-hover: #{colors.$notice--grey--button--text--light--hover};
+	--notice-grey-button-text-disabled: #{colors.$notice--grey--button--text--light--disabled};
+	--notice-grey-button-bg-disabled: #{colors.$notice--grey--button--bg--light--disabled};
 
 	// Light - Buttons
 	--button-bg: #{colors.$button--bg--light};
@@ -484,8 +505,8 @@
 	--toast-success-text: #2e7d32;
 	--toast-error-bg: #{colors.$error--bg--light};
 	--toast-error-text: #{colors.$error};
-	--toast-warning-bg: #{colors.$notice--bg--light};
-	--toast-warning-text: #{colors.$notice--text--light};
+	--toast-warning-bg: #{colors.$notice--yellow--bg--light};
+	--toast-warning-text: #{colors.$notice--yellow--text--light};
 	--toast-info-bg: #e3f2fd;
 	--toast-info-text: #1565c0;
 
@@ -613,14 +634,35 @@ html[data-theme='dark'] {
 	--placeholder-bound-bg: #{colors.$placeholder--bound--bg--dark};
 	--placeholder-bound-bg-hover: #{colors.$placeholder--bound--bg--dark--hover};
 
-	// Dark - Notices
-	--notice-bg: #{colors.$notice--bg--dark};
-	--notice-text: #{colors.$notice--text--dark};
+	// Dark - Notices (Yellow)
+	--notice-yellow-bg: #{colors.$notice--yellow--bg--dark};
+	--notice-yellow-text: #{colors.$notice--yellow--text--dark};
+	--notice-yellow-button-bg: #{colors.$notice--yellow--button--bg--dark};
+	--notice-yellow-button-bg-hover: #{colors.$notice--yellow--button--bg--dark--hover};
+	--notice-yellow-button-text: #{colors.$notice--yellow--button--text--dark};
+	--notice-yellow-button-text-hover: #{colors.$notice--yellow--button--text--dark--hover};
+	--notice-yellow-button-text-disabled: #{colors.$notice--yellow--button--text--dark--disabled};
+	--notice-yellow-button-bg-disabled: #{colors.$notice--yellow--button--bg--dark--disabled};
 
-	--notice-button-bg: #{colors.$notice--button--bg--dark};
-	--notice-button-bg-hover: #{colors.$notice--button--bg--dark--hover};
-	--notice-button-text: #{colors.$notice--button--text--dark};
-	--notice-button-text-hover: #{colors.$notice--button--text--dark--hover};
+	// Dark - Notices (Blue)
+	--notice-blue-bg: #{colors.$notice--blue--bg--dark};
+	--notice-blue-text: #{colors.$notice--blue--text--dark};
+	--notice-blue-button-bg: #{colors.$notice--blue--button--bg--dark};
+	--notice-blue-button-bg-hover: #{colors.$notice--blue--button--bg--dark--hover};
+	--notice-blue-button-text: #{colors.$notice--blue--button--text--dark};
+	--notice-blue-button-text-hover: #{colors.$notice--blue--button--text--dark--hover};
+	--notice-blue-button-text-disabled: #{colors.$notice--blue--button--text--dark--disabled};
+	--notice-blue-button-bg-disabled: #{colors.$notice--blue--button--bg--dark--disabled};
+
+	// Dark - Notices (Grey)
+	--notice-grey-bg: #{colors.$notice--grey--bg--dark};
+	--notice-grey-text: #{colors.$notice--grey--text--dark};
+	--notice-grey-button-bg: #{colors.$notice--grey--button--bg--dark};
+	--notice-grey-button-bg-hover: #{colors.$notice--grey--button--bg--dark--hover};
+	--notice-grey-button-text: #{colors.$notice--grey--button--text--dark};
+	--notice-grey-button-text-hover: #{colors.$notice--grey--button--text--dark--hover};
+	--notice-grey-button-text-disabled: #{colors.$notice--grey--button--text--dark--disabled};
+	--notice-grey-button-bg-disabled: #{colors.$notice--grey--button--bg--dark--disabled};
 
 	// Dark - Buttons
 	--button-bg: #{colors.$button--bg--dark};
@@ -974,8 +1016,8 @@ html[data-theme='dark'] {
 	--toast-success-text: #66bb6a;
 	--toast-error-bg: #{colors.$error--bg--dark};
 	--toast-error-text: #{colors.$error};
-	--toast-warning-bg: #{colors.$notice--bg--dark};
-	--toast-warning-text: #{colors.$notice--text--dark};
+	--toast-warning-bg: #{colors.$notice--yellow--bg--dark};
+	--toast-warning-text: #{colors.$notice--yellow--text--dark};
 	--toast-info-bg: #0d2744;
 	--toast-info-text: #64b5f6;
 


### PR DESCRIPTION
## Summary
- Tier/Rule/Component edits now stage as drafts instead of writing to canonical. The editor lists pick up a yellow \"Pending\" pill (or red \"Will delete\" / green \"New\") so what's pending is obvious at a glance.
- New header buttons: \"Commit (N)\" opens a dialog showing avatar + username + a per-section diff (Tiers / Rules / Components) with field-level `old → new` lines and an optional note textarea. \"Discard\" (only when there are pending changes) prompts a confirm before wiping all of the user's drafts.
- Preview tab and the difficulty list both feed through `with_drafts=true`, so the editor's pending state is reflected before commit.
- Bonus: clickable tier chip on the party detail page that opens `/database/difficulties?tab=preview&shortcode=…` in a new tab for editors (role ≥ 7) and auto-runs the preview.
- `Notice` color tokens split into per-variant trees (`--notice-yellow-*` / `--notice-blue-*` / `--notice-grey-*`) with a new `gray` default so notice components can pull tokens without inheriting toast-warning colors. Plus a `_colors.scss` reshuffle.

## Test plan
- [ ] Edit a tier weight / color, edit a rule, delete a component → header shows \"Commit (3)\" and each row gets a pending pill.
- [ ] Commit dialog lists all three groups with avatar + username + diffs; submit with optional note → drafts cleared, canonical updated.
- [ ] Discard → all pending cleared, lists refresh to canonical.
- [ ] As editor, open a scored party → tier chip is a link; cmd-click opens the editor preview tab with shortcode pre-filled and the preview auto-runs. As non-editor, chip is a plain span.