### PR TITLE
unit chrome polish + edit pane fixes

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1370,6 +1370,7 @@
 	"label_exorcism_hint": "Higher exorcism reduces the negative effect",
 	"label_perpetuity_ring": "Perpetuity Ring",
 	"label_level": "Level",
+	"label_level_n": "Level {level}",
 	"label_value": "Value",
 
 	"toolbar_bold": "Bold",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1352,6 +1352,7 @@
 	"label_exorcism_hint": "退魔レベルが高いほどマイナス効果が軽減されます",
 	"label_perpetuity_ring": "久遠の指輪",
 	"label_level": "レベル",
+	"label_level_n": "レベル {level}",
 	"label_value": "値",
 
 	"toolbar_bold": "太字",

--- a/src/lib/api/adapters/grid.adapter.ts
+++ b/src/lib/api/adapters/grid.adapter.ts
@@ -346,20 +346,20 @@ export class GridAdapter extends BaseAdapter {
 		params: Partial<GridCharacter>,
 		headers?: Record<string, string>
 	): Promise<GridCharacter> {
-		// Flatten nested awakening object into awakening_id/awakening_level
-		// since the Rails API expects flat params, not nested attributes
+		// The character controller permits `awakening: { id, level }` nested
+		// only — top-level awakening_id/awakening_level get stripped by strong
+		// params. Forward the nested shape directly. Null is sent as { id: null,
+		// level: null } so transform_character_params doesn't try to dereference
+		// a nil hash.
 		const { awakening, ...rest } = params as Partial<GridCharacter> & {
 			awakening?: { id: string; level: number } | null
 		}
 		const body: Record<string, unknown> = { ...rest }
 		if (awakening !== undefined) {
-			if (awakening === null) {
-				body.awakeningId = null
-				body.awakeningLevel = null
-			} else {
-				body.awakeningId = awakening.id
-				body.awakeningLevel = awakening.level
-			}
+			body.awakening =
+				awakening === null
+					? { id: null, level: null }
+					: { id: awakening.id, level: awakening.level }
 		}
 
 		const response = await this.request<{ gridCharacter: GridCharacter }>(

--- a/src/lib/components/collection/CollectionCharacterPane.svelte
+++ b/src/lib/components/collection/CollectionCharacterPane.svelte
@@ -133,9 +133,19 @@
 				}
 			}
 
-			// Handle rings (API expects ring1, ring2, ring3, ring4)
+			// Handle rings (API expects ring1, ring2, ring3, ring4). The pane
+			// only includes rings the user actually set, so pad the remainder
+			// with explicit null hashes so cleared slots get written back as
+			// empty instead of leaving stale values on the record.
 			if (updates.rings) {
-				updates.rings.forEach((ring, index) => {
+				const padded: Array<{ modifier: number | null; strength: number | null }> = [
+					...updates.rings,
+					...Array(Math.max(0, 4 - updates.rings.length)).fill({
+						modifier: null,
+						strength: null
+					})
+				]
+				padded.forEach((ring, index) => {
 					const key = `ring${index + 1}` as keyof typeof input
 					input[key] = ring
 				})

--- a/src/lib/components/extra/ExtraSummonsGrid.svelte
+++ b/src/lib/components/extra/ExtraSummonsGrid.svelte
@@ -6,9 +6,11 @@
 	interface Props {
 		summons?: GridSummon[]
 		offset?: number
+		/** Per-position in-collection map plumbed through from SummonGrid. */
+		collectionStatus?: Map<number, boolean> | null
 	}
 
-	let { summons = [], offset = 4 }: Props = $props()
+	let { summons = [], offset = 4, collectionStatus = null }: Props = $props()
 
 	// Find summons by position (4 and 5 for subaura)
 	let subauraSlots = $derived(() => {
@@ -24,7 +26,16 @@
 	<ul class="grid" id="ExtraSummons">
 		{#each subauraSlots() as summon, i (i)}
 			<li>
-				<SummonUnit item={summon} position={offset + i} />
+				<SummonUnit
+					item={summon}
+					position={offset + i}
+					notInCollection={collectionStatus != null &&
+						!!summon?.summon?.granblueId &&
+						!collectionStatus.get(offset + i)}
+					inCollection={collectionStatus != null &&
+						!!summon?.summon?.granblueId &&
+						!!collectionStatus.get(offset + i)}
+				/>
 			</li>
 		{/each}
 	</ul>

--- a/src/lib/components/extra/ExtraWeaponsGrid.svelte
+++ b/src/lib/components/extra/ExtraWeaponsGrid.svelte
@@ -7,9 +7,11 @@
 	interface Props {
 		weapons?: GridWeapon[]
 		offset?: number
+		/** Per-position in-collection map plumbed through from WeaponGrid. */
+		collectionStatus?: Map<number, boolean> | null
 	}
 
-	let { weapons = [], offset = 9 }: Props = $props()
+	let { weapons = [], offset = 9, collectionStatus = null }: Props = $props()
 
 	// Create array for extra weapon slots by finding weapons at positions offset+0, offset+1, offset+2
 	let extraWeaponSlots = $derived.by(() => {
@@ -21,7 +23,16 @@
 	<ul class="grid">
 		{#each extraWeaponSlots as weapon, i (i)}
 			<li class:empty={!weapon}>
-				<WeaponUnit item={weapon} position={offset + i} />
+				<WeaponUnit
+					item={weapon}
+					position={offset + i}
+					notInCollection={collectionStatus != null &&
+						!!weapon?.weapon?.granblueId &&
+						!collectionStatus.get(offset + i)}
+					inCollection={collectionStatus != null &&
+						!!weapon?.weapon?.granblueId &&
+						!!collectionStatus.get(offset + i)}
+				/>
 			</li>
 		{/each}
 	</ul>

--- a/src/lib/components/grids/SummonGrid.svelte
+++ b/src/lib/components/grids/SummonGrid.svelte
@@ -67,7 +67,10 @@
 
 		check(main, -1)
 		subSummonSlots.forEach((s, i) => check(s, i))
-		// Skip friend slot — friend summons aren't owned, so collection doesn't apply
+		// Skip friend slot — friend summons aren't owned, so collection doesn't apply.
+		// Include subaura positions (offset 4, 5) so ExtraSummonsGrid can
+		// surface in-collection status there too.
+		summons.filter((s) => s.position >= 4 && s.position <= 5).forEach((s) => check(s, s.position))
 		return status
 	})
 </script>
@@ -149,7 +152,7 @@
 				<SummonUnit item={friend} position={6} sizeOverride="grid" />
 			</div>
 		</div>
-		<ExtraSummons {summons} offset={4} />
+		<ExtraSummons {summons} offset={4} {collectionStatus} />
 	</div>
 </div>
 

--- a/src/lib/components/grids/WeaponGrid.svelte
+++ b/src/lib/components/grids/WeaponGrid.svelte
@@ -84,6 +84,9 @@
 
 		check(mainhand, -1)
 		subWeaponSlots.forEach((w, i) => check(w, i))
+		// Include the extra weapon positions (offset 9, 10, 11) so
+		// ExtraWeaponsGrid can surface in-collection status there too.
+		weapons.filter((w) => w.position >= 9 && w.position <= 11).forEach((w) => check(w, w.position))
 		return status
 	})
 </script>
@@ -156,7 +159,7 @@
 	{#if raidExtra || showGuidebooks}
 		<ExtraContainer>
 			{#if raidExtra}
-				<ExtraWeapons {weapons} offset={9} />
+				<ExtraWeapons {weapons} offset={9} {collectionStatus} />
 			{/if}
 			{#if showGuidebooks}
 				<Guidebooks

--- a/src/lib/components/sidebar/CharacterEditPane.svelte
+++ b/src/lib/components/sidebar/CharacterEditPane.svelte
@@ -44,7 +44,7 @@
 			id: string
 			level: number
 		} | null
-		rings: ExtendedMastery[]
+		rings?: ExtendedMastery[]
 		earring?: ExtendedMastery | null
 		perpetuity?: boolean
 	}
@@ -109,13 +109,30 @@
 		return false
 	}
 
+	// Drop placeholder rings (modifier=0 or strength=0) from the payload. The
+	// edit pane seeds 4 ring entries for the form, but unselected slots stay
+	// at 0. Sending them as-is writes `{modifier:1, strength:0}` into ring1
+	// etc., which the backend reads as drift against the collection's null
+	// defaults and flags the section as out of sync. Returning only the real
+	// rings lets the backend pad ring3/ring4 with its empty default.
+	function normalizeRings(input: ExtendedMastery[]): ExtendedMastery[] {
+		return input.filter((r) => r.modifier > 0 && r.strength > 0)
+	}
+
 	// Export save function so parent can call it from header button
 	export function save() {
 		const updates: CharacterEditUpdates = {
 			uncapLevel,
 			transcendenceStep,
-			rings,
 			perpetuity: showPerpetuity ? perpetuity : undefined
+		}
+
+		// Only include rings in the payload when the user actually picked
+		// something. Backend's `if rings.present?` then skips the column update
+		// entirely instead of overwriting ring1-4 with placeholder zeros.
+		const realRings = normalizeRings(rings)
+		if (realRings.length > 0) {
+			updates.rings = realRings
 		}
 
 		// Format awakening for API

--- a/src/lib/components/sidebar/EditWeaponPane.svelte
+++ b/src/lib/components/sidebar/EditWeaponPane.svelte
@@ -18,6 +18,7 @@
 	import { useSyncGridWeapon } from '$lib/api/mutations/grid.mutations'
 	import Icon from '$lib/components/Icon.svelte'
 	import { getElementKey } from '$lib/utils/element'
+	import { canWeaponBeModified } from '$lib/utils/modificationDetector'
 	import { useEditPaneHeader } from './useEditPaneHeader.svelte'
 
 	interface Props {
@@ -31,7 +32,13 @@
 
 	let { paneId, weapon, partyId, partyShortcode, onSave, onCancel }: Props = $props()
 
-	let activeTab = $state<'stats' | 'notes'>('stats')
+	// Weapons without any modifiable accessory (no awakening, befoulment,
+	// AX, weapon keys, bullet slots, or element override) skip the Stats
+	// tab entirely — the edit pane becomes notes-only so the owner can
+	// still configure substitutes and a description.
+	const canEditStats = $derived(canWeaponBeModified(weapon))
+
+	let activeTab = $state<'stats' | 'notes'>(canEditStats ? 'stats' : 'notes')
 
 	let editPaneRef: ReturnType<typeof WeaponEditPane> | undefined = $state()
 
@@ -117,14 +124,16 @@
 		</div>
 	{/if}
 
-	<div class="tabs">
-		<SegmentedControl bind:value={activeTab} variant="background" size="small" grow>
-			<Segment value="stats">{m.tab_stats()}</Segment>
-			<Segment value="notes">{m.tab_notes()}</Segment>
-		</SegmentedControl>
-	</div>
+	{#if canEditStats}
+		<div class="tabs">
+			<SegmentedControl bind:value={activeTab} variant="background" size="small" grow>
+				<Segment value="stats">{m.tab_stats()}</Segment>
+				<Segment value="notes">{m.tab_notes()}</Segment>
+			</SegmentedControl>
+		</div>
+	{/if}
 
-	{#if activeTab === 'stats'}
+	{#if canEditStats && activeTab === 'stats'}
 		<WeaponEditPane
 			bind:this={editPaneRef}
 			{weaponData}

--- a/src/lib/components/sidebar/edit/AwakeningSelect.svelte
+++ b/src/lib/components/sidebar/edit/AwakeningSelect.svelte
@@ -3,7 +3,7 @@
 	import type { Awakening } from '$lib/types/api/entities'
 	import { NO_AWAKENING } from '$lib/types/api/entities'
 	import Select from '$lib/components/ui/Select.svelte'
-	import Input from '$lib/components/ui/Input.svelte'
+	import Slider from '$lib/components/ui/Slider.svelte'
 	import DetailRow from '$lib/components/sidebar/details/DetailRow.svelte'
 	import { getAwakeningImage } from '$lib/utils/modifiers'
 	import { localizedName } from '$lib/utils/locale'
@@ -35,9 +35,6 @@
 	// Local state derived from props — overrides are temporary until props change
 	let selectedId = $derived(value ? value.id || value.slug || NO_AWAKENING.id : NO_AWAKENING.id)
 	let localLevel = $derived(level)
-
-	// Error state for level input
-	let levelError = $state('')
 
 	// Helper to get a unique identifier for an awakening (use id if available, fallback to slug)
 	function getAwakeningKey(awk: Awakening): string {
@@ -89,33 +86,8 @@
 		}
 	}
 
-	// Handle level change with validation
-	function handleLevelChange(event: Event) {
-		const input = event.target as HTMLInputElement
-		const newLevel = parseInt(input.value, 10)
-
-		// Validate the level
-		if (isNaN(newLevel)) {
-			levelError = 'Please enter a valid number'
-			return
-		}
-
-		if (newLevel < 1) {
-			levelError = 'Level must be at least 1'
-			return
-		}
-
-		if (newLevel > maxLevel) {
-			levelError = `Level cannot exceed ${maxLevel}`
-			return
-		}
-
-		if (!Number.isInteger(newLevel)) {
-			levelError = 'Level must be a whole number'
-			return
-		}
-
-		levelError = ''
+	// Slider clamps within [1, maxLevel] already, so no extra validation needed.
+	function handleLevelChange(newLevel: number) {
 		localLevel = newLevel
 		onLevelChange?.(newLevel)
 	}
@@ -135,18 +107,16 @@
 	</div>
 
 	{#if !isNoAwakening}
-		<DetailRow label={m.label_level()} noPadding error={levelError || undefined}>
-			<Input
-				type="number"
-				min={1}
-				max={maxLevel}
-				step={1}
-				value={localLevel}
-				oninput={handleLevelChange}
-				contained
-				variant="number"
-				placeholder="1~{maxLevel}"
-			/>
+		<DetailRow label={m.label_level_n({ level: String(localLevel) })} noPadding>
+			<div class="level-slider">
+				<Slider
+					value={localLevel}
+					min={1}
+					max={maxLevel}
+					step={1}
+					onValueChange={handleLevelChange}
+				/>
+			</div>
 		</DetailRow>
 	{/if}
 </div>
@@ -162,5 +132,13 @@
 
 	.awakening-type {
 		flex: 1;
+	}
+
+	// Give the slider enough room to feel draggable rather than crammed into
+	// the DetailRow's right-aligned value cell.
+	.level-slider {
+		min-width: 160px;
+		display: flex;
+		align-items: center;
 	}
 </style>

--- a/src/lib/components/units/BookmarkOverlay.svelte
+++ b/src/lib/components/units/BookmarkOverlay.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	/**
+	 * Circular bookmark badge overlaid on the top-left of a unit's image to
+	 * signal that the user owns this item in their collection.
+	 */
+	import Icon from '$lib/components/Icon.svelte'
+</script>
+
+<div class="bookmark-overlay" aria-hidden="true">
+	<Icon name="bookmark" width={12} height={16} />
+</div>
+
+<style lang="scss">
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/effects' as effects;
+
+	.bookmark-overlay {
+		position: absolute;
+		top: spacing.$unit;
+		left: spacing.$unit;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: spacing.$unit;
+		border-radius: 50%;
+		background: rgba(0, 0, 0, 0.8);
+		color: white;
+		z-index: effects.$z-sticky;
+		pointer-events: none;
+	}
+</style>

--- a/src/lib/components/units/BookmarkOverlay.svelte
+++ b/src/lib/components/units/BookmarkOverlay.svelte
@@ -52,7 +52,9 @@
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
+		border: 2px solid rgba(0, 0, 0, 0.14);
 		border-radius: 50%;
+		backdrop-filter: blur(2px);
 		z-index: effects.$z-sticky;
 		pointer-events: none;
 

--- a/src/lib/components/units/BookmarkOverlay.svelte
+++ b/src/lib/components/units/BookmarkOverlay.svelte
@@ -1,16 +1,45 @@
 <script lang="ts">
 	/**
 	 * Circular bookmark badge overlaid on the top-left of a unit's image to
-	 * signal that the user owns this item in their collection.
+	 * signal that the user owns this item in their collection. Element-tinted
+	 * so it reads as part of the unit's chrome, with the background staying
+	 * translucent enough to let the artwork show through.
 	 */
 	import Icon from '$lib/components/Icon.svelte'
+
+	interface Props {
+		/** Granblue element id (1=wind, 2=fire, 3=water, 4=earth, 5=dark, 6=light). */
+		element?: number | null | undefined
+	}
+
+	let { element }: Props = $props()
+
+	const elementClass = $derived.by(() => {
+		switch (element) {
+			case 1:
+				return 'wind'
+			case 2:
+				return 'fire'
+			case 3:
+				return 'water'
+			case 4:
+				return 'earth'
+			case 5:
+				return 'dark'
+			case 6:
+				return 'light'
+			default:
+				return 'neutral'
+		}
+	})
 </script>
 
-<div class="bookmark-overlay" aria-hidden="true">
+<div class="bookmark-overlay {elementClass}" aria-hidden="true">
 	<Icon name="bookmark" width={12} height={16} />
 </div>
 
 <style lang="scss">
+	@use '$src/themes/colors' as *;
 	@use '$src/themes/spacing' as spacing;
 	@use '$src/themes/effects' as effects;
 
@@ -18,18 +47,51 @@
 		position: absolute;
 		top: spacing.$unit;
 		left: spacing.$unit;
-		// Explicit square sizing — the bookmark glyph is 12x16, so relying on
-		// padding alone gave a 28x32 capsule. Fixed width/height + flex
-		// centering keeps the badge a true 32x32 circle.
 		width: 32px;
 		height: 32px;
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
 		border-radius: 50%;
-		background: rgba(0, 0, 0, 0.8);
-		color: white;
 		z-index: effects.$z-sticky;
 		pointer-events: none;
+
+		// Element-tinted background sits at 0.8 alpha so the underlying image
+		// still reads through, while the foreground icon picks up the
+		// matching bright tone for contrast against the translucent fill.
+		&.wind {
+			background: rgba($wind-text-10, 0.8);
+			color: $wind-bg-20;
+		}
+
+		&.fire {
+			background: rgba($fire-text-10, 0.8);
+			color: $fire-bg-20;
+		}
+
+		&.water {
+			background: rgba($water-text-10, 0.8);
+			color: $water-bg-20;
+		}
+
+		&.earth {
+			background: rgba($earth-text-10, 0.8);
+			color: $earth-bg-20;
+		}
+
+		&.dark {
+			background: rgba($dark-text-10, 0.8);
+			color: $dark-bg-20;
+		}
+
+		&.light {
+			background: rgba($light-text-10, 0.8);
+			color: $light-bg-20;
+		}
+
+		&.neutral {
+			background: rgba(0, 0, 0, 0.8);
+			color: white;
+		}
 	}
 </style>

--- a/src/lib/components/units/BookmarkOverlay.svelte
+++ b/src/lib/components/units/BookmarkOverlay.svelte
@@ -18,10 +18,14 @@
 		position: absolute;
 		top: spacing.$unit;
 		left: spacing.$unit;
+		// Explicit square sizing — the bookmark glyph is 12x16, so relying on
+		// padding alone gave a 28x32 capsule. Fixed width/height + flex
+		// centering keeps the badge a true 32x32 circle.
+		width: 32px;
+		height: 32px;
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		padding: spacing.$unit;
 		border-radius: 50%;
 		background: rgba(0, 0, 0, 0.8);
 		color: white;

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -8,6 +8,7 @@
 	import MenuItems from '$lib/components/ui/menu/MenuItems.svelte'
 	import RemoveUnitDialog from './RemoveUnitDialog.svelte'
 	import SubstituteCountBadge from './SubstituteCountBadge.svelte'
+	import BookmarkOverlay from './BookmarkOverlay.svelte'
 	import UncapIndicator from '$lib/components/uncap/UncapIndicator.svelte'
 	import CharacterTags from '$lib/components/tags/CharacterTags.svelte'
 	import Tooltip from '$lib/components/ui/Tooltip.svelte'
@@ -209,7 +210,7 @@
 	class:orphaned={item?.orphaned}
 >
 	{#if item}
-		<UnitMenuContainer showGearButton={true}>
+		<UnitMenuContainer showGearButton={true} gearPosition="top-right">
 			{#snippet trigger()}
 				<div
 					class="focus-ring-wrapper {elementClass}"
@@ -282,6 +283,9 @@
 									alt={localizedName(item?.character?.name)}
 									src={imageUrl}
 								/>
+							{/if}
+							{#if inCollection}
+								<BookmarkOverlay />
 							{/if}
 						</div>
 					{/key}
@@ -385,7 +389,6 @@
 		{/if}
 	{/key}
 	<div class="name" class:not-in-collection={notInCollection}>
-		{#if item && inCollection}<Icon name="bookmark" width={12} height={16} />{/if}
 		<span class="name-text">{item ? localizedName(item?.character?.name) : ''}</span>
 		{#if item?.artifact}
 			<Icon name="gem" size={12} class="artifact-indicator" />

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -532,18 +532,13 @@
 	}
 
 	.name {
-		font-size: typography.$font-small;
-		text-align: center;
-		color: var(--text-secondary);
-
-		:global(span) {
-			display: inline;
-			vertical-align: -4px;
-		}
-
+		display: flex;
+		flex-wrap: wrap;
 		align-items: center;
 		justify-content: center;
 		gap: spacing.$unit-fourth;
+		font-size: typography.$font-small;
+		color: var(--text-secondary);
 
 		:global(.artifact-indicator) {
 			color: var(--extra-purple-text);

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -386,7 +386,7 @@
 	{/key}
 	<div class="name" class:not-in-collection={notInCollection}>
 		{#if item && inCollection}<Icon name="bookmark" width={12} height={16} />{/if}
-		{item ? localizedName(item?.character?.name) : ''}
+		<span class="name-text">{item ? localizedName(item?.character?.name) : ''}</span>
 		{#if item?.artifact}
 			<Icon name="gem" size={12} class="artifact-indicator" />
 		{/if}
@@ -533,7 +533,6 @@
 
 	.name {
 		display: flex;
-		flex-wrap: wrap;
 		align-items: center;
 		justify-content: center;
 		gap: spacing.$unit-half;
@@ -544,6 +543,15 @@
 			color: var(--extra-purple-text);
 			flex-shrink: 0;
 		}
+	}
+
+	.name-text {
+		// min-width: 0 lets the text item shrink under content size so long
+		// names wrap inside the span instead of forcing the bookmark/badge
+		// onto their own flex line.
+		min-width: 0;
+		text-align: center;
+		overflow-wrap: anywhere;
 	}
 
 	.perpetuity {

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -7,6 +7,7 @@
 	import UnitMenuContainer from '$lib/components/ui/menu/UnitMenuContainer.svelte'
 	import MenuItems from '$lib/components/ui/menu/MenuItems.svelte'
 	import RemoveUnitDialog from './RemoveUnitDialog.svelte'
+	import SubstituteCountBadge from './SubstituteCountBadge.svelte'
 	import UncapIndicator from '$lib/components/uncap/UncapIndicator.svelte'
 	import CharacterTags from '$lib/components/tags/CharacterTags.svelte'
 	import Tooltip from '$lib/components/ui/Tooltip.svelte'
@@ -282,6 +283,7 @@
 									src={imageUrl}
 								/>
 							{/if}
+							<SubstituteCountBadge count={item?.substitutions?.length ?? 0} />
 						</div>
 					{/key}
 				</div>

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -285,7 +285,9 @@
 								/>
 							{/if}
 							{#if inCollection}
-								<BookmarkOverlay />
+								<BookmarkOverlay
+									element={item?.character?.element ?? mainWeaponElement ?? partyElement}
+								/>
 							{/if}
 						</div>
 					{/key}

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -563,7 +563,7 @@
 		position: absolute;
 		z-index: effects.$z-tooltip;
 		top: calc(spacing.$unit * -1);
-		right: spacing.$unit-3x;
+		right: 44px;
 		width: spacing.$unit-4x;
 		height: spacing.$unit-4x;
 		padding: 0;

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -284,13 +284,13 @@
 									src={imageUrl}
 								/>
 							{/if}
-							{#if inCollection}
-								<BookmarkOverlay
-									element={item?.character?.element ?? mainWeaponElement ?? partyElement}
-								/>
-							{/if}
 						</div>
 					{/key}
+					{#if inCollection}
+						<BookmarkOverlay
+							element={item?.character?.element ?? mainWeaponElement ?? partyElement}
+						/>
+					{/if}
 				</div>
 			{/snippet}
 

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -536,7 +536,7 @@
 		flex-wrap: wrap;
 		align-items: center;
 		justify-content: center;
-		gap: spacing.$unit-fourth;
+		gap: spacing.$unit-half;
 		font-size: typography.$font-small;
 		color: var(--text-secondary);
 

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -283,7 +283,6 @@
 									src={imageUrl}
 								/>
 							{/if}
-							<SubstituteCountBadge count={item?.substitutions?.length ?? 0} />
 						</div>
 					{/key}
 				</div>
@@ -390,6 +389,9 @@
 		{item ? localizedName(item?.character?.name) : ''}
 		{#if item?.artifact}
 			<Icon name="gem" size={12} class="artifact-indicator" />
+		{/if}
+		{#if item}
+			<SubstituteCountBadge count={item.substitutions?.length ?? 0} />
 		{/if}
 	</div>
 	{#if item?.character}

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -391,7 +391,10 @@
 			<Icon name="gem" size={12} class="artifact-indicator" />
 		{/if}
 		{#if item}
-			<SubstituteCountBadge count={item.substitutions?.length ?? 0} />
+			<SubstituteCountBadge
+				count={item.substitutions?.length ?? 0}
+				element={item.character?.element ?? mainWeaponElement ?? partyElement}
+			/>
 		{/if}
 	</div>
 	{#if item?.character}

--- a/src/lib/components/units/SubstituteCountBadge.svelte
+++ b/src/lib/components/units/SubstituteCountBadge.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	/**
-	 * Small circular count badge for the unit components. Renders the number of
-	 * substitutes configured for the slot, anchored to the bottom-right of the
-	 * containing frame via absolute positioning. Renders nothing when there are
-	 * no substitutes.
+	 * Inline circular count badge appended to a unit's name. Shows how many
+	 * substitutes the slot has configured; renders nothing when there are
+	 * none. Sized to sit alongside body text, not as an image overlay.
 	 */
 	interface Props {
 		count: number
@@ -13,34 +12,28 @@
 </script>
 
 {#if count > 0}
-	<div class="substitute-count-badge" title="{count} substitute{count === 1 ? '' : 's'}">
+	<span class="substitute-count-badge" title="{count} substitute{count === 1 ? '' : 's'}">
 		{count}
-	</div>
+	</span>
 {/if}
 
 <style lang="scss">
 	@use '$src/themes/spacing' as spacing;
 	@use '$src/themes/typography' as typography;
-	@use '$src/themes/effects' as effects;
 
 	.substitute-count-badge {
-		position: absolute;
-		bottom: spacing.$unit-half;
-		right: spacing.$unit-half;
-		min-width: 20px;
-		height: 20px;
-		padding: 0 spacing.$unit-half;
-		border-radius: 999px;
-		background: rgba(0, 0, 0, 0.7);
-		color: white;
-		font-size: typography.$font-tiny;
-		font-weight: 600;
-		line-height: 1;
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		z-index: effects.$z-tooltip;
-		pointer-events: none;
-		backdrop-filter: blur(4px);
+		min-width: 16px;
+		height: 16px;
+		padding: 0 spacing.$unit-half;
+		border-radius: 999px;
+		background: var(--button-contained-bg);
+		color: var(--text-secondary);
+		font-size: typography.$font-tiny;
+		font-weight: 600;
+		line-height: 1;
+		vertical-align: middle;
 	}
 </style>

--- a/src/lib/components/units/SubstituteCountBadge.svelte
+++ b/src/lib/components/units/SubstituteCountBadge.svelte
@@ -53,6 +53,10 @@
 		justify-content: center;
 		min-width: 16px;
 		height: 16px;
+		// Bumps the gap between name text and the badge from the row's default
+		// $unit-fourth up to $unit-half without changing spacing between other
+		// inline indicators (bookmark, artifact gem).
+		margin-left: $unit-fourth;
 		padding: 0 $unit-half;
 		border-radius: 999px;
 		font-size: $font-tiny;

--- a/src/lib/components/units/SubstituteCountBadge.svelte
+++ b/src/lib/components/units/SubstituteCountBadge.svelte
@@ -2,24 +2,50 @@
 	/**
 	 * Inline circular count badge appended to a unit's name. Shows how many
 	 * substitutes the slot has configured; renders nothing when there are
-	 * none. Sized to sit alongside body text, not as an image overlay.
+	 * none. Element-tinted to match CharacterTag so it reads as part of the
+	 * unit's chrome rather than a generic chip.
 	 */
 	interface Props {
 		count: number
+		/** Granblue element id (1=wind, 2=fire, 3=water, 4=earth, 5=dark, 6=light). */
+		element?: number | null | undefined
 	}
 
-	let { count }: Props = $props()
+	let { count, element }: Props = $props()
+
+	const elementClass = $derived.by(() => {
+		switch (element) {
+			case 1:
+				return 'wind'
+			case 2:
+				return 'fire'
+			case 3:
+				return 'water'
+			case 4:
+				return 'earth'
+			case 5:
+				return 'dark'
+			case 6:
+				return 'light'
+			default:
+				return 'neutral'
+		}
+	})
 </script>
 
 {#if count > 0}
-	<span class="substitute-count-badge" title="{count} substitute{count === 1 ? '' : 's'}">
+	<span
+		class="substitute-count-badge {elementClass}"
+		title="{count} substitute{count === 1 ? '' : 's'}"
+	>
 		{count}
 	</span>
 {/if}
 
 <style lang="scss">
-	@use '$src/themes/spacing' as spacing;
-	@use '$src/themes/typography' as typography;
+	@use '$src/themes/colors' as *;
+	@use '$src/themes/spacing' as *;
+	@use '$src/themes/typography' as *;
 
 	.substitute-count-badge {
 		display: inline-flex;
@@ -27,13 +53,84 @@
 		justify-content: center;
 		min-width: 16px;
 		height: 16px;
-		padding: 0 spacing.$unit-half;
+		padding: 0 $unit-half;
 		border-radius: 999px;
-		background: var(--button-contained-bg);
-		color: var(--text-secondary);
-		font-size: typography.$font-tiny;
+		font-size: $font-tiny;
 		font-weight: 600;
 		line-height: 1;
 		vertical-align: middle;
+
+		&.wind {
+			background-color: $wind-bg-20;
+			color: $wind-text-20;
+		}
+
+		&.fire {
+			background-color: $fire-bg-20;
+			color: $fire-text-20;
+		}
+
+		&.water {
+			background-color: $water-bg-20;
+			color: $water-text-20;
+		}
+
+		&.earth {
+			background-color: $earth-bg-20;
+			color: $earth-text-20;
+		}
+
+		&.dark {
+			background-color: $dark-bg-20;
+			color: $dark-text-20;
+		}
+
+		&.light {
+			background-color: $light-bg-20;
+			color: $light-text-20;
+		}
+
+		&.neutral {
+			background-color: $grey-80;
+			color: $grey-40;
+		}
+	}
+
+	// Dark mode adjustments mirror CharacterTag.
+	:global(.dark) .substitute-count-badge {
+		&.wind {
+			background-color: $wind-text-10;
+			color: $wind-bg-20;
+		}
+
+		&.fire {
+			background-color: $fire-text-10;
+			color: $fire-bg-20;
+		}
+
+		&.water {
+			background-color: $water-text-10;
+			color: $water-bg-20;
+		}
+
+		&.earth {
+			background-color: $earth-text-10;
+			color: $earth-bg-20;
+		}
+
+		&.dark {
+			background-color: $dark-text-10;
+			color: $dark-bg-20;
+		}
+
+		&.light {
+			background-color: $light-text-10;
+			color: $light-bg-20;
+		}
+
+		&.neutral {
+			background-color: $grey-30;
+			color: $grey-80;
+		}
 	}
 </style>

--- a/src/lib/components/units/SubstituteCountBadge.svelte
+++ b/src/lib/components/units/SubstituteCountBadge.svelte
@@ -53,10 +53,6 @@
 		justify-content: center;
 		min-width: 16px;
 		height: 16px;
-		// Bumps the gap between name text and the badge from the row's default
-		// $unit-fourth up to $unit-half without changing spacing between other
-		// inline indicators (bookmark, artifact gem).
-		margin-left: $unit-fourth;
 		padding: 0 $unit-half;
 		border-radius: 999px;
 		font-size: $font-tiny;

--- a/src/lib/components/units/SubstituteCountBadge.svelte
+++ b/src/lib/components/units/SubstituteCountBadge.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	/**
+	 * Small circular count badge for the unit components. Renders the number of
+	 * substitutes configured for the slot, anchored to the bottom-right of the
+	 * containing frame via absolute positioning. Renders nothing when there are
+	 * no substitutes.
+	 */
+	interface Props {
+		count: number
+	}
+
+	let { count }: Props = $props()
+</script>
+
+{#if count > 0}
+	<div class="substitute-count-badge" title="{count} substitute{count === 1 ? '' : 's'}">
+		{count}
+	</div>
+{/if}
+
+<style lang="scss">
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+	@use '$src/themes/effects' as effects;
+
+	.substitute-count-badge {
+		position: absolute;
+		bottom: spacing.$unit-half;
+		right: spacing.$unit-half;
+		min-width: 20px;
+		height: 20px;
+		padding: 0 spacing.$unit-half;
+		border-radius: 999px;
+		background: rgba(0, 0, 0, 0.7);
+		color: white;
+		font-size: typography.$font-tiny;
+		font-weight: 600;
+		line-height: 1;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		z-index: effects.$z-tooltip;
+		pointer-events: none;
+		backdrop-filter: blur(4px);
+	}
+</style>

--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -237,7 +237,6 @@
 								alt={localizedName(item?.summon?.name)}
 								src={imageUrl}
 							/>
-							<SubstituteCountBadge count={item?.substitutions?.length ?? 0} />
 						</div>
 					{/key}
 					{#if showQuickSummon && ctx?.canEdit()}
@@ -373,6 +372,9 @@
 	<div class="name" class:not-in-collection={notInCollection}>
 		{#if item && inCollection}<Icon name="bookmark" width={12} height={16} />{/if}
 		{item ? localizedName(item?.summon?.name) : ''}
+		{#if item}
+			<SubstituteCountBadge count={item.substitutions?.length ?? 0} />
+		{/if}
 	</div>
 </div>
 

--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -7,6 +7,7 @@
 	import UnitMenuContainer from '$lib/components/ui/menu/UnitMenuContainer.svelte'
 	import MenuItems from '$lib/components/ui/menu/MenuItems.svelte'
 	import RemoveUnitDialog from './RemoveUnitDialog.svelte'
+	import SubstituteCountBadge from './SubstituteCountBadge.svelte'
 	import UncapIndicator from '$lib/components/uncap/UncapIndicator.svelte'
 	import { getSummonImage } from '$lib/features/database/detail/image'
 	import { getPlaceholderImage, getSummonTransformation } from '$lib/utils/images'
@@ -236,6 +237,7 @@
 								alt={localizedName(item?.summon?.name)}
 								src={imageUrl}
 							/>
+							<SubstituteCountBadge count={item?.substitutions?.length ?? 0} />
 						</div>
 					{/key}
 					{#if showQuickSummon && ctx?.canEdit()}

--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -8,6 +8,7 @@
 	import MenuItems from '$lib/components/ui/menu/MenuItems.svelte'
 	import RemoveUnitDialog from './RemoveUnitDialog.svelte'
 	import SubstituteCountBadge from './SubstituteCountBadge.svelte'
+	import BookmarkOverlay from './BookmarkOverlay.svelte'
 	import UncapIndicator from '$lib/components/uncap/UncapIndicator.svelte'
 	import { getSummonImage } from '$lib/features/database/detail/image'
 	import { getPlaceholderImage, getSummonTransformation } from '$lib/utils/images'
@@ -198,7 +199,7 @@
 	class:orphaned={item?.orphaned}
 >
 	{#if item}
-		<UnitMenuContainer showGearButton={true}>
+		<UnitMenuContainer showGearButton={true} gearPosition="top-right">
 			{#snippet trigger()}
 				<div
 					class="focus-ring-wrapper {elementClass}"
@@ -237,6 +238,9 @@
 								alt={localizedName(item?.summon?.name)}
 								src={imageUrl}
 							/>
+							{#if inCollection}
+								<BookmarkOverlay />
+							{/if}
 						</div>
 					{/key}
 					{#if showQuickSummon && ctx?.canEdit()}
@@ -370,7 +374,6 @@
 		/>
 	{/if}
 	<div class="name" class:not-in-collection={notInCollection}>
-		{#if item && inCollection}<Icon name="bookmark" width={12} height={16} />{/if}
 		<span class="name-text">{item ? localizedName(item?.summon?.name) : ''}</span>
 		{#if item}
 			<SubstituteCountBadge

--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -373,7 +373,10 @@
 		{#if item && inCollection}<Icon name="bookmark" width={12} height={16} />{/if}
 		{item ? localizedName(item?.summon?.name) : ''}
 		{#if item}
-			<SubstituteCountBadge count={item.substitutions?.length ?? 0} />
+			<SubstituteCountBadge
+				count={item.substitutions?.length ?? 0}
+				element={item.summon?.element}
+			/>
 		{/if}
 	</div>
 </div>

--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -238,11 +238,11 @@
 								alt={localizedName(item?.summon?.name)}
 								src={imageUrl}
 							/>
-							{#if inCollection}
-								<BookmarkOverlay element={item?.summon?.element} />
-							{/if}
 						</div>
 					{/key}
+					{#if inCollection}
+						<BookmarkOverlay element={item?.summon?.element} />
+					{/if}
 					{#if showQuickSummon && ctx?.canEdit()}
 						<button
 							class="quick-summon"

--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -531,7 +531,7 @@
 		flex-wrap: wrap;
 		align-items: center;
 		justify-content: center;
-		gap: spacing.$unit-fourth;
+		gap: spacing.$unit-half;
 		font-size: typography.$font-small;
 		color: var(--text-secondary);
 	}

--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -527,14 +527,13 @@
 	}
 
 	.name {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: center;
+		gap: spacing.$unit-fourth;
 		font-size: typography.$font-small;
-		text-align: center;
 		color: var(--text-secondary);
-
-		:global(span) {
-			display: inline;
-			vertical-align: -4px;
-		}
 	}
 
 	.orphaned-badge {

--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -371,7 +371,7 @@
 	{/if}
 	<div class="name" class:not-in-collection={notInCollection}>
 		{#if item && inCollection}<Icon name="bookmark" width={12} height={16} />{/if}
-		{item ? localizedName(item?.summon?.name) : ''}
+		<span class="name-text">{item ? localizedName(item?.summon?.name) : ''}</span>
 		{#if item}
 			<SubstituteCountBadge
 				count={item.substitutions?.length ?? 0}
@@ -528,12 +528,17 @@
 
 	.name {
 		display: flex;
-		flex-wrap: wrap;
 		align-items: center;
 		justify-content: center;
 		gap: spacing.$unit-half;
 		font-size: typography.$font-small;
 		color: var(--text-secondary);
+	}
+
+	.name-text {
+		min-width: 0;
+		text-align: center;
+		overflow-wrap: anywhere;
 	}
 
 	.orphaned-badge {

--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -239,7 +239,7 @@
 								src={imageUrl}
 							/>
 							{#if inCollection}
-								<BookmarkOverlay />
+								<BookmarkOverlay element={item?.summon?.element} />
 							{/if}
 						</div>
 					{/key}

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -414,7 +414,10 @@
 		{#if item && inCollection}<Icon name="bookmark" width={12} height={16} />{/if}
 		{item ? localizedName(item?.weapon?.name) : ''}
 		{#if item}
-			<SubstituteCountBadge count={item.substitutions?.length ?? 0} />
+			<SubstituteCountBadge
+				count={item.substitutions?.length ?? 0}
+				element={item.element || item.weapon?.element}
+			/>
 		{/if}
 	</div>
 </div>

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -594,7 +594,7 @@
 		flex-wrap: wrap;
 		align-items: center;
 		justify-content: center;
-		gap: spacing.$unit-fourth;
+		gap: spacing.$unit-half;
 		font-size: typography.$font-small;
 		color: var(--text-secondary);
 	}

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -303,7 +303,7 @@
 								onerror={(e) => handleImageFallback(e, fallbackUrl)}
 							/>
 							{#if inCollection}
-								<BookmarkOverlay />
+								<BookmarkOverlay element={item?.element || item?.weapon?.element} />
 							{/if}
 						</div>
 					{/key}

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -22,7 +22,6 @@
 		openDetailsSidebar,
 		openWeaponEditSidebar
 	} from '$lib/features/details/openDetailsSidebar.svelte'
-	import { canWeaponBeModified } from '$lib/utils/modificationDetector'
 	import { getDatabaseUrl, canAccessDatabase } from '$lib/utils/database'
 	import { getElementClassName } from '$lib/utils/element'
 	import { collectionTeamsPane } from '$lib/stores/collectionTeamsPane.svelte'
@@ -132,7 +131,9 @@
 		await ctx.services.gridService.removeWeapon(party.id, item.id, editKey || undefined)
 	}, 'Failed to remove weapon')
 
-	let canEditItem = $derived(canWeaponBeModified(item))
+	// Edit is always available for owners — non-modifiable weapons still get
+	// the notes-only pane so substitutes/description can be configured.
+	let canEditItem = $derived(!!item?.id)
 
 	function getSaveCallback() {
 		return async (id: string, updates: Partial<GridWeapon>) => {

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -302,11 +302,11 @@
 								src={imageUrl}
 								onerror={(e) => handleImageFallback(e, fallbackUrl)}
 							/>
-							{#if inCollection}
-								<BookmarkOverlay element={item?.element || item?.weapon?.element} />
-							{/if}
 						</div>
 					{/key}
+					{#if inCollection}
+						<BookmarkOverlay element={item?.element || item?.weapon?.element} />
+					{/if}
 				</div>
 			{/snippet}
 
@@ -603,10 +603,11 @@
 
 	// Weapons render the awakening icon at the top-left of the frame, which
 	// collides with the bookmark overlay's default top-anchored position.
-	// Pull the bookmark up so it sits above the awakening icon. Awakening's
-	// own positioning is unchanged.
-	.frame.weapon :global(.bookmark-overlay) {
-		margin-top: calc(spacing.$unit-2x * -1);
+	// Pull the bookmark up and slightly out so it sits above the awakening
+	// icon. Awakening's own positioning is unchanged.
+	.focus-ring-wrapper :global(.bookmark-overlay) {
+		margin-top: -21px;
+		margin-left: -6px;
 	}
 
 	.name-text {

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -7,6 +7,7 @@
 	import UnitMenuContainer from '$lib/components/ui/menu/UnitMenuContainer.svelte'
 	import MenuItems from '$lib/components/ui/menu/MenuItems.svelte'
 	import RemoveUnitDialog from './RemoveUnitDialog.svelte'
+	import SubstituteCountBadge from './SubstituteCountBadge.svelte'
 	import Tooltip from '$lib/components/ui/Tooltip.svelte'
 	import UncapIndicator from '$lib/components/uncap/UncapIndicator.svelte'
 	import { getWeaponImage } from '$lib/features/database/detail/image'
@@ -300,6 +301,7 @@
 								src={imageUrl}
 								onerror={(e) => handleImageFallback(e, fallbackUrl)}
 							/>
+							<SubstituteCountBadge count={item?.substitutions?.length ?? 0} />
 						</div>
 					{/key}
 				</div>

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -601,6 +601,14 @@
 		color: var(--text-secondary);
 	}
 
+	// Weapons render the awakening icon at the top-left of the frame, which
+	// collides with the bookmark overlay's default top-anchored position.
+	// Pull the bookmark up so it sits above the awakening icon. Awakening's
+	// own positioning is unchanged.
+	.frame.weapon :global(.bookmark-overlay) {
+		margin-top: calc(spacing.$unit-2x * -1);
+	}
+
 	.name-text {
 		min-width: 0;
 		text-align: center;

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -8,6 +8,7 @@
 	import MenuItems from '$lib/components/ui/menu/MenuItems.svelte'
 	import RemoveUnitDialog from './RemoveUnitDialog.svelte'
 	import SubstituteCountBadge from './SubstituteCountBadge.svelte'
+	import BookmarkOverlay from './BookmarkOverlay.svelte'
 	import Tooltip from '$lib/components/ui/Tooltip.svelte'
 	import UncapIndicator from '$lib/components/uncap/UncapIndicator.svelte'
 	import { getWeaponImage } from '$lib/features/database/detail/image'
@@ -238,7 +239,7 @@
 	class:orphaned={item?.orphaned}
 >
 	{#if item}
-		<UnitMenuContainer showGearButton={true}>
+		<UnitMenuContainer showGearButton={true} gearPosition="top-right">
 			{#snippet trigger()}
 				<div
 					class="focus-ring-wrapper {elementClass}"
@@ -301,6 +302,9 @@
 								src={imageUrl}
 								onerror={(e) => handleImageFallback(e, fallbackUrl)}
 							/>
+							{#if inCollection}
+								<BookmarkOverlay />
+							{/if}
 						</div>
 					{/key}
 				</div>
@@ -411,7 +415,6 @@
 		/>
 	{/if}
 	<div class="name" class:not-in-collection={notInCollection}>
-		{#if item && inCollection}<Icon name="bookmark" width={12} height={16} />{/if}
 		<span class="name-text">{item ? localizedName(item?.weapon?.name) : ''}</span>
 		{#if item}
 			<SubstituteCountBadge

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -590,14 +590,13 @@
 	}
 
 	.name {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: center;
+		gap: spacing.$unit-fourth;
 		font-size: typography.$font-small;
-		text-align: center;
 		color: var(--text-secondary);
-
-		:global(span) {
-			display: inline;
-			vertical-align: -4px;
-		}
 	}
 
 	.modifiers {

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -412,7 +412,7 @@
 	{/if}
 	<div class="name" class:not-in-collection={notInCollection}>
 		{#if item && inCollection}<Icon name="bookmark" width={12} height={16} />{/if}
-		{item ? localizedName(item?.weapon?.name) : ''}
+		<span class="name-text">{item ? localizedName(item?.weapon?.name) : ''}</span>
 		{#if item}
 			<SubstituteCountBadge
 				count={item.substitutions?.length ?? 0}
@@ -591,12 +591,17 @@
 
 	.name {
 		display: flex;
-		flex-wrap: wrap;
 		align-items: center;
 		justify-content: center;
 		gap: spacing.$unit-half;
 		font-size: typography.$font-small;
 		color: var(--text-secondary);
+	}
+
+	.name-text {
+		min-width: 0;
+		text-align: center;
+		overflow-wrap: anywhere;
 	}
 
 	.modifiers {

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -301,7 +301,6 @@
 								src={imageUrl}
 								onerror={(e) => handleImageFallback(e, fallbackUrl)}
 							/>
-							<SubstituteCountBadge count={item?.substitutions?.length ?? 0} />
 						</div>
 					{/key}
 				</div>
@@ -414,6 +413,9 @@
 	<div class="name" class:not-in-collection={notInCollection}>
 		{#if item && inCollection}<Icon name="bookmark" width={12} height={16} />{/if}
 		{item ? localizedName(item?.weapon?.name) : ''}
+		{#if item}
+			<SubstituteCountBadge count={item.substitutions?.length ?? 0} />
+		{/if}
 	</div>
 </div>
 

--- a/src/lib/features/details/openDetailsSidebar.svelte.ts
+++ b/src/lib/features/details/openDetailsSidebar.svelte.ts
@@ -8,7 +8,7 @@ import EditWeaponPane from '$lib/components/sidebar/EditWeaponPane.svelte'
 import EditCharacterPane from '$lib/components/sidebar/EditCharacterPane.svelte'
 import EditSummonPane from '$lib/components/sidebar/EditSummonPane.svelte'
 import type { GridCharacter, GridWeapon, GridSummon } from '$lib/types/api/party'
-import { canWeaponBeModified, canCharacterBeModified } from '$lib/utils/modificationDetector'
+import { canCharacterBeModified } from '$lib/utils/modificationDetector'
 import * as m from '$lib/paraglide/messages'
 
 interface DetailsSidebarOptions {
@@ -62,8 +62,10 @@ export function openDetailsSidebar(options: DetailsSidebarOptions) {
 		itemName = getName(summon)
 	}
 
-	// Check if this item can be edited
-	const canEditWeapon = type === 'weapon' && canWeaponBeModified(item as GridWeapon)
+	// Owners can always edit notes (substitutes + description) on any weapon
+	// or character, regardless of whether the item has stat-modifiable fields.
+	// The edit pane itself decides whether to surface the Stats tab.
+	const canEditWeapon = type === 'weapon' && !!(item as GridWeapon).id
 	const canEditCharacter = type === 'character' && canCharacterBeModified(item as GridCharacter)
 	const canEdit = canEditWeapon || canEditCharacter
 
@@ -123,7 +125,10 @@ export function openDetailsSidebar(options: DetailsSidebarOptions) {
 	if (isOwner) {
 		const overflow: OverflowMenuItem[] = []
 		if (onReplace) {
-			overflow.push({ label: m.context_edit({ type: typeLabel }), handler: onReplace })
+			// The "replace" handler swaps the slot to a different item — label it
+			// honestly so it doesn't get confused with the primary Edit action
+			// (which opens the stat/notes edit pane).
+			overflow.push({ label: m.context_replace({ type: typeLabel }), handler: onReplace })
 		}
 		if (onRemove) {
 			overflow.push({


### PR DESCRIPTION
## Summary

A pile of small UI fixes to grid units (substitute counts, bookmark overlay, name row alignment, perpetuity placement) plus three character-edit bug fixes that were tangled into the same branch as #857.

### Unit chrome
- New \`SubstituteCountBadge\` next to the name on every unit (Character / Weapon / Summon), element-tinted via the same palette as CharacterTag. Hidden when the slot has no substitutes.
- Subaura summons (positions 4–5) and extra weapons (9–11) now receive in-collection state from their grid wrappers, so their bookmarks render correctly.
- New \`BookmarkOverlay\` — circular badge over the top-left of the image, element-tinted background with backdrop blur and a soft border. Replaces the inline bookmark icon next to the name. Weapon's awakening icon sits in the same area so the badge gets a small per-unit margin nudge.
- Gear (settings) button moves to the top-right of the image; perpetuity ring nudged in 44px so they don't overlap.
- Name row converted to flex (\`align-items / justify-content / gap\` rules were inert without \`display: flex\`); long names wrap inside their own flex slot via \`min-width: 0\` so the bookmark/icon doesn't get bumped to its own line.
- Description copy on empty Mastery/Roles/Notes/Substitutes placeholders (the team-owner read-only sidebar): title-cased labels and a one-line description above each Add button.

### Edit pane fixes
- Character edit: don't save the four placeholder rings the form seeds when the user hasn't actually picked anything (was writing \`{modifier:1, strength:0}\` into \`ring1\` and friends, then the new out-of-sync check flagged it).
- Character edit: send awakening as the nested \`{ id, level }\` payload the controller permits (was sending top-level \`awakeningId\`/\`awakeningLevel\` which strong params silently stripped — saving Awakening level did nothing).
- Awakening level field: replace the number input with the existing ui/Slider so the range is draggable; level shows in the row label ("Level 5").
- Weapons: rename the overflow "Edit weapon" item to "Replace weapon" (it always swapped the slot — the label was lying). Non-modifiable weapons (no awakening/befoulment/AX/keys) now get the Edit pane too — it auto-falls back to a notes-only view so substitutes and description are still editable.

## Test plan
- [x] \`pnpm check\` — 0 errors
- [x] \`pnpm test\` — 1587 / 1587 pass
- [ ] Manual: drop a duplicate weapon into a party — count badge updates; bookmark renders correctly on subaura / extra slots.
- [ ] Manual: edit a character's awakening level via the slider, save, reopen — level persists (previously got dropped).
- [ ] Manual: open a non-modifiable weapon (no awakening/AX/keys) — Edit goes to the notes-only pane; overflow says "Replace weapon".