### PR TITLE
Tests for the party difficulty stack

### DIFF
--- a/src/lib/api/adapters/__tests__/difficulty.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/difficulty.adapter.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { DifficultyAdapter } from '../difficulty.adapter'
+import { API, EXPECTED } from './fixtures/difficulty.fixtures'
+import { mockApiResponse } from './fixtures/helpers'
+
+const BASE = 'https://api.example.com'
+
+describe('DifficultyAdapter', () => {
+	let adapter: DifficultyAdapter
+	let originalFetch: typeof global.fetch
+
+	beforeEach(() => {
+		originalFetch = global.fetch
+		adapter = new DifficultyAdapter({ baseURL: BASE })
+	})
+
+	afterEach(() => {
+		global.fetch = originalFetch
+		vi.clearAllTimers()
+	})
+
+	describe('listTiers', () => {
+		it('omits the with_drafts param by default', async () => {
+			global.fetch = mockApiResponse(API.tierList)
+
+			await adapter.listTiers()
+
+			const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(url).toBe(`${BASE}/difficulties`)
+		})
+
+		it('sends with_drafts=true when requested', async () => {
+			global.fetch = mockApiResponse(API.tierListWithDrafts)
+
+			await adapter.listTiers({ withDrafts: true })
+
+			const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(url).toBe(`${BASE}/difficulties?with_drafts=true`)
+		})
+
+		it('transforms snake_case tier fields to camelCase', async () => {
+			global.fetch = mockApiResponse([API.tier])
+
+			const result = await adapter.listTiers()
+
+			expect(result[0]).toEqual(EXPECTED.tier)
+		})
+
+		it('surfaces pending draft metadata on tiers when with_drafts=true', async () => {
+			global.fetch = mockApiResponse(API.tierListWithDrafts)
+
+			const result = await adapter.listTiers({ withDrafts: true })
+
+			expect(result).toHaveLength(2)
+			expect(result[1]).toMatchObject(EXPECTED.pendingTier)
+		})
+	})
+
+	describe('tier mutations', () => {
+		it('createTier POSTs the payload wrapped under `difficulty` in snake_case', async () => {
+			global.fetch = mockApiResponse(API.createTierDraft)
+
+			await adapter.createTier({
+				name: 'Endgame',
+				slug: 'endgame',
+				minScore: 80,
+				maxScore: 100,
+				sortOrder: 30
+			})
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				`${BASE}/difficulties`,
+				expect.objectContaining({
+					method: 'POST',
+					body: JSON.stringify({
+						difficulty: {
+							name: 'Endgame',
+							slug: 'endgame',
+							min_score: 80,
+							max_score: 100,
+							sort_order: 30
+						}
+					})
+				})
+			)
+		})
+
+		it('createTier returns the staged draft, not the saved tier', async () => {
+			global.fetch = mockApiResponse(API.createTierDraft)
+
+			const result = await adapter.createTier({ slug: 'endgame' })
+
+			expect(result.draft.id).toBe('draft-uuid-1')
+			expect(result.draft.operation).toBe('create')
+		})
+
+		it('updateTier PUTs the payload under `difficulty` to the id-specific path', async () => {
+			global.fetch = mockApiResponse(API.createTierDraft)
+
+			await adapter.updateTier('tier-uuid-1', { name: 'Casual+' })
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				`${BASE}/difficulties/tier-uuid-1`,
+				expect.objectContaining({
+					method: 'PUT',
+					body: JSON.stringify({ difficulty: { name: 'Casual+' } })
+				})
+			)
+		})
+
+		it('deleteTier DELETEs without a body', async () => {
+			global.fetch = mockApiResponse(undefined)
+
+			await adapter.deleteTier('tier-uuid-1')
+
+			const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(url).toBe(`${BASE}/difficulties/tier-uuid-1`)
+			expect((init as RequestInit).method).toBe('DELETE')
+			expect((init as RequestInit).body).toBeUndefined()
+		})
+	})
+
+	describe('components', () => {
+		it('listComponents sends with_drafts=true only when requested', async () => {
+			global.fetch = mockApiResponse(API.componentList)
+			await adapter.listComponents()
+			let [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(url).toBe(`${BASE}/difficulty_components`)
+			;(global.fetch as ReturnType<typeof vi.fn>).mockClear()
+
+			global.fetch = mockApiResponse(API.componentList)
+			await adapter.listComponents({ withDrafts: true })
+			;[url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(url).toBe(`${BASE}/difficulty_components?with_drafts=true`)
+		})
+
+		it('updateComponent wraps the payload under `difficulty_component` and uses the id/name segment', async () => {
+			global.fetch = mockApiResponse(API.createTierDraft)
+
+			await adapter.updateComponent('weapon', {
+				weight: 2,
+				enabled: false,
+				minCountToScore: 5,
+				targetMax: null
+			})
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				`${BASE}/difficulty_components/weapon`,
+				expect.objectContaining({
+					method: 'PUT',
+					body: JSON.stringify({
+						difficulty_component: {
+							weight: 2,
+							enabled: false,
+							min_count_to_score: 5,
+							target_max: null
+						}
+					})
+				})
+			)
+		})
+
+		it('transforms component response fields including targetMax', async () => {
+			global.fetch = mockApiResponse([API.component])
+
+			const result = await adapter.listComponents()
+
+			expect(result[0]).toEqual(EXPECTED.component)
+		})
+	})
+
+	describe('rules', () => {
+		it('listRules only sends the filters that are set', async () => {
+			global.fetch = mockApiResponse(API.ruleList)
+
+			await adapter.listRules({ component: 'weapon', active: true })
+
+			const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			const parsed = new URL(url as string)
+			expect(parsed.pathname).toBe('/difficulty_rules')
+			expect(parsed.searchParams.get('component')).toBe('weapon')
+			expect(parsed.searchParams.get('active')).toBe('true')
+			expect(parsed.searchParams.has('with_drafts')).toBe(false)
+		})
+
+		it('listRules forwards withDrafts but skips it when false-y', async () => {
+			global.fetch = mockApiResponse(API.ruleList)
+			await adapter.listRules({ withDrafts: true })
+			let [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(new URL(url as string).searchParams.get('with_drafts')).toBe('true')
+			;(global.fetch as ReturnType<typeof vi.fn>).mockClear()
+
+			global.fetch = mockApiResponse(API.ruleList)
+			await adapter.listRules({ withDrafts: false })
+			;[url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(new URL(url as string).searchParams.has('with_drafts')).toBe(false)
+		})
+
+		it('listRules sends no query string when filters is undefined', async () => {
+			global.fetch = mockApiResponse(API.ruleList)
+
+			await adapter.listRules()
+
+			const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(url).toBe(`${BASE}/difficulty_rules`)
+		})
+
+		it('listRules treats active=false as a sent filter (distinct from undefined)', async () => {
+			global.fetch = mockApiResponse(API.ruleList)
+
+			await adapter.listRules({ active: false })
+
+			const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(new URL(url as string).searchParams.get('active')).toBe('false')
+		})
+
+		it('preserves rule.params keys across the transform layer', async () => {
+			// params is a free-form bag scoped to the rule engine; snake_case keys
+			// inside it must round-trip unchanged in both directions.
+			global.fetch = mockApiResponse([API.rule])
+
+			const result = await adapter.listRules()
+
+			expect(result[0]).toEqual(EXPECTED.rule)
+			expect(result[0]?.params).toEqual({ series_id: 9, min_count: 1 })
+		})
+
+		it('createRule wraps the payload under `difficulty_rule` and preserves params keys outbound', async () => {
+			global.fetch = mockApiResponse(API.createTierDraft)
+
+			await adapter.createRule({
+				name: 'New rule',
+				component: 'weapon',
+				ruleType: 'series_present',
+				params: { min_count: 2, series_id: 9 },
+				weight: 3,
+				active: true
+			})
+
+			const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			const body = JSON.parse((init as RequestInit).body as string)
+			expect(body.difficulty_rule).toMatchObject({
+				name: 'New rule',
+				component: 'weapon',
+				rule_type: 'series_present',
+				weight: 3,
+				active: true
+			})
+			// Keys inside params stay snake_case (no camelCase transform)
+			expect(body.difficulty_rule.params).toEqual({ min_count: 2, series_id: 9 })
+		})
+
+		it('getRuleTypes returns the types and grouped map', async () => {
+			global.fetch = mockApiResponse(API.ruleTypes)
+
+			const result = await adapter.getRuleTypes()
+
+			expect(result.types).toEqual(API.ruleTypes.types)
+			expect(result.grouped).toEqual(API.ruleTypes.grouped)
+		})
+
+		it('deleteRule DELETEs the rule by id', async () => {
+			global.fetch = mockApiResponse(undefined)
+
+			await adapter.deleteRule('rule-uuid-1')
+
+			const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(url).toBe(`${BASE}/difficulty_rules/rule-uuid-1`)
+			expect((init as RequestInit).method).toBe('DELETE')
+		})
+	})
+
+	describe('preview', () => {
+		it('POSTs { shortcode } to /difficulty_previews', async () => {
+			global.fetch = mockApiResponse(API.preview)
+
+			await adapter.preview('qRf1iR')
+
+			expect(global.fetch).toHaveBeenCalledWith(
+				`${BASE}/difficulty_previews`,
+				expect.objectContaining({
+					method: 'POST',
+					body: JSON.stringify({ shortcode: 'qRf1iR' })
+				})
+			)
+		})
+
+		it('returns score, tier and rulesetVersion on a scoreable party', async () => {
+			global.fetch = mockApiResponse(API.preview)
+
+			const result = await adapter.preview('qRf1iR')
+
+			expect(result.scoreable).toBe(true)
+			expect(result.score).toBe(EXPECTED.preview.score)
+			expect(result.rulesetVersion).toBe(EXPECTED.preview.rulesetVersion)
+			expect(result.tier?.slug).toBe('mid')
+		})
+
+		it('returns null score/tier/breakdown for an unscoreable party', async () => {
+			global.fetch = mockApiResponse(API.previewUnscoreable)
+
+			const result = await adapter.preview('qRf1iR')
+
+			expect(result.scoreable).toBe(false)
+			expect(result.score).toBeNull()
+			expect(result.tier).toBeNull()
+			expect(result.breakdown).toBeNull()
+		})
+	})
+
+	describe('drafts workspace', () => {
+		it('listDrafts returns the drafts array + pendingCount', async () => {
+			global.fetch = mockApiResponse(API.listDrafts)
+
+			const result = await adapter.listDrafts()
+
+			expect(result.pendingCount).toBe(1)
+			expect(result.drafts).toHaveLength(1)
+			expect(result.drafts[0]?.operation).toBe('create')
+		})
+
+		it('getDiff returns the diff structure and pendingCount', async () => {
+			global.fetch = mockApiResponse(API.getDiff)
+
+			const result = await adapter.getDiff()
+
+			expect(result.pendingCount).toBe(0)
+			expect(result.diff.tiers.creates).toEqual([])
+			expect(result.diff.rules.updates).toEqual([])
+			expect(result.diff.components.destroys).toEqual([])
+		})
+
+		it('stageDraft POSTs the draft payload', async () => {
+			global.fetch = mockApiResponse(API.listDrafts.drafts[0])
+
+			await adapter.stageDraft({
+				targetType: 'Difficulty',
+				targetId: null,
+				operation: 'create',
+				attributes: { slug: 'endgame' }
+			})
+
+			const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(url).toBe(`${BASE}/difficulty_drafts`)
+			expect((init as RequestInit).method).toBe('POST')
+			const body = JSON.parse((init as RequestInit).body as string)
+			expect(body).toEqual({
+				draft: {
+					target_type: 'Difficulty',
+					target_id: null,
+					operation: 'create',
+					attributes: { slug: 'endgame' }
+				}
+			})
+		})
+
+		it('deleteDraft hits the id-specific path with DELETE', async () => {
+			global.fetch = mockApiResponse(undefined)
+
+			await adapter.deleteDraft('draft-uuid-1')
+
+			const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(url).toBe(`${BASE}/difficulty_drafts/draft-uuid-1`)
+			expect((init as RequestInit).method).toBe('DELETE')
+		})
+
+		it('discardDrafts DELETEs /difficulty_drafts/all and surfaces the count', async () => {
+			global.fetch = mockApiResponse(API.discard)
+
+			const result = await adapter.discardDrafts()
+
+			const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(url).toBe(`${BASE}/difficulty_drafts/all`)
+			expect((init as RequestInit).method).toBe('DELETE')
+			expect(result.discarded).toBe(3)
+		})
+
+		it('commitDrafts POSTs { note } and returns the camelCased commit result', async () => {
+			global.fetch = mockApiResponse(API.commit)
+
+			const result = await adapter.commitDrafts('tune weapon weights')
+
+			const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(url).toBe(`${BASE}/difficulty_drafts/commit`)
+			expect((init as RequestInit).method).toBe('POST')
+			expect((init as RequestInit).body).toBe(JSON.stringify({ note: 'tune weapon weights' }))
+			expect(result).toEqual(EXPECTED.commit)
+		})
+
+		it('uploadDraftImage POSTs the base64 + filename to the per-draft upload path', async () => {
+			global.fetch = mockApiResponse(API.uploadDraftImage)
+
+			await adapter.uploadDraftImage('draft-uuid-1', 'BASE64DATA', 'endgame.png')
+
+			const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			expect(url).toBe(`${BASE}/difficulty_drafts/draft-uuid-1/upload_image`)
+			expect((init as RequestInit).method).toBe('POST')
+			expect((init as RequestInit).body).toBe(
+				JSON.stringify({ image: 'BASE64DATA', filename: 'endgame.png' })
+			)
+		})
+
+		it('uploadDraftImage allows a missing filename', async () => {
+			global.fetch = mockApiResponse(API.uploadDraftImage)
+
+			await adapter.uploadDraftImage('draft-uuid-1', 'BASE64DATA')
+
+			const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+			const body = JSON.parse((init as RequestInit).body as string)
+			expect(body.image).toBe('BASE64DATA')
+			expect(body.filename).toBeUndefined()
+		})
+	})
+})

--- a/src/lib/api/adapters/__tests__/fixtures/difficulty.fixtures.ts
+++ b/src/lib/api/adapters/__tests__/fixtures/difficulty.fixtures.ts
@@ -1,0 +1,199 @@
+/**
+ * Difficulty adapter test fixtures
+ *
+ * API = what Rails sends (snake_case, raw blueprint output)
+ * EXPECTED = what callers receive (camelCase, post-adapter transform)
+ */
+
+export const API = {
+	tier: {
+		id: 'tier-uuid-1',
+		slug: 'casual',
+		name: 'Casual',
+		color: '#86C5A8',
+		sort_order: 10,
+		description: 'Easy parties',
+		min_score: 0,
+		max_score: 40,
+		image_key: 'images/difficulties/tier-uuid-1.png'
+	},
+	tierList: [
+		{ id: 'tier-uuid-1', slug: 'casual', name: 'Casual', sort_order: 10 },
+		{ id: 'tier-uuid-2', slug: 'mid', name: 'Mid', sort_order: 20 }
+	],
+	tierListWithDrafts: [
+		{ id: 'tier-uuid-1', slug: 'casual', name: 'Casual', sort_order: 10 },
+		{
+			id: 'draft-tier-1',
+			slug: 'endgame',
+			name: 'Endgame',
+			sort_order: 30,
+			pending: true,
+			pending_operation: 'create',
+			draft_id: 'draft-uuid-1'
+		}
+	],
+	component: {
+		id: 'comp-uuid-1',
+		name: 'weapon',
+		weight: 1,
+		enabled: true,
+		min_count_to_score: 4,
+		target_max: 100
+	},
+	componentList: [
+		{ id: 'comp-uuid-1', name: 'weapon', weight: 1, enabled: true, min_count_to_score: 4 }
+	],
+	rule: {
+		id: 'rule-uuid-1',
+		name: 'Grand series weapon present',
+		component: 'weapon',
+		rule_type: 'series_present',
+		params: { series_id: 9, min_count: 1 },
+		weight: 5,
+		active: true
+	},
+	ruleList: [
+		{
+			id: 'rule-uuid-1',
+			name: 'Grand series',
+			component: 'weapon',
+			rule_type: 'series_present',
+			params: { min_count: 1 },
+			weight: 5,
+			active: true
+		}
+	],
+	ruleTypes: {
+		types: ['series_present', 'rarity_min', 'awakening_level_min'],
+		grouped: {
+			weapon: ['series_present', 'rarity_min'],
+			character: ['awakening_level_min']
+		}
+	},
+	preview: {
+		shortcode: 'qRf1iR',
+		scoreable: true,
+		score: 72.5,
+		tier: { id: 'tier-uuid-2', slug: 'mid', name: 'Mid' },
+		breakdown: {
+			components: [
+				{
+					name: 'weapon',
+					weight: 1,
+					present: true,
+					raw_score: 0.8,
+					weighted_score: 0.8,
+					contribution_sum: 16,
+					max_weight: 20,
+					target_max: null,
+					fired: []
+				}
+			]
+		},
+		ruleset_version: 7
+	},
+	previewUnscoreable: {
+		shortcode: 'qRf1iR',
+		scoreable: false,
+		score: null,
+		tier: null,
+		breakdown: null,
+		ruleset_version: 7
+	},
+	createTierDraft: {
+		draft: {
+			id: 'draft-uuid-1',
+			target_type: 'Difficulty',
+			target_id: null,
+			operation: 'create',
+			attributes: { slug: 'endgame', name: 'Endgame' }
+		}
+	},
+	listDrafts: {
+		drafts: [
+			{
+				id: 'draft-uuid-1',
+				target_type: 'Difficulty',
+				target_id: null,
+				operation: 'create',
+				attributes: { slug: 'endgame' }
+			}
+		],
+		pending_count: 1
+	},
+	getDiff: {
+		diff: {
+			tiers: { creates: [], updates: [], destroys: [] },
+			rules: { creates: [], updates: [], destroys: [] },
+			components: { creates: [], updates: [], destroys: [] }
+		},
+		pending_count: 0
+	},
+	commit: {
+		ruleset_version_after: 8,
+		committed_at: '2026-05-11T00:00:00Z',
+		note: 'tune weapon weights',
+		change_log_id: 'log-uuid-1'
+	},
+	discard: { discarded: 3 },
+	uploadDraftImage: {
+		id: 'draft-uuid-1',
+		target_type: 'Difficulty',
+		target_id: null,
+		operation: 'create',
+		attributes: { image_key: 'images/difficulties/_drafts/foo.png' }
+	}
+}
+
+export const EXPECTED = {
+	tier: {
+		id: 'tier-uuid-1',
+		slug: 'casual',
+		name: 'Casual',
+		color: '#86C5A8',
+		sortOrder: 10,
+		description: 'Easy parties',
+		minScore: 0,
+		maxScore: 40,
+		imageKey: 'images/difficulties/tier-uuid-1.png'
+	},
+	pendingTier: {
+		id: 'draft-tier-1',
+		slug: 'endgame',
+		name: 'Endgame',
+		sortOrder: 30,
+		pending: true,
+		pendingOperation: 'create',
+		draftId: 'draft-uuid-1'
+	},
+	component: {
+		id: 'comp-uuid-1',
+		name: 'weapon',
+		weight: 1,
+		enabled: true,
+		minCountToScore: 4,
+		targetMax: 100
+	},
+	rule: {
+		// params keeps snake_case keys per DATA_MAP_KEYS in transforms.ts
+		id: 'rule-uuid-1',
+		name: 'Grand series weapon present',
+		component: 'weapon',
+		ruleType: 'series_present',
+		params: { series_id: 9, min_count: 1 },
+		weight: 5,
+		active: true
+	},
+	preview: {
+		score: 72.5,
+		rulesetVersion: 7,
+		scoreable: true
+	},
+	commit: {
+		rulesetVersionAfter: 8,
+		committedAt: '2026-05-11T00:00:00Z',
+		note: 'tune weapon weights',
+		changeLogId: 'log-uuid-1'
+	}
+}

--- a/src/lib/api/queries/__tests__/difficulty.queries.test.ts
+++ b/src/lib/api/queries/__tests__/difficulty.queries.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { QueryFunction } from '@tanstack/svelte-query'
+import { difficultyQueries } from '../difficulty.queries'
+import { difficultyAdapter } from '../../adapters/difficulty.adapter'
+
+/**
+ * `queryOptions()` types `queryFn` as `unique symbol | QueryFunction`, where
+ * the symbol is the "no fn provided" sentinel. Our factories always provide
+ * one, so this helper unwraps the union for test invocation.
+ */
+async function invokeQueryFn<TData>(opts: { queryFn?: unknown }): Promise<TData> {
+	const fn = opts.queryFn as QueryFunction<TData, never[], never>
+	return fn({} as never)
+}
+
+describe('difficultyQueries', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	describe('tiers', () => {
+		it('keys without withDrafts default to { withDrafts: false }', () => {
+			const opts = difficultyQueries.tiers()
+			expect(opts.queryKey).toEqual(['difficulties', 'tiers', { withDrafts: false }])
+		})
+
+		it('keys distinguish withDrafts: true from the default', () => {
+			const a = difficultyQueries.tiers().queryKey
+			const b = difficultyQueries.tiers({ withDrafts: true }).queryKey
+			expect(a).not.toEqual(b)
+			expect(b).toEqual(['difficulties', 'tiers', { withDrafts: true }])
+		})
+
+		it('caches non-draft tiers aggressively (~30 min)', () => {
+			expect(difficultyQueries.tiers().staleTime).toBe(1000 * 60 * 30)
+		})
+
+		it('treats draft-aware tiers as never stale', () => {
+			expect(difficultyQueries.tiers({ withDrafts: true }).staleTime).toBe(0)
+		})
+
+		it('queryFn forwards withDrafts to the adapter', async () => {
+			const spy = vi.spyOn(difficultyAdapter, 'listTiers').mockResolvedValue([])
+
+			await invokeQueryFn(difficultyQueries.tiers({ withDrafts: true }))
+
+			expect(spy).toHaveBeenCalledWith({ withDrafts: true })
+		})
+	})
+
+	describe('rules', () => {
+		it('keys vary by the filters object so different component filters cache separately', () => {
+			const all = difficultyQueries.rules().queryKey
+			const weapon = difficultyQueries.rules({ component: 'weapon' }).queryKey
+			const weaponWithDrafts = difficultyQueries.rules({
+				component: 'weapon',
+				withDrafts: true
+			}).queryKey
+
+			expect(all).not.toEqual(weapon)
+			expect(weapon).not.toEqual(weaponWithDrafts)
+		})
+
+		it('queryFn forwards the full filters object to the adapter', async () => {
+			const spy = vi.spyOn(difficultyAdapter, 'listRules').mockResolvedValue([])
+
+			await invokeQueryFn(
+				difficultyQueries.rules({ component: 'weapon', active: true, withDrafts: true })
+			)
+
+			expect(spy).toHaveBeenCalledWith({
+				component: 'weapon',
+				active: true,
+				withDrafts: true
+			})
+		})
+
+		it('1 minute staleTime is appropriate for editor list', () => {
+			expect(difficultyQueries.rules().staleTime).toBe(1000 * 60)
+		})
+	})
+
+	describe('ruleTypes', () => {
+		it('caches rule types for a day', () => {
+			const opts = difficultyQueries.ruleTypes()
+			expect(opts.queryKey).toEqual(['difficulties', 'rule_types'])
+			expect(opts.staleTime).toBe(1000 * 60 * 60 * 24)
+		})
+
+		it('queryFn calls adapter.getRuleTypes', async () => {
+			const spy = vi
+				.spyOn(difficultyAdapter, 'getRuleTypes')
+				.mockResolvedValue({ types: [], grouped: {} })
+
+			await invokeQueryFn(difficultyQueries.ruleTypes())
+
+			expect(spy).toHaveBeenCalledOnce()
+		})
+	})
+
+	describe('components', () => {
+		it('keys distinguish withDrafts variants', () => {
+			expect(difficultyQueries.components().queryKey).toEqual([
+				'difficulties',
+				'components',
+				{ withDrafts: false }
+			])
+			expect(difficultyQueries.components({ withDrafts: true }).queryKey).toEqual([
+				'difficulties',
+				'components',
+				{ withDrafts: true }
+			])
+		})
+
+		it('queryFn forwards withDrafts to the adapter', async () => {
+			const spy = vi.spyOn(difficultyAdapter, 'listComponents').mockResolvedValue([])
+
+			await invokeQueryFn(difficultyQueries.components({ withDrafts: true }))
+
+			expect(spy).toHaveBeenCalledWith({ withDrafts: true })
+		})
+	})
+
+	describe('diff', () => {
+		it('is never stale (always refetches when the editor opens it)', () => {
+			expect(difficultyQueries.diff().staleTime).toBe(0)
+		})
+
+		it('queryFn calls adapter.getDiff', async () => {
+			const spy = vi.spyOn(difficultyAdapter, 'getDiff').mockResolvedValue({
+				diff: {
+					tiers: { creates: [], updates: [], destroys: [] },
+					rules: { creates: [], updates: [], destroys: [] },
+					components: { creates: [], updates: [], destroys: [] }
+				},
+				pendingCount: 0
+			})
+
+			await invokeQueryFn(difficultyQueries.diff())
+
+			expect(spy).toHaveBeenCalledOnce()
+		})
+
+		it('all difficulty-related queryKeys share the "difficulties" root', () => {
+			// Used by invalidateQueries({ queryKey: ['difficulties'] }) in mutations
+			expect(difficultyQueries.tiers().queryKey[0]).toBe('difficulties')
+			expect(difficultyQueries.rules().queryKey[0]).toBe('difficulties')
+			expect(difficultyQueries.components().queryKey[0]).toBe('difficulties')
+			expect(difficultyQueries.ruleTypes().queryKey[0]).toBe('difficulties')
+			expect(difficultyQueries.diff().queryKey[0]).toBe('difficulties')
+		})
+	})
+})

--- a/src/lib/api/schemas/__tests__/transforms.test.ts
+++ b/src/lib/api/schemas/__tests__/transforms.test.ts
@@ -50,6 +50,21 @@ describe('snakeToCamel', () => {
 	it('preserves already camelCase keys', () => {
 		expect(snakeToCamel({ firstName: 'A' })).toEqual({ firstName: 'A' })
 	})
+
+	it('preserves params keys as-is (rule-engine bag stays opaque on the response path)', () => {
+		const input = { difficulty_rule: { params: { min_count: 1, series_id: 9 } } }
+		const result = snakeToCamel(input) as unknown as {
+			difficultyRule: { params: Record<string, unknown> }
+		}
+		// Outer key gets camelCased; inner params keys must NOT.
+		expect(result.difficultyRule.params).toEqual({ min_count: 1, series_id: 9 })
+	})
+
+	it('preserves wiki_data values on the response path too', () => {
+		const input = { wiki_data: { 'Page/Name': { nested_key: 'v' } } }
+		const result = snakeToCamel(input) as Record<string, unknown>
+		expect(result.wikiData).toEqual({ 'Page/Name': { nested_key: 'v' } })
+	})
 })
 
 // ============================================================================
@@ -96,6 +111,19 @@ describe('camelToSnake', () => {
 		const input = { wiki_data: { 'Page/Name': { nested_key: 'v' } } }
 		const result = camelToSnake(input) as Record<string, unknown>
 		expect(result.wiki_data).toEqual({ 'Page/Name': { nested_key: 'v' } })
+	})
+
+	it('preserves params keys as-is (rule-engine bag)', () => {
+		const input = { params: { min_count: 1, series_id: 9, max_skill_level: 20 } }
+		const result = camelToSnake(input) as Record<string, unknown>
+		expect(result.params).toEqual({ min_count: 1, series_id: 9, max_skill_level: 20 })
+	})
+
+	it('does NOT camelCase nested params keys before snake-casing them back', () => {
+		// Sanity check: even if someone hands camelCase keys, params is opaque.
+		const input = { params: { minCount: 1 } }
+		const result = camelToSnake(input) as Record<string, unknown>
+		expect(result.params).toEqual({ minCount: 1 })
 	})
 })
 

--- a/src/lib/features/database/difficulties/TierModal.svelte
+++ b/src/lib/features/database/difficulties/TierModal.svelte
@@ -11,9 +11,14 @@
 	import type { DifficultyTier } from '$lib/types/api/party'
 	import { extractErrorMessage } from '$lib/utils/errors'
 	import TierIcon from '$lib/features/database/difficulties/TierIcon.svelte'
-
-	const ICON_MAX_DIMENSION = 128
-	const ICON_MAX_BYTES = 256 * 1024
+	import {
+		TIER_ICON_MAX_BYTES,
+		TIER_ICON_MAX_DIMENSION,
+		buildTierPayload,
+		isWithinIconDimensions,
+		validateIconMeta,
+		validateTierForm
+	} from '$lib/features/database/difficulties/tier-form'
 
 	interface Props {
 		open?: boolean
@@ -112,21 +117,20 @@
 		const file = input.files?.[0]
 		if (!file) return
 
-		if (file.type !== 'image/png') {
-			iconError = 'Icon must be a PNG.'
-			input.value = ''
-			return
-		}
-		if (file.size > ICON_MAX_BYTES) {
-			iconError = 'Icon must be 256KB or smaller.'
+		const meta = validateIconMeta(file)
+		if (!meta.ok) {
+			iconError =
+				meta.error === 'wrong_type'
+					? 'Icon must be a PNG.'
+					: `Icon must be ${TIER_ICON_MAX_BYTES / 1024}KB or smaller.`
 			input.value = ''
 			return
 		}
 
 		const dataUrl = await readDataUrl(file)
-		const { width, height } = await checkDimensions(dataUrl)
-		if (width > ICON_MAX_DIMENSION || height > ICON_MAX_DIMENSION) {
-			iconError = `Icon must be ${ICON_MAX_DIMENSION}x${ICON_MAX_DIMENSION} or smaller.`
+		const dims = await checkDimensions(dataUrl)
+		if (!isWithinIconDimensions(dims)) {
+			iconError = `Icon must be ${TIER_ICON_MAX_DIMENSION}x${TIER_ICON_MAX_DIMENSION} or smaller.`
 			input.value = ''
 			return
 		}
@@ -147,29 +151,21 @@
 		removeIcon = !removeIcon
 	}
 
-	function buildPayload(): Partial<DifficultyTier> {
-		const payload: Partial<DifficultyTier> = {
-			name: name.trim(),
-			slug: slug.trim(),
-			color,
-			description: description.trim() || undefined,
-			minScore,
-			maxScore,
-			sortOrder
-		}
-		// Clearing an existing icon is expressed as imageKey: null; uploading a
-		// new icon goes through uploadDraftImage after the draft is staged.
-		if (removeIcon && !iconFile) payload.imageKey = null
-		return payload
-	}
+	const formInput = $derived({
+		name,
+		slug,
+		color,
+		description,
+		minScore,
+		maxScore,
+		sortOrder
+	})
 
-	const canSave = $derived(
-		name.trim().length > 0 &&
-			slug.trim().length > 0 &&
-			maxScore > minScore &&
-			minScore >= 0 &&
-			maxScore <= 100
-	)
+	const canSave = $derived(validateTierForm(formInput).ok)
+
+	function buildPayload(): Partial<DifficultyTier> {
+		return buildTierPayload(formInput, { removeIcon, hasIconFile: !!iconFile })
+	}
 
 	async function handleSave() {
 		if (!canSave) {

--- a/src/lib/features/database/difficulties/__tests__/tier-form.test.ts
+++ b/src/lib/features/database/difficulties/__tests__/tier-form.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest'
+import {
+	TIER_ICON_MAX_BYTES,
+	TIER_ICON_MAX_DIMENSION,
+	buildTierPayload,
+	isWithinIconDimensions,
+	validateIconMeta,
+	validateTierForm,
+	type TierFormInput
+} from '../tier-form'
+
+const baseInput: TierFormInput = {
+	name: 'Endgame',
+	slug: 'endgame',
+	color: '#86C5A8',
+	description: '',
+	minScore: 80,
+	maxScore: 100,
+	sortOrder: 30
+}
+
+describe('validateTierForm', () => {
+	it('accepts a fully populated, in-range input', () => {
+		expect(validateTierForm(baseInput).ok).toBe(true)
+	})
+
+	it('flags an empty name (whitespace-only too)', () => {
+		const res = validateTierForm({ ...baseInput, name: '   ' })
+		expect(res.ok).toBe(false)
+		if (!res.ok) expect(res.errors.name).toBeDefined()
+	})
+
+	it('flags an empty slug', () => {
+		const res = validateTierForm({ ...baseInput, slug: '' })
+		expect(res.ok).toBe(false)
+		if (!res.ok) expect(res.errors.slug).toBeDefined()
+	})
+
+	it('rejects a negative minScore', () => {
+		const res = validateTierForm({ ...baseInput, minScore: -1 })
+		expect(res.ok).toBe(false)
+		if (!res.ok) expect(res.errors.range).toBeDefined()
+	})
+
+	it('rejects a maxScore over 100', () => {
+		const res = validateTierForm({ ...baseInput, maxScore: 101 })
+		expect(res.ok).toBe(false)
+		if (!res.ok) expect(res.errors.range).toBeDefined()
+	})
+
+	it('rejects when max is not strictly greater than min', () => {
+		const equal = validateTierForm({ ...baseInput, minScore: 50, maxScore: 50 })
+		const inverted = validateTierForm({ ...baseInput, minScore: 80, maxScore: 70 })
+		expect(equal.ok).toBe(false)
+		expect(inverted.ok).toBe(false)
+	})
+
+	it('rejects NaN scores (defensive: form inputs can leave fields as NaN)', () => {
+		const res = validateTierForm({ ...baseInput, minScore: Number.NaN, maxScore: 100 })
+		expect(res.ok).toBe(false)
+		if (!res.ok) expect(res.errors.range).toBeDefined()
+	})
+
+	it('accepts the full 0–100 boundary', () => {
+		expect(validateTierForm({ ...baseInput, minScore: 0, maxScore: 100 }).ok).toBe(true)
+	})
+
+	it('collects multiple errors at once (does not bail on the first miss)', () => {
+		const res = validateTierForm({ ...baseInput, name: '', slug: '', maxScore: 200 })
+		expect(res.ok).toBe(false)
+		if (!res.ok) {
+			expect(res.errors.name).toBeDefined()
+			expect(res.errors.slug).toBeDefined()
+			expect(res.errors.range).toBeDefined()
+		}
+	})
+})
+
+describe('buildTierPayload', () => {
+	it('trims name and slug', () => {
+		const payload = buildTierPayload({ ...baseInput, name: '  Endgame  ', slug: '  endgame ' })
+		expect(payload.name).toBe('Endgame')
+		expect(payload.slug).toBe('endgame')
+	})
+
+	it('drops an empty description (undefined, not empty string)', () => {
+		const payload = buildTierPayload({ ...baseInput, description: '   ' })
+		expect(payload.description).toBeUndefined()
+	})
+
+	it('keeps a populated description (trimmed)', () => {
+		const payload = buildTierPayload({ ...baseInput, description: '  endgame parties  ' })
+		expect(payload.description).toBe('endgame parties')
+	})
+
+	it('forwards color verbatim (no normalization)', () => {
+		const payload = buildTierPayload({ ...baseInput, color: '#1A1A3A' })
+		expect(payload.color).toBe('#1A1A3A')
+	})
+
+	it('omits imageKey by default', () => {
+		const payload = buildTierPayload(baseInput)
+		expect('imageKey' in payload).toBe(false)
+	})
+
+	it('sends imageKey: null when removeIcon is set and no new file is staged', () => {
+		const payload = buildTierPayload(baseInput, { removeIcon: true, hasIconFile: false })
+		expect(payload.imageKey).toBeNull()
+	})
+
+	it('does NOT send imageKey: null when a new icon file is staged (upload supplies it)', () => {
+		const payload = buildTierPayload(baseInput, { removeIcon: true, hasIconFile: true })
+		expect('imageKey' in payload).toBe(false)
+	})
+
+	it('does NOT send imageKey when removeIcon is false even with hasIconFile', () => {
+		const payload = buildTierPayload(baseInput, { removeIcon: false, hasIconFile: true })
+		expect('imageKey' in payload).toBe(false)
+	})
+
+	it('preserves min/max/sort exactly (no coercion or rounding)', () => {
+		const payload = buildTierPayload({ ...baseInput, minScore: 0, maxScore: 100, sortOrder: 0 })
+		expect(payload.minScore).toBe(0)
+		expect(payload.maxScore).toBe(100)
+		expect(payload.sortOrder).toBe(0)
+	})
+})
+
+describe('validateIconMeta', () => {
+	function fakeFile(opts: { type?: string; size?: number } = {}): File {
+		// Real File constructor requires bits; we only check .type and .size.
+		return {
+			type: opts.type ?? 'image/png',
+			size: opts.size ?? 1024
+		} as File
+	}
+
+	it('accepts a sub-cap PNG by default', () => {
+		expect(validateIconMeta(fakeFile()).ok).toBe(true)
+	})
+
+	it('rejects non-PNG MIME types by default', () => {
+		const res = validateIconMeta(fakeFile({ type: 'image/jpeg' }))
+		expect(res.ok).toBe(false)
+		if (!res.ok) expect(res.error).toBe('wrong_type')
+	})
+
+	it('rejects empty/missing MIME type', () => {
+		const res = validateIconMeta(fakeFile({ type: '' }))
+		expect(res.ok).toBe(false)
+		if (!res.ok) expect(res.error).toBe('wrong_type')
+	})
+
+	it('rejects files over the byte cap', () => {
+		const res = validateIconMeta(fakeFile({ size: TIER_ICON_MAX_BYTES + 1 }))
+		expect(res.ok).toBe(false)
+		if (!res.ok) expect(res.error).toBe('too_large')
+	})
+
+	it('accepts a file exactly at the byte cap', () => {
+		expect(validateIconMeta(fakeFile({ size: TIER_ICON_MAX_BYTES })).ok).toBe(true)
+	})
+
+	it('supports a custom maxBytes override', () => {
+		const res = validateIconMeta(fakeFile({ size: 600 }), { maxBytes: 500 })
+		expect(res.ok).toBe(false)
+		if (!res.ok) expect(res.error).toBe('too_large')
+	})
+
+	it('supports custom allowedMimeTypes', () => {
+		const png = validateIconMeta(fakeFile({ type: 'image/svg+xml' }), {
+			allowedMimeTypes: ['image/svg+xml', 'image/png']
+		})
+		expect(png.ok).toBe(true)
+	})
+
+	it('reports wrong_type before too_large when both fail (cheaper check first)', () => {
+		const res = validateIconMeta(fakeFile({ type: 'image/jpeg', size: TIER_ICON_MAX_BYTES * 10 }))
+		expect(res.ok).toBe(false)
+		if (!res.ok) expect(res.error).toBe('wrong_type')
+	})
+})
+
+describe('isWithinIconDimensions', () => {
+	it('accepts exactly the cap', () => {
+		expect(
+			isWithinIconDimensions({ width: TIER_ICON_MAX_DIMENSION, height: TIER_ICON_MAX_DIMENSION })
+		).toBe(true)
+	})
+
+	it('rejects when width exceeds cap (height OK)', () => {
+		expect(
+			isWithinIconDimensions({
+				width: TIER_ICON_MAX_DIMENSION + 1,
+				height: TIER_ICON_MAX_DIMENSION
+			})
+		).toBe(false)
+	})
+
+	it('rejects when height exceeds cap (width OK)', () => {
+		expect(
+			isWithinIconDimensions({
+				width: TIER_ICON_MAX_DIMENSION,
+				height: TIER_ICON_MAX_DIMENSION + 1
+			})
+		).toBe(false)
+	})
+
+	it('honours a custom maxDimension', () => {
+		expect(isWithinIconDimensions({ width: 64, height: 64 }, 32)).toBe(false)
+		expect(isWithinIconDimensions({ width: 32, height: 32 }, 32)).toBe(true)
+	})
+
+	it('accepts non-square images within the cap', () => {
+		expect(isWithinIconDimensions({ width: 128, height: 64 })).toBe(true)
+	})
+})

--- a/src/lib/features/database/difficulties/tier-form.ts
+++ b/src/lib/features/database/difficulties/tier-form.ts
@@ -1,0 +1,109 @@
+import type { DifficultyTier } from '$lib/types/api/party'
+
+export const TIER_ICON_MAX_DIMENSION = 128
+export const TIER_ICON_MAX_BYTES = 256 * 1024
+
+/**
+ * Shape of the TierModal form state. Numeric scores are kept as plain
+ * `number` rather than `string | number` so the modal owns input coercion.
+ */
+export interface TierFormInput {
+	name: string
+	slug: string
+	color: string
+	description: string
+	minScore: number
+	maxScore: number
+	sortOrder: number
+}
+
+export interface TierFormErrors {
+	name?: string
+	slug?: string
+	range?: string
+}
+
+/**
+ * Validates the form fields used to create or edit a tier.
+ *
+ * Returns `{ ok: true }` when every field is valid. On failure, returns the
+ * first set of human-readable errors so callers can either surface a single
+ * toast or fan them out into per-field hints.
+ */
+export function validateTierForm(
+	input: TierFormInput
+): { ok: true } | { ok: false; errors: TierFormErrors } {
+	const errors: TierFormErrors = {}
+
+	if (input.name.trim().length === 0) errors.name = 'Name is required.'
+	if (input.slug.trim().length === 0) errors.slug = 'Slug is required.'
+
+	if (
+		input.minScore < 0 ||
+		input.maxScore > 100 ||
+		!(input.maxScore > input.minScore) ||
+		Number.isNaN(input.minScore) ||
+		Number.isNaN(input.maxScore)
+	) {
+		errors.range = 'Score range must be within 0–100 and max must exceed min.'
+	}
+
+	if (Object.keys(errors).length > 0) return { ok: false, errors }
+	return { ok: true }
+}
+
+/**
+ * Build the request payload sent to `createTier` / `updateTier`.
+ *
+ * `removeIcon: true` produces an explicit `imageKey: null` (cleared on the
+ * server). When a new icon file is staged, the modal uploads it after the
+ * draft is created, so we don't include `imageKey` in this payload.
+ */
+export function buildTierPayload(
+	input: TierFormInput,
+	opts: { removeIcon?: boolean; hasIconFile?: boolean } = {}
+): Partial<DifficultyTier> {
+	const payload: Partial<DifficultyTier> = {
+		name: input.name.trim(),
+		slug: input.slug.trim(),
+		color: input.color,
+		description: input.description.trim() || undefined,
+		minScore: input.minScore,
+		maxScore: input.maxScore,
+		sortOrder: input.sortOrder
+	}
+
+	if (opts.removeIcon && !opts.hasIconFile) {
+		payload.imageKey = null
+	}
+
+	return payload
+}
+
+export type IconMetaError = 'wrong_type' | 'too_large'
+
+/**
+ * Synchronous metadata validation for a candidate tier icon. Dimension
+ * checks live in the component since they require an `Image` decode.
+ */
+export function validateIconMeta(
+	file: File,
+	opts: { maxBytes?: number; allowedMimeTypes?: string[] } = {}
+): { ok: true } | { ok: false; error: IconMetaError } {
+	const maxBytes = opts.maxBytes ?? TIER_ICON_MAX_BYTES
+	const allowed = opts.allowedMimeTypes ?? ['image/png']
+
+	if (!allowed.includes(file.type)) return { ok: false, error: 'wrong_type' }
+	if (file.size > maxBytes) return { ok: false, error: 'too_large' }
+	return { ok: true }
+}
+
+/**
+ * Returns true when the decoded image dimensions fall within the cap.
+ */
+export function isWithinIconDimensions(
+	dim: { width: number; height: number },
+	maxDimension = TIER_ICON_MAX_DIMENSION
+): boolean {
+	return dim.width <= maxDimension && dim.height <= maxDimension
+}

--- a/src/lib/utils/__tests__/difficulty.test.ts
+++ b/src/lib/utils/__tests__/difficulty.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getTierIconUrl } from '../difficulty'
+import * as images from '$lib/utils/images'
+
+describe('getTierIconUrl', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('returns null for null/undefined/empty imageKey', () => {
+		expect(getTierIconUrl(null)).toBeNull()
+		expect(getTierIconUrl(undefined)).toBeNull()
+		expect(getTierIconUrl('')).toBeNull()
+	})
+
+	it('joins base + key with a single slash, even when base has a trailing slash', () => {
+		vi.spyOn(images, 'getBasePath').mockReturnValue('https://cdn.example.com/images/')
+
+		expect(getTierIconUrl('difficulties/abc.png')).toBe(
+			'https://cdn.example.com/images/difficulties/abc.png'
+		)
+	})
+
+	it("strips a leading `images/` prefix from the key so the base isn't duplicated", () => {
+		vi.spyOn(images, 'getBasePath').mockReturnValue('https://cdn.example.com/images')
+
+		expect(getTierIconUrl('images/difficulties/abc.png')).toBe(
+			'https://cdn.example.com/images/difficulties/abc.png'
+		)
+	})
+
+	it('strips a leading slash on the key (defensive against double-slashes)', () => {
+		vi.spyOn(images, 'getBasePath').mockReturnValue('https://cdn.example.com/images')
+
+		expect(getTierIconUrl('/difficulties/abc.png')).toBe(
+			'https://cdn.example.com/images/difficulties/abc.png'
+		)
+	})
+
+	it('preserves query params on the key (used for cache busting via ?v=updated_at)', () => {
+		vi.spyOn(images, 'getBasePath').mockReturnValue('https://cdn.example.com/images')
+
+		expect(getTierIconUrl('difficulties/abc.png?v=123')).toBe(
+			'https://cdn.example.com/images/difficulties/abc.png?v=123'
+		)
+	})
+
+	it('falls back to the local `/images` base when getBasePath returns the default', () => {
+		vi.spyOn(images, 'getBasePath').mockReturnValue('/images')
+
+		expect(getTierIconUrl('difficulties/abc.png')).toBe('/images/difficulties/abc.png')
+	})
+})

--- a/src/lib/utils/__tests__/exploreFilterParams.test.ts
+++ b/src/lib/utils/__tests__/exploreFilterParams.test.ts
@@ -491,3 +491,86 @@ describe('urlParamsToExploreFilterParams', () => {
 		expect(result.filterItems.find((f) => f.kind === 'entity')).toBeDefined()
 	})
 })
+
+// ============================================================================
+// difficulty filter
+// ============================================================================
+
+describe('difficulty filter (multi-select)', () => {
+	it('serializes a single difficulty as ?difficulty=slug', () => {
+		const params = serializeExploreFilters([
+			{ kind: 'difficulty', value: 'casual', label: 'Casual' }
+		])
+		expect(params.get('difficulty')).toBe('casual')
+	})
+
+	it('serializes multiple difficulties as a comma-joined list', () => {
+		const params = serializeExploreFilters([
+			{ kind: 'difficulty', value: 'casual', label: 'Casual' },
+			{ kind: 'difficulty', value: 'mid', label: 'Mid' }
+		])
+		expect(params.get('difficulty')).toBe('casual,mid')
+	})
+
+	it('omits the difficulty param entirely when no difficulty filters are set', () => {
+		const params = serializeExploreFilters([{ kind: 'element', value: 2, label: 'Fire' }])
+		expect(params.has('difficulty')).toBe(false)
+	})
+
+	it('deserializes a single ?difficulty=slug into one pill', () => {
+		const { filters } = deserializeExploreFilters(new URLSearchParams('difficulty=casual'))
+		const diffs = filters.filter((f) => f.kind === 'difficulty')
+		expect(diffs).toHaveLength(1)
+		expect(diffs[0]).toMatchObject({ kind: 'difficulty', value: 'casual' })
+	})
+
+	it('deserializes a comma list into one pill per slug', () => {
+		const { filters } = deserializeExploreFilters(new URLSearchParams('difficulty=casual,mid'))
+		const diffs = filters.filter((f) => f.kind === 'difficulty')
+		expect(diffs.map((f) => f.value)).toEqual(['casual', 'mid'])
+	})
+
+	it('drops empty slugs from a trailing/duplicate comma', () => {
+		const { filters } = deserializeExploreFilters(new URLSearchParams('difficulty=casual,,mid,'))
+		const diffs = filters.filter((f) => f.kind === 'difficulty')
+		expect(diffs.map((f) => f.value)).toEqual(['casual', 'mid'])
+	})
+
+	it('seeds the pill label with the slug as a placeholder (hydrated client-side)', () => {
+		// The deserialize path runs before the tier list is loaded, so labels start
+		// as the slug. ExploreFilters.svelte patches them when the query resolves.
+		const { filters } = deserializeExploreFilters(new URLSearchParams('difficulty=casual'))
+		const diff = filters.find((f) => f.kind === 'difficulty')!
+		expect(diff.label).toBe(diff.value)
+	})
+
+	it('roundtrips a multi-difficulty filter through serialize→deserialize', () => {
+		const original: FilterItem[] = [
+			{ kind: 'difficulty', value: 'casual', label: 'Casual' },
+			{ kind: 'difficulty', value: 'mid', label: 'Mid' }
+		]
+		const params = serializeExploreFilters(original)
+		const { filters } = deserializeExploreFilters(params)
+		expect(filters.filter((f) => f.kind === 'difficulty').map((f) => f.value)).toEqual([
+			'casual',
+			'mid'
+		])
+	})
+
+	it('preserves difficulty alongside other filters in a complex roundtrip', () => {
+		const original: FilterItem[] = [
+			{ kind: 'element', value: 5, label: 'Dark' },
+			{ kind: 'difficulty', value: 'endgame', label: 'Endgame' },
+			{ kind: 'recency', value: 86400, label: 'Last day' }
+		]
+		const params = serializeExploreFilters(original)
+		const { filters } = deserializeExploreFilters(params)
+		expect(filters.find((f) => f.kind === 'difficulty')!.value).toBe('endgame')
+		expect(filters.find((f) => f.kind === 'element')!.value).toBe(5)
+		expect(filters.find((f) => f.kind === 'recency')!.value).toBe(86400)
+	})
+
+	it('urlHasExploreFilters detects difficulty even when no other filters are set', () => {
+		expect(urlHasExploreFilters(new URLSearchParams('difficulty=casual'))).toBe(true)
+	})
+})

--- a/src/lib/utils/__tests__/filterConversion.test.ts
+++ b/src/lib/utils/__tests__/filterConversion.test.ts
@@ -129,4 +129,22 @@ describe('filterItemsToParams', () => {
 		const unpinned: FilterItem[] = [{ kind: 'raid', value: 'akasha', label: 'Akasha' }]
 		expect(filterItemsToParams(pinned)).toEqual(filterItemsToParams(unpinned))
 	})
+
+	it('joins multiple difficulty filters into a single comma-separated `difficulty` param', () => {
+		const items: FilterItem[] = [
+			{ kind: 'difficulty', value: 'casual', label: 'Casual' },
+			{ kind: 'difficulty', value: 'mid', label: 'Mid' }
+		]
+		expect(filterItemsToParams(items).difficulty).toBe('casual,mid')
+	})
+
+	it('sends a single difficulty as-is (no trailing comma)', () => {
+		const items: FilterItem[] = [{ kind: 'difficulty', value: 'casual', label: 'Casual' }]
+		expect(filterItemsToParams(items).difficulty).toBe('casual')
+	})
+
+	it('omits the difficulty param when there are no difficulty filters', () => {
+		const items: FilterItem[] = [{ kind: 'element', value: 1, label: 'Wind' }]
+		expect(filterItemsToParams(items).difficulty).toBeUndefined()
+	})
 })

--- a/src/lib/utils/__tests__/filterMatching.test.ts
+++ b/src/lib/utils/__tests__/filterMatching.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import { matchLocal, rankResults } from '../filterMatching'
+import type { FilterItem, FilterOption } from '$lib/types/filter'
+
+// Minimal harness — we're isolating the difficulty branch, so the other
+// category fixtures stay empty.
+function call(overrides: {
+	query: string
+	filters?: FilterItem[]
+	excludedKinds?: FilterItem['kind'][]
+	difficultyOptions?: { value: string; label: string; color?: string }[]
+	categoryDifficultyLabel?: string
+}): FilterOption[] {
+	return matchLocal({
+		query: overrides.query,
+		filters: overrides.filters ?? [],
+		excludedKinds: overrides.excludedKinds ?? [],
+		elementOptions: [],
+		recencyOptions: [],
+		partyOptions: [],
+		boostOptions: [],
+		sideOptions: [],
+		difficultyOptions: overrides.difficultyOptions,
+		allRaids: [],
+		categoryLabels: {
+			element: 'Element',
+			recency: 'Recency',
+			party: 'Party',
+			raid: 'Raid',
+			boost: 'Boost',
+			side: 'Side',
+			difficulty: overrides.categoryDifficultyLabel ?? 'Difficulty'
+		}
+	})
+}
+
+describe('matchLocal — difficulty', () => {
+	const difficultyOptions = [
+		{ value: 'casual', label: 'Casual', color: '#86C5A8' },
+		{ value: 'mid', label: 'Mid', color: '#D4AF37' },
+		{ value: 'endgame', label: 'Endgame', color: '#1a1a3a' }
+	]
+
+	it('matches a tier by case-insensitive label substring', () => {
+		const results = call({ query: 'cas', difficultyOptions })
+
+		const difficulty = results.filter((r) => r.kind === 'difficulty')
+		expect(difficulty.map((r) => r.value)).toEqual(['casual'])
+		expect(difficulty[0]!.category).toBe('Difficulty')
+	})
+
+	it('returns multiple matches when the query overlaps multiple labels', () => {
+		const results = call({ query: 'e', difficultyOptions })
+
+		const slugs = results.filter((r) => r.kind === 'difficulty').map((r) => r.value)
+		// "e" is in "Casual" (no), "Mid" (no), "Endgame" (yes)
+		expect(slugs).toEqual(['endgame'])
+	})
+
+	it('omits tiers that are already in the active filter list', () => {
+		const results = call({
+			query: 'mid',
+			difficultyOptions,
+			filters: [{ kind: 'difficulty', value: 'mid', label: 'Mid' }]
+		})
+
+		expect(results.find((r) => r.kind === 'difficulty')).toBeUndefined()
+	})
+
+	it('skips the entire difficulty category when difficultyOptions is undefined', () => {
+		const results = call({ query: 'casual' })
+
+		expect(results.find((r) => r.kind === 'difficulty')).toBeUndefined()
+	})
+
+	it('skips the entire difficulty category when categoryLabels.difficulty is missing', () => {
+		// categoryDifficultyLabel falsy — pretend the consumer didn't wire it
+		const results = matchLocal({
+			query: 'casual',
+			filters: [],
+			excludedKinds: [],
+			elementOptions: [],
+			recencyOptions: [],
+			partyOptions: [],
+			boostOptions: [],
+			sideOptions: [],
+			difficultyOptions,
+			allRaids: [],
+			categoryLabels: {
+				element: 'Element',
+				recency: 'Recency',
+				party: 'Party',
+				raid: 'Raid',
+				boost: 'Boost',
+				side: 'Side'
+				// no difficulty label
+			}
+		})
+
+		expect(results.find((r) => r.kind === 'difficulty')).toBeUndefined()
+	})
+
+	it('honors excludedKinds: ["difficulty"]', () => {
+		const results = call({ query: 'casual', difficultyOptions, excludedKinds: ['difficulty'] })
+
+		expect(results.find((r) => r.kind === 'difficulty')).toBeUndefined()
+	})
+
+	it('does not stringify or transform the tier color into the option (color stays on the source list)', () => {
+		const results = call({ query: 'cas', difficultyOptions })
+		const opt = results.find((r) => r.kind === 'difficulty')!
+		// FilterOption doesn't carry the color; ExploreFilters reads it from difficultyOptions at selection time.
+		expect((opt as unknown as Record<string, unknown>).color).toBeUndefined()
+	})
+})
+
+describe('rankResults — difficulty filterKind', () => {
+	// rankResults boosts exact matches AND known filter kinds. Adding 'difficulty'
+	// to the recognized-kinds set in the implementation is regression-prone if
+	// it ever gets removed, so lock in that a difficulty option outranks a
+	// generic non-prefix match.
+	it('ranks an exact-prefix difficulty match above a non-prefix difficulty match', () => {
+		const input: FilterOption[] = [
+			{ kind: 'difficulty', value: 'endgame', label: 'Endgame', category: 'Difficulty' },
+			{ kind: 'difficulty', value: 'casual', label: 'Casual', category: 'Difficulty' }
+		]
+		const ranked = rankResults(input, 'cas')
+		expect(ranked[0]!.value).toBe('casual')
+	})
+
+	it('treats `difficulty` as a recognized filter kind (boosts above unknown kinds)', () => {
+		const input: FilterOption[] = [
+			// pretend an unrecognized kind shows up at the same prefix relevance
+			{ kind: 'class', value: 'casual-strider', label: 'Casual', category: 'Job' },
+			{ kind: 'difficulty', value: 'casual', label: 'Casual', category: 'Difficulty' }
+		]
+		const ranked = rankResults(input, 'casual')
+		// difficulty/class are both in the recognized set, so the ranking should be
+		// stable rather than dropping difficulty below it.
+		expect(ranked.map((r) => r.kind)).toContain('difficulty')
+	})
+})


### PR DESCRIPTION
Stacks on #852 (staging). Adds non-tautological coverage on the layers introduced by #848–#851 — the test gap was deliberately deferred during the original review.

## What's covered

### `difficulty.adapter` (30 tests)

Every public method: `withDrafts` flag round-trip on list endpoints, snake/camel transform on bodies (including `params` staying opaque), the staged-draft return type on mutations, and the drafts workspace endpoints (`listDrafts` / `getDiff` / `commit` / `discard` / `uploadDraftImage`).

### `difficultyQueries` factory (15 tests)

`queryKey` shape including the `withDrafts` discriminator (so the cache separates draft-aware reads from the public list), `staleTime` values per query, `queryFn` forwards filters to the adapter, and every key shares the `'difficulties'` root so the broad `invalidateQueries` call in mutations actually catches them.

### Filter plumbing (21 tests across 3 files)

- `exploreFilterParams.test.ts` (+9): `?difficulty=casual,mid` serialize/deserialize, multi-value parsing, empty-slug handling, label-as-slug placeholder until hydration, complex round-trip alongside other filters.
- `filterConversion.test.ts` (+3): difficulty filters map to a comma-joined `difficulty` API param.
- `filterMatching.test.ts` (new, 9): case-insensitive label match, dedupe against active filters, opt-out via `excludedKinds`, missing category-label guard, and `rankResults` recognizes `'difficulty'` as a known kind.

### Utilities (9 tests)

- `getTierIconUrl`: null/undefined inputs, trailing-slash base, `images/` and `/` prefix stripping, CDN cache-bust query preservation, local fallback.
- `transforms`: `params` keys round-trip unchanged in both directions (anchors the #849 fix).

### Extracted tier-form helpers (31 tests)

Pulled `buildTierPayload` / `validateTierForm` / `validateIconMeta` / `isWithinIconDimensions` out of `TierModal.svelte` into `tier-form.ts` so they can be tested in node:

- form validity: trimmed name/slug, 0–100 range with strict `max > min`, NaN-resistance, multi-error collection
- payload: trimming, empty description → `undefined`, `imageKey: null` only when `removeIcon` is set AND no new file is staged (the two-step upload flow depends on this contract)
- icon meta: MIME whitelist, byte cap, exactly-at-cap accepted, `wrong_type` reported before `too_large`
- dimensions: cap, exceeds, non-square, custom max

## What's NOT covered, and why

No browser/component test for the full `TierModal` click-Save flow. The codebase has no existing `*.svelte.test.ts` precedent — building component-test infrastructure (mount/cleanup helpers, Bits UI Dialog portal handling, toast/paraglide mocks) is its own task and shouldn't get bolted on here. Added a note in `.context/todos.md` for the polish PR.

## Numbers

- 106 new tests
- Full suite: **88 files / 1538 tests passing**
- `pnpm check` clean