### PR TITLE
add tier icon picker + upload to the difficulty editor

### DIFF
--- a/src/lib/api/adapters/difficulty.adapter.ts
+++ b/src/lib/api/adapters/difficulty.adapter.ts
@@ -275,6 +275,24 @@ export class DifficultyAdapter extends BaseAdapter {
 			body: JSON.stringify({ note })
 		})
 	}
+
+	/**
+	 * Uploads a tier icon to the draft's S3 staging area. The image survives
+	 * there until commit (which promotes it to the canonical key) or discard
+	 * (which removes it). Pass the bare base64 — no `data:image/png;base64,` prefix.
+	 */
+	async uploadDraftImage(
+		draftId: string,
+		base64Image: string,
+		filename?: string,
+		options?: RequestOptions
+	): Promise<DifficultyDraft> {
+		return this.request<DifficultyDraft>(`/difficulty_drafts/${draftId}/upload_image`, {
+			...options,
+			method: 'POST',
+			body: JSON.stringify({ image: base64Image, filename })
+		})
+	}
 }
 
 export const difficultyAdapter = new DifficultyAdapter(DEFAULT_ADAPTER_CONFIG)

--- a/src/lib/components/party/info/DescriptionTile.svelte
+++ b/src/lib/components/party/info/DescriptionTile.svelte
@@ -427,7 +427,7 @@
 				<Tooltip
 					content={m.party_difficulty_tooltip({
 						tier: difficulty.tier.name,
-						score: difficulty.score.toFixed(0)
+						score: difficulty.score?.toFixed(0) ?? '—'
 					})}
 				>
 					{#if isEditor && difficultyPreviewHref}

--- a/src/lib/features/database/difficulties/PreviewPanel.svelte
+++ b/src/lib/features/database/difficulties/PreviewPanel.svelte
@@ -93,7 +93,7 @@
 		</div>
 		<Button
 			variant="primary"
-			size="regular"
+			size="medium"
 			onclick={runPreview}
 			disabled={loading || !shortcode.trim()}
 		>

--- a/src/lib/features/database/difficulties/TierIcon.svelte
+++ b/src/lib/features/database/difficulties/TierIcon.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { getTierIconUrl } from '$lib/utils/difficulty'
+
+	interface Props {
+		imageKey?: string | null | undefined
+		/** Direct image URL override; takes precedence over imageKey (used for upload previews) */
+		src?: string | null | undefined
+		/** Fallback color swatch when no image is present */
+		color?: string | null | undefined
+		name?: string
+		/** Outer rounded-rect container size in px */
+		size?: number
+		/** Image size in px; defaults to the container size (image fills) */
+		imageSize?: number
+	}
+
+	let { imageKey, src, color, name = '', size = 32, imageSize }: Props = $props()
+
+	const url = $derived(src ?? getTierIconUrl(imageKey))
+	const containerStyle = $derived(
+		url
+			? `width: ${size}px; height: ${size}px;`
+			: `width: ${size}px; height: ${size}px; background: ${color || 'var(--placeholder-bg)'};`
+	)
+	const imgSizePx = $derived(imageSize ?? size)
+	const imageStyle = $derived(`width: ${imgSizePx}px; height: ${imgSizePx}px;`)
+</script>
+
+<span class="tier-icon" style={containerStyle} aria-hidden={!name}>
+	{#if url}
+		<img src={url} alt={name} style={imageStyle} />
+	{/if}
+</span>
+
+<style lang="scss">
+	@use '$src/themes/layout' as layout;
+
+	.tier-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 50%;
+		overflow: hidden;
+		flex-shrink: 0;
+		border: 1px solid var(--border-subtle);
+
+		img {
+			object-fit: contain;
+		}
+	}
+</style>

--- a/src/lib/features/database/difficulties/TierModal.svelte
+++ b/src/lib/features/database/difficulties/TierModal.svelte
@@ -39,6 +39,8 @@
 	let iconError = $state<string | null>(null)
 	let iconInputRef: HTMLInputElement | undefined = $state(undefined)
 	let isUploadingIcon = $state(false)
+	// Tracks intent to clear an existing tier.imageKey without uploading a new one.
+	let removeIcon = $state(false)
 
 	const queryClient = useQueryClient()
 
@@ -61,6 +63,7 @@
 			iconFile = null
 			iconPreview = null
 			iconError = null
+			removeIcon = false
 			if (tier) {
 				name = tier.name ?? ''
 				slug = tier.slug ?? ''
@@ -130,6 +133,7 @@
 
 		iconFile = file
 		iconPreview = dataUrl
+		removeIcon = false
 	}
 
 	function clearIcon() {
@@ -139,8 +143,12 @@
 		if (iconInputRef) iconInputRef.value = ''
 	}
 
+	function toggleRemoveIcon() {
+		removeIcon = !removeIcon
+	}
+
 	function buildPayload(): Partial<DifficultyTier> {
-		return {
+		const payload: Partial<DifficultyTier> = {
 			name: name.trim(),
 			slug: slug.trim(),
 			color,
@@ -149,6 +157,10 @@
 			maxScore,
 			sortOrder
 		}
+		// Clearing an existing icon is expressed as imageKey: null; uploading a
+		// new icon goes through uploadDraftImage after the draft is staged.
+		if (removeIcon && !iconFile) payload.imageKey = null
+		return payload
 	}
 
 	const canSave = $derived(
@@ -240,13 +252,23 @@
 			editable={true}
 		>
 			<div class="icon-control">
-				<TierIcon imageKey={tier?.imageKey} src={iconPreview} {color} {name} size={40} />
+				<TierIcon
+					imageKey={removeIcon ? null : tier?.imageKey}
+					src={iconPreview}
+					{color}
+					{name}
+					size={40}
+				/>
 				<div class="icon-actions">
 					<Button variant="ghost" size="small" onclick={openIconPicker}>
-						{iconPreview || tier?.imageKey ? 'Replace' : 'Upload'}
+						{iconPreview || (tier?.imageKey && !removeIcon) ? 'Replace' : 'Upload'}
 					</Button>
 					{#if iconPreview}
 						<Button variant="ghost" size="small" onclick={clearIcon}>Cancel</Button>
+					{:else if tier?.imageKey}
+						<Button variant="ghost" size="small" onclick={toggleRemoveIcon}>
+							{removeIcon ? 'Undo' : 'Remove'}
+						</Button>
 					{/if}
 				</div>
 				<input

--- a/src/lib/features/database/difficulties/TierModal.svelte
+++ b/src/lib/features/database/difficulties/TierModal.svelte
@@ -10,6 +10,10 @@
 	import { difficultyAdapter } from '$lib/api/adapters/difficulty.adapter'
 	import type { DifficultyTier } from '$lib/types/api/party'
 	import { extractErrorMessage } from '$lib/utils/errors'
+	import TierIcon from '$lib/features/database/difficulties/TierIcon.svelte'
+
+	const ICON_MAX_DIMENSION = 128
+	const ICON_MAX_BYTES = 256 * 1024
 
 	interface Props {
 		open?: boolean
@@ -30,6 +34,11 @@
 	let minScore = $state<number>(0)
 	let maxScore = $state<number>(100)
 	let sortOrder = $state<number>(0)
+	let iconFile = $state<File | null>(null)
+	let iconPreview = $state<string | null>(null)
+	let iconError = $state<string | null>(null)
+	let iconInputRef: HTMLInputElement | undefined = $state(undefined)
+	let isUploadingIcon = $state(false)
 
 	const queryClient = useQueryClient()
 
@@ -49,6 +58,9 @@
 
 	$effect(() => {
 		if (open) {
+			iconFile = null
+			iconPreview = null
+			iconError = null
 			if (tier) {
 				name = tier.name ?? ''
 				slug = tier.slug ?? ''
@@ -68,6 +80,64 @@
 			}
 		}
 	})
+
+	function openIconPicker() {
+		iconInputRef?.click()
+	}
+
+	async function readDataUrl(file: File): Promise<string> {
+		return new Promise((resolve, reject) => {
+			const reader = new FileReader()
+			reader.onload = () => resolve(reader.result as string)
+			reader.onerror = () => reject(reader.error)
+			reader.readAsDataURL(file)
+		})
+	}
+
+	async function checkDimensions(dataUrl: string): Promise<{ width: number; height: number }> {
+		return new Promise((resolve, reject) => {
+			const img = new Image()
+			img.onload = () => resolve({ width: img.width, height: img.height })
+			img.onerror = () => reject(new Error('Could not decode image'))
+			img.src = dataUrl
+		})
+	}
+
+	async function handleIconSelect(e: Event) {
+		iconError = null
+		const input = e.target as HTMLInputElement
+		const file = input.files?.[0]
+		if (!file) return
+
+		if (file.type !== 'image/png') {
+			iconError = 'Icon must be a PNG.'
+			input.value = ''
+			return
+		}
+		if (file.size > ICON_MAX_BYTES) {
+			iconError = 'Icon must be 256KB or smaller.'
+			input.value = ''
+			return
+		}
+
+		const dataUrl = await readDataUrl(file)
+		const { width, height } = await checkDimensions(dataUrl)
+		if (width > ICON_MAX_DIMENSION || height > ICON_MAX_DIMENSION) {
+			iconError = `Icon must be ${ICON_MAX_DIMENSION}x${ICON_MAX_DIMENSION} or smaller.`
+			input.value = ''
+			return
+		}
+
+		iconFile = file
+		iconPreview = dataUrl
+	}
+
+	function clearIcon() {
+		iconFile = null
+		iconPreview = null
+		iconError = null
+		if (iconInputRef) iconInputRef.value = ''
+	}
 
 	function buildPayload(): Partial<DifficultyTier> {
 		return {
@@ -96,11 +166,22 @@
 		}
 
 		try {
-			if (isEditing && tier) {
-				await updateMut.mutateAsync({ id: tier.id, data: buildPayload() })
-			} else {
-				await createMut.mutateAsync(buildPayload())
+			const result =
+				isEditing && tier
+					? await updateMut.mutateAsync({ id: tier.id, data: buildPayload() })
+					: await createMut.mutateAsync(buildPayload())
+
+			if (iconFile && result.draft?.id) {
+				isUploadingIcon = true
+				try {
+					const dataUrl = await readDataUrl(iconFile)
+					const base64 = dataUrl.replace(/^data:[^;]+;base64,/, '')
+					await difficultyAdapter.uploadDraftImage(result.draft.id, base64, iconFile.name)
+				} finally {
+					isUploadingIcon = false
+				}
 			}
+
 			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
 			toast.success(isEditing ? 'Tier updated' : 'Tier created')
 			open = false
@@ -154,6 +235,33 @@
 			</div>
 		</DetailItem>
 		<DetailItem
+			label="Icon"
+			sublabel="Optional. PNG, 128×128 or smaller, 256KB max. Shown next to the tier name."
+			editable={true}
+		>
+			<div class="icon-control">
+				<TierIcon imageKey={tier?.imageKey} src={iconPreview} {color} {name} size={40} />
+				<div class="icon-actions">
+					<Button variant="ghost" size="small" onclick={openIconPicker}>
+						{iconPreview || tier?.imageKey ? 'Replace' : 'Upload'}
+					</Button>
+					{#if iconPreview}
+						<Button variant="ghost" size="small" onclick={clearIcon}>Cancel</Button>
+					{/if}
+				</div>
+				<input
+					bind:this={iconInputRef}
+					type="file"
+					accept="image/png"
+					onchange={handleIconSelect}
+					class="icon-input-hidden"
+				/>
+				{#if iconError}
+					<p class="icon-error">{iconError}</p>
+				{/if}
+			</div>
+		</DetailItem>
+		<DetailItem
 			label="Sort Order"
 			sublabel="Lower values appear first in lists"
 			bind:value={sortOrder}
@@ -190,9 +298,9 @@
 	<ModalFooter
 		onCancel={() => (open = false)}
 		primaryAction={{
-			label: isSaving ? 'Saving…' : isEditing ? 'Save' : 'Create',
+			label: isSaving || isUploadingIcon ? 'Saving…' : isEditing ? 'Save' : 'Create',
 			onclick: handleSave,
-			disabled: isSaving || isDeleting || !canSave
+			disabled: isSaving || isUploadingIcon || isDeleting || !canSave
 		}}
 	>
 		{#snippet left()}
@@ -270,6 +378,29 @@
 		font-size: typography.$font-small;
 		color: var(--text-secondary);
 		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+	}
+
+	.icon-control {
+		display: flex;
+		align-items: center;
+		gap: spacing.$unit;
+		flex-wrap: wrap;
+	}
+
+	.icon-actions {
+		display: flex;
+		gap: spacing.$unit-half;
+	}
+
+	.icon-input-hidden {
+		display: none;
+	}
+
+	.icon-error {
+		flex-basis: 100%;
+		margin: 0;
+		color: var(--danger);
+		font-size: typography.$font-small;
 	}
 
 	.description-input {

--- a/src/lib/features/database/difficulties/TierModal.svelte
+++ b/src/lib/features/database/difficulties/TierModal.svelte
@@ -177,25 +177,40 @@
 			return
 		}
 
+		let iconUploadError: unknown = null
 		try {
 			const result =
 				isEditing && tier
 					? await updateMut.mutateAsync({ id: tier.id, data: buildPayload() })
 					: await createMut.mutateAsync(buildPayload())
 
+			// Image upload runs after the draft is already staged. If it fails we
+			// surface a partial-success toast and still close the modal so the
+			// staged tier shows up in the list.
 			if (iconFile && result.draft?.id) {
 				isUploadingIcon = true
 				try {
 					const dataUrl = await readDataUrl(iconFile)
 					const base64 = dataUrl.replace(/^data:[^;]+;base64,/, '')
 					await difficultyAdapter.uploadDraftImage(result.draft.id, base64, iconFile.name)
+				} catch (err) {
+					iconUploadError = err
 				} finally {
 					isUploadingIcon = false
 				}
 			}
 
 			await queryClient.invalidateQueries({ queryKey: ['difficulties'] })
-			toast.success(isEditing ? 'Tier updated' : 'Tier created')
+			if (iconUploadError) {
+				toast.error(
+					extractErrorMessage(
+						iconUploadError,
+						'Tier change staged, but the icon upload failed — try Replace.'
+					)
+				)
+			} else {
+				toast.success(isEditing ? 'Tier change staged' : 'Tier creation staged')
+			}
 			open = false
 			onOpenChange?.(false)
 		} catch (err) {

--- a/src/lib/features/database/difficulties/TierRow.svelte
+++ b/src/lib/features/database/difficulties/TierRow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { DifficultyTier } from '$lib/types/api/party'
+	import TierIcon from '$lib/features/database/difficulties/TierIcon.svelte'
 
 	interface Props {
 		tier: DifficultyTier
@@ -26,7 +27,7 @@
 
 {#snippet rowContent()}
 	<div class="left">
-		<span class="swatch" style:background={tier.color || 'var(--input-bg)'}></span>
+		<TierIcon imageKey={tier.imageKey} color={tier.color} name={tier.name} size={28} />
 		<span class="name-info">
 			<span class="name">{tier.name}</span>
 			<span class="slug">{tier.slug}</span>
@@ -70,14 +71,6 @@
 			display: flex;
 			align-items: center;
 			gap: spacing.$unit;
-		}
-
-		.swatch {
-			width: 18px;
-			height: 18px;
-			border-radius: 50%;
-			border: 1px solid var(--border-subtle);
-			flex-shrink: 0;
 		}
 
 		.name-info {

--- a/src/lib/types/api/party.ts
+++ b/src/lib/types/api/party.ts
@@ -136,6 +136,8 @@ export interface DifficultyTier {
 	description?: string
 	minScore?: number
 	maxScore?: number
+	/** Optional uploaded tier icon. Stored as an S3-style key, e.g. `images/difficulties/<id>.png` */
+	imageKey?: string | null
 	/** Editor-only metadata when the row reflects an unsaved draft */
 	pending?: boolean
 	pendingOperation?: 'create' | 'update' | 'destroy' | null

--- a/src/lib/types/api/party.ts
+++ b/src/lib/types/api/party.ts
@@ -144,11 +144,13 @@ export interface DifficultyTier {
 	draftId?: string | null
 }
 
-// Embedded difficulty payload on Party
+// Embedded difficulty payload on Party. score/breakdown are null when the
+// party isn't yet scoreable (matches DifficultyPreviewResult on the editor
+// side).
 export interface PartyDifficulty {
 	tier: DifficultyTier | null
-	score: number
-	breakdown: Record<string, unknown>
+	score: number | null
+	breakdown: Record<string, unknown> | null
 	computedAt: string
 }
 

--- a/src/lib/utils/difficulty.ts
+++ b/src/lib/utils/difficulty.ts
@@ -1,0 +1,16 @@
+/**
+ * Difficulty tier icon URL helper.
+ *
+ * Tiers store an S3-style key on the backend (e.g. `images/difficulties/<uuid>.png`,
+ * versioned with `?v=<updated_at>` to bust caches). The public icon URL is built
+ * by joining that key with the configured image base — same pattern as Role icons.
+ */
+
+import { getBasePath } from '$lib/utils/images'
+
+export function getTierIconUrl(imageKey: string | null | undefined): string | null {
+	if (!imageKey) return null
+	const base = getBasePath().replace(/\/$/, '')
+	const path = imageKey.replace(/^images\//, '').replace(/^\//, '')
+	return `${base}/${path}`
+}


### PR DESCRIPTION
## Summary
- New \`TierIcon\` component renders an uploaded tier icon from a versioned URL, falling back to a color swatch.
- TierRow swaps its color circle for the new component, so editors see the actual icon (or color) in the list.
- TierModal grows an Icon picker that mirrors the Role-icon pattern: PNG / ≤128×128 / ≤256KB validation, instant preview, replace/cancel actions. On save, the modal stages the draft first (existing flow), grabs the returned \`draft.id\`, then \`POST\`s the base64 to \`/difficulty_drafts/:id/upload_image\` so the icon lives at the temp S3 key until commit.
- New \`getTierIconUrl\` helper joins the API's stored \`image_key\` with the configured image base, same way \`getRoleIconUrl\` works on the Roles branch.

## Test plan
- [ ] Upload a 128×128 PNG → preview appears immediately. Save → request hits \`upload_image\`. Hover commit dialog → tier appears in the pending list.
- [ ] Commit → tier list rerenders with the real icon. \`?v=<updated_at>\` query busts caches on re-upload.
- [ ] Reject non-PNG, >128px, >256KB with clear inline errors before sending.
- [ ] Replacing an existing icon swaps the preview; Cancel discards the local file without affecting the saved icon.
- [ ] In dev with \`PUBLIC_SIERO_IMG_URL\` pointed at the API host, uploaded icons resolve through Rails' static-file serving.