### PR TITLE
drop tier.color from difficulty tier

### DIFF
--- a/src/lib/components/explore/ExploreFilters.svelte
+++ b/src/lib/components/explore/ExploreFilters.svelte
@@ -82,8 +82,7 @@
 	const difficultyOptions = $derived(
 		(difficultyTiersQuery.data ?? []).map((tier) => ({
 			value: tier.slug,
-			label: tier.name,
-			color: tier.color
+			label: tier.name
 		}))
 	)
 
@@ -99,7 +98,7 @@
 			const tier = tiers.find((t) => t.slug === f.value)
 			if (!tier) return f
 			changed = true
-			return { ...f, label: tier.name, color: tier.color }
+			return { ...f, label: tier.name }
 		})
 		if (changed) {
 			filters = next
@@ -375,12 +374,10 @@
 		} else if (option.kind === 'class') {
 			newFilter = { kind: 'class', value: option.value as string, label: option.label }
 		} else if (option.kind === 'difficulty') {
-			const tier = difficultyOptions.find((t: { value: string }) => t.value === option.value)
 			newFilter = {
 				kind: 'difficulty',
 				value: option.value as string,
-				label: option.label,
-				color: tier?.color
+				label: option.label
 			}
 		} else {
 			newFilter = { kind: 'party', value: option.value as string, label: option.label }

--- a/src/lib/components/party/info/DescriptionTile.svelte
+++ b/src/lib/components/party/info/DescriptionTile.svelte
@@ -435,7 +435,6 @@
 					{#if isEditor && difficultyPreviewHref}
 						<a
 							class="token difficulty editor-link"
-							style:background={difficulty.tier.color || undefined}
 							href={difficultyPreviewHref}
 							target="_blank"
 							rel="noopener"
@@ -443,7 +442,7 @@
 							{difficulty.tier.name}
 						</a>
 					{:else}
-						<span class="token difficulty" style:background={difficulty.tier.color || undefined}>
+						<span class="token difficulty">
 							{difficulty.tier.name}
 						</span>
 					{/if}

--- a/src/lib/features/database/difficulties/PreviewPanel.svelte
+++ b/src/lib/features/database/difficulties/PreviewPanel.svelte
@@ -114,8 +114,6 @@
 		{:else}
 			<div class="result-summary">
 				<div class="result-headline">
-					<span class="tier-swatch" style:background={result.tier?.color || 'var(--input-bg)'}
-					></span>
 					<div class="result-text">
 						<span class="result-tier">{result.tier?.name ?? 'Unassigned'}</span>
 						<span class="result-score">{result.score?.toFixed(2) ?? '—'} / 100</span>
@@ -226,13 +224,6 @@
 		display: flex;
 		align-items: center;
 		gap: spacing.$unit;
-	}
-
-	.tier-swatch {
-		width: spacing.$unit-4x;
-		height: spacing.$unit-4x;
-		border-radius: 50%;
-		border: 1px solid var(--border-subtle);
 	}
 
 	.result-text {

--- a/src/lib/features/database/difficulties/TierModal.svelte
+++ b/src/lib/features/database/difficulties/TierModal.svelte
@@ -34,7 +34,6 @@
 	// Form state
 	let name = $state('')
 	let slug = $state('')
-	let color = $state('#86C5A8')
 	let description = $state('')
 	let minScore = $state<number>(0)
 	let maxScore = $state<number>(100)
@@ -68,7 +67,6 @@
 			if (tier) {
 				name = tier.name ?? ''
 				slug = tier.slug ?? ''
-				color = tier.color ?? '#86C5A8'
 				description = tier.description ?? ''
 				minScore = tier.minScore ?? 0
 				maxScore = tier.maxScore ?? 100
@@ -76,7 +74,6 @@
 			} else {
 				name = ''
 				slug = ''
-				color = '#86C5A8'
 				description = ''
 				minScore = 0
 				maxScore = 100
@@ -118,7 +115,6 @@
 	const formInput = $derived({
 		name,
 		slug,
-		color,
 		description,
 		minScore,
 		maxScore,
@@ -218,12 +214,6 @@
 			placeholder="endgame"
 			width="280px"
 		/>
-		<DetailItem label="Color" editable={true}>
-			<div class="color-control">
-				<input type="color" bind:value={color} aria-label="Tier color" class="color-input" />
-				<span class="color-value">{color}</span>
-			</div>
-		</DetailItem>
 		<DetailItem
 			label="Icon"
 			sublabel="Optional. PNG, 128×128 or smaller, 256KB max. Shown next to the tier name."
@@ -338,37 +328,6 @@
 		font-size: typography.$font-regular;
 		font-weight: typography.$bold;
 		color: var(--text-secondary);
-	}
-
-	.color-control {
-		display: flex;
-		align-items: center;
-		gap: spacing.$unit;
-	}
-
-	.color-input {
-		width: 42px;
-		height: 32px;
-		padding: 0;
-		border: 1px solid var(--border-subtle);
-		border-radius: layout.$item-corner-small;
-		background: transparent;
-		cursor: pointer;
-
-		&::-webkit-color-swatch-wrapper {
-			padding: 2px;
-		}
-
-		&::-webkit-color-swatch {
-			border-radius: 3px;
-			border: none;
-		}
-	}
-
-	.color-value {
-		font-size: typography.$font-small;
-		color: var(--text-secondary);
-		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 	}
 
 	.description-input {

--- a/src/lib/features/database/difficulties/__tests__/tier-form.test.ts
+++ b/src/lib/features/database/difficulties/__tests__/tier-form.test.ts
@@ -4,7 +4,6 @@ import { buildTierPayload, validateTierForm, type TierFormInput } from '../tier-
 const baseInput: TierFormInput = {
 	name: 'Endgame',
 	slug: 'endgame',
-	color: '#86C5A8',
 	description: '',
 	minScore: 80,
 	maxScore: 100,
@@ -83,11 +82,6 @@ describe('buildTierPayload', () => {
 	it('keeps a populated description (trimmed)', () => {
 		const payload = buildTierPayload({ ...baseInput, description: '  endgame parties  ' })
 		expect(payload.description).toBe('endgame parties')
-	})
-
-	it('forwards color verbatim (no normalization)', () => {
-		const payload = buildTierPayload({ ...baseInput, color: '#1A1A3A' })
-		expect(payload.color).toBe('#1A1A3A')
 	})
 
 	it('omits imageKey by default', () => {

--- a/src/lib/features/database/difficulties/tier-form.ts
+++ b/src/lib/features/database/difficulties/tier-form.ts
@@ -7,7 +7,6 @@ import type { DifficultyTier } from '$lib/types/api/party'
 export interface TierFormInput {
 	name: string
 	slug: string
-	color: string
 	description: string
 	minScore: number
 	maxScore: number
@@ -63,7 +62,6 @@ export function buildTierPayload(
 	const payload: Partial<DifficultyTier> = {
 		name: input.name.trim(),
 		slug: input.slug.trim(),
-		color: input.color,
 		description: input.description.trim() || undefined,
 		minScore: input.minScore,
 		maxScore: input.maxScore,

--- a/src/lib/types/api/party.ts
+++ b/src/lib/types/api/party.ts
@@ -200,7 +200,6 @@ export interface DifficultyTier {
 	id: string
 	slug: string
 	name: string
-	color?: string
 	sortOrder: number
 	description?: string
 	minScore?: number

--- a/src/lib/types/filter.ts
+++ b/src/lib/types/filter.ts
@@ -18,7 +18,7 @@ export type FilterItem =
 	| { kind: 'party'; value: string; label: string; pinned?: boolean }
 	| { kind: 'boost'; value: string; label: string; pinned?: boolean }
 	| { kind: 'side'; value: string; label: string; pinned?: boolean }
-	| { kind: 'difficulty'; value: string; label: string; color?: string; pinned?: boolean }
+	| { kind: 'difficulty'; value: string; label: string; pinned?: boolean }
 
 export interface FilterOption {
 	kind: FilterItem['kind']

--- a/src/lib/utils/__tests__/filterMatching.test.ts
+++ b/src/lib/utils/__tests__/filterMatching.test.ts
@@ -8,7 +8,7 @@ function call(overrides: {
 	query: string
 	filters?: FilterItem[]
 	excludedKinds?: FilterItem['kind'][]
-	difficultyOptions?: { value: string; label: string; color?: string }[]
+	difficultyOptions?: { value: string; label: string }[]
 	categoryDifficultyLabel?: string
 }): FilterOption[] {
 	return matchLocal({
@@ -36,9 +36,9 @@ function call(overrides: {
 
 describe('matchLocal — difficulty', () => {
 	const difficultyOptions = [
-		{ value: 'casual', label: 'Casual', color: '#86C5A8' },
-		{ value: 'mid', label: 'Mid', color: '#D4AF37' },
-		{ value: 'endgame', label: 'Endgame', color: '#1a1a3a' }
+		{ value: 'casual', label: 'Casual' },
+		{ value: 'mid', label: 'Mid' },
+		{ value: 'endgame', label: 'Endgame' }
 	]
 
 	it('matches a tier by case-insensitive label substring', () => {
@@ -104,13 +104,6 @@ describe('matchLocal — difficulty', () => {
 		const results = call({ query: 'casual', difficultyOptions, excludedKinds: ['difficulty'] })
 
 		expect(results.find((r) => r.kind === 'difficulty')).toBeUndefined()
-	})
-
-	it('does not stringify or transform the tier color into the option (color stays on the source list)', () => {
-		const results = call({ query: 'cas', difficultyOptions })
-		const opt = results.find((r) => r.kind === 'difficulty')!
-		// FilterOption doesn't carry the color; ExploreFilters reads it from difficultyOptions at selection time.
-		expect((opt as unknown as Record<string, unknown>).color).toBeUndefined()
 	})
 })
 

--- a/src/lib/utils/filterMatching.ts
+++ b/src/lib/utils/filterMatching.ts
@@ -17,7 +17,7 @@ interface MatchLocalParams {
 	partyOptions: { value: string; label: string }[]
 	boostOptions: OptionWithAliases[]
 	sideOptions: { value: string; label: string }[]
-	difficultyOptions?: { value: string; label: string; color?: string }[]
+	difficultyOptions?: { value: string; label: string }[]
 	allRaids: RaidFull[]
 	categoryLabels: {
 		element: string


### PR DESCRIPTION
## Summary
- Stops applying `tier.color` as the difficulty chip background in `DescriptionTile`; the chip now uses the theme's neutral button-bg + secondary-text, which has proper contrast in both light and dark mode.
- Removes `color` from the `DifficultyTier` type, the tier admin form (`TierModal`/`tier-form`), the explore filter pipeline, and the preview panel swatch — color is being phased out, so the frontend stops reading/writing it everywhere.
- Test fixtures and one obsolete "color doesn't leak" test updated.

## Test plan
- [ ] Open a party with a difficulty tier — chip is legible on both themes
- [ ] Difficulty admin modal renders without the color picker; create/edit/delete still works
- [ ] Explore difficulty filters and URL round-trip still work
- [ ] `pnpm check` clean, `tier-form` + `filterMatching` tests pass