### PR TITLE
details sidebar: notes/subs tab, stats UncapIndicators, list markers

### DIFF
--- a/src/lib/components/collection/CollectionCharacterPane.svelte
+++ b/src/lib/components/collection/CollectionCharacterPane.svelte
@@ -346,6 +346,7 @@
 			<div class="info-view">
 				<BasicInfoSection type="character" itemData={characterData} />
 				<StatsSection
+					type="character"
 					itemData={characterData}
 					gridUncapLevel={character.uncapLevel}
 					gridTranscendence={character.transcendenceStep}

--- a/src/lib/components/collection/CollectionSummonPane.svelte
+++ b/src/lib/components/collection/CollectionSummonPane.svelte
@@ -220,6 +220,7 @@
 			<div class="info-view">
 				<BasicInfoSection type="summon" itemData={summonData} />
 				<StatsSection
+					type="summon"
 					itemData={summonData}
 					gridUncapLevel={summon.uncapLevel}
 					gridTranscendence={summon.transcendenceStep}

--- a/src/lib/components/collection/CollectionWeaponPane.svelte
+++ b/src/lib/components/collection/CollectionWeaponPane.svelte
@@ -307,6 +307,7 @@
 			<div class="info-view">
 				<BasicInfoSection type="weapon" itemData={weaponData} />
 				<StatsSection
+					type="weapon"
 					itemData={weaponData}
 					gridUncapLevel={weapon.uncapLevel}
 					gridTranscendence={weapon.transcendenceStep}

--- a/src/lib/components/sidebar/DescriptionPane.svelte
+++ b/src/lib/components/sidebar/DescriptionPane.svelte
@@ -97,6 +97,19 @@
 		flex-direction: column;
 		height: 100%;
 		color: var(--text-primary);
+
+		// Restore native list markers inside user-generated description content.
+		// The global reset in app.scss strips them for our own UI lists, but
+		// user-authored rich text should render real bullets and numbers.
+		:global(ul) {
+			list-style: disc;
+			padding-inline-start: $unit-3x;
+		}
+
+		:global(ol) {
+			list-style: decimal;
+			padding-inline-start: $unit-3x;
+		}
 	}
 
 	.video-embed {

--- a/src/lib/components/sidebar/DetailsSidebar.svelte
+++ b/src/lib/components/sidebar/DetailsSidebar.svelte
@@ -77,8 +77,9 @@
 
 	// Default-tab rules per type:
 	// - Weapon: Team only when there's substantive team-side content (notes,
-	//   subs, awakening, AX, befoulment, weapon keys, or bullets). Bare
-	//   affordances like an empty key slot or element picker aren't enough.
+	//   subs, awakening, AX, befoulment, weapon keys, bullets, or a picked
+	//   element override). Bare affordances like an empty key slot aren't
+	//   enough.
 	// - Summon: Team only when there are notes or substitutions. Uncap/quick/
 	//   friend flags alone aren't enough to push past the canonical Info view.
 	// - Character: Team whenever there are modifications or notes/subs.
@@ -89,7 +90,8 @@
 					modificationStatus.hasAxSkills ||
 					modificationStatus.hasBefoulment ||
 					modificationStatus.hasWeaponKeys ||
-					modificationStatus.hasBullets
+					modificationStatus.hasBullets ||
+					modificationStatus.hasElement
 			: type === 'summon'
 				? hasNotesOrSubstitutions(item)
 				: modificationStatus.hasModifications || hasNotesOrSubstitutions(item)

--- a/src/lib/components/sidebar/DetailsSidebar.svelte
+++ b/src/lib/components/sidebar/DetailsSidebar.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import type { GridCharacter, GridWeapon, GridSummon } from '$lib/types/api/party'
-	import { detectModifications, canWeaponBeModified } from '$lib/utils/modificationDetector'
+	import {
+		detectModifications,
+		canWeaponBeModified,
+		hasNotesOrSubstitutions
+	} from '$lib/utils/modificationDetector'
 	import { partyStore } from '$lib/stores/partyStore.svelte'
 	import { sidebar } from '$lib/stores/sidebar.svelte'
 	import DetailsSidebarSegmentedControl from './modifications/DetailsSidebarSegmentedControl.svelte'
@@ -57,11 +61,12 @@
 
 	let modificationStatus = $derived(detectModifications(type, item))
 
-	// For weapons, only show segmented control if the weapon can be modified
+	// Show segmented control whenever Team view has something to show: actual
+	// modifications, a modifiable weapon, or party-side notes/substitutions.
 	const showSegmentedControl = $derived(
-		type === 'weapon'
+		(type === 'weapon'
 			? canWeaponBeModified(item as GridWeapon)
-			: modificationStatus.hasModifications
+			: modificationStatus.hasModifications) || hasNotesOrSubstitutions(item)
 	)
 
 	// Track selected view - updated reactively based on modifiability
@@ -70,16 +75,34 @@
 	// Track the item ID to detect when switching to a different item
 	let currentItemId = $state<string | undefined>(undefined)
 
+	// Default-tab rules per type:
+	// - Weapon: Team only when there's substantive team-side content (notes,
+	//   subs, awakening, AX, befoulment, weapon keys, or bullets). Bare
+	//   affordances like an empty key slot or element picker aren't enough.
+	// - Summon: Team only when there are notes or substitutions. Uncap/quick/
+	//   friend flags alone aren't enough to push past the canonical Info view.
+	// - Character: Team whenever there are modifications or notes/subs.
+	const defaultToTeamView = $derived(
+		type === 'weapon'
+			? hasNotesOrSubstitutions(item) ||
+					modificationStatus.hasAwakening ||
+					modificationStatus.hasAxSkills ||
+					modificationStatus.hasBefoulment ||
+					modificationStatus.hasWeaponKeys ||
+					modificationStatus.hasBullets
+			: type === 'summon'
+				? hasNotesOrSubstitutions(item)
+				: modificationStatus.hasModifications || hasNotesOrSubstitutions(item)
+	)
+
 	// Update view when switching to a different item
 	$effect(() => {
 		const itemId = item && 'id' in item ? item.id : undefined
 		if (itemId !== currentItemId) {
 			currentItemId = itemId
-			if (!showSegmentedControl) {
-				// Force canonical view for non-modifiable items
+			if (!showSegmentedControl || !defaultToTeamView) {
 				selectedView = 'canonical'
 			} else {
-				// Default to user view for modifiable items
 				selectedView = 'user'
 			}
 		}
@@ -358,7 +381,7 @@
 	{#if selectedView === 'canonical'}
 		<div class="canonical-view">
 			<BasicInfoSection {type} {itemData} />
-			<StatsSection {itemData} {gridUncapLevel} {gridTranscendence} />
+			<StatsSection {type} {itemData} {gridUncapLevel} {gridTranscendence} />
 			<SkillsSection {type} {itemData} />
 		</div>
 	{:else}

--- a/src/lib/components/sidebar/details/DetailRow.svelte
+++ b/src/lib/components/sidebar/details/DetailRow.svelte
@@ -2,9 +2,11 @@
 	import type { Snippet } from 'svelte'
 
 	interface Props {
-		label: string
+		label?: string
 		value?: string | number | null | undefined
 		children?: Snippet
+		/** Custom label content (e.g. an icon or indicator). Takes precedence over `label`. */
+		labelSlot?: Snippet
 		/** Remove padding for inline edit contexts */
 		noPadding?: boolean
 		/** Remove min-width from value (for compact controls like switches) */
@@ -17,6 +19,7 @@
 		label,
 		value,
 		children,
+		labelSlot,
 		noPadding = false,
 		compact = false,
 		error = undefined
@@ -25,7 +28,13 @@
 
 <div class="detail-row-wrapper">
 	<div class="detail-row" class:no-padding={noPadding} class:compact class:has-control={children}>
-		<span class="label">{label}</span>
+		<span class="label">
+			{#if labelSlot}
+				{@render labelSlot()}
+			{:else}
+				{label}
+			{/if}
+		</span>
 		<span class="value">
 			{#if children}
 				{@render children()}

--- a/src/lib/components/sidebar/details/StatsSection.svelte
+++ b/src/lib/components/sidebar/details/StatsSection.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import DetailsSection from './DetailsSection.svelte'
 	import DetailRow from './DetailRow.svelte'
+	import UncapIndicator from '$lib/components/uncap/UncapIndicator.svelte'
+	import Tooltip from '$lib/components/ui/Tooltip.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	interface Props {
+		type: 'character' | 'weapon' | 'summon'
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic entity data from API
 		itemData: any
 		gridUncapLevel: number | null
@@ -11,37 +14,113 @@
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	let { itemData, gridUncapLevel, gridTranscendence }: Props = $props()
+	let { type, itemData, gridUncapLevel, gridTranscendence }: Props = $props()
+
+	// Indicator capability flags. For characters the data model overloads
+	// `uncap.transcendence`: regular characters use it for transcendence (purple
+	// star + fragments), while special characters use it to mean ULB (a second
+	// blue star, no transcendence indicator).
+	const special = $derived(type === 'character' && !!itemData?.special)
+	const flb = $derived(!!itemData?.uncap?.flb)
+	const hasTranscendence = $derived(!!itemData?.uncap?.transcendence)
+	const hasUlb = $derived(
+		type === 'character'
+			? special
+				? hasTranscendence // special chars: ULB lives on the transcendence flag
+				: false // regular chars don't have a ULB tier
+			: !!itemData?.uncap?.ulb
+	)
+	// UncapIndicator's `ulb` prop doubles as "transcendence capability" for
+	// regular characters. Mirror what CharacterUncapSection.svelte does.
+	const ulbProp = $derived(type === 'character' ? (special ? hasUlb : hasTranscendence) : hasUlb)
+	const transcendenceProp = $derived(special ? false : hasTranscendence)
+
+	// MLB level differs between special (3*) and regular characters (4*).
+	const mlbLevel = $derived(type === 'character' && !special ? 4 : 3)
+	const flbLevel = $derived(mlbLevel + 1)
+	const ulbLevel = $derived(flbLevel + 1)
+
+	// Transcendence row shows full uncap + transcendence stage filled to 5.
+	const transcendenceLevel = $derived(type === 'character' && !special ? 6 : 6)
+
+	// Stat value for the transcendence row. Characters store it on the stat
+	// block; weapons/summons store it at the top level.
+	const hpTranscendenceValue = $derived(
+		type === 'character' ? itemData?.hp?.maxHpTranscendence : itemData?.transcendenceHp
+	)
+	const atkTranscendenceValue = $derived(
+		type === 'character' ? itemData?.atk?.maxAtkTranscendence : itemData?.transcendenceAtk
+	)
+
+	const showFlbRow = $derived(flb && (type === 'character' ? !!itemData?.hp?.maxHpFlb : true))
+	const showUlbRow = $derived(hasUlb)
+	// Show the transcendence row whenever the item can be transcended — the
+	// Info view advertises max-tier stats, not the grid's current uncap.
+	const showTranscendenceRow = $derived(transcendenceProp)
 </script>
+
+{#snippet indicator(label: string, uncapLevel: number, transcendenceStage = 0)}
+	<Tooltip content={label}>
+		<UncapIndicator
+			{type}
+			{uncapLevel}
+			{transcendenceStage}
+			{flb}
+			ulb={ulbProp}
+			transcendence={transcendenceProp}
+			{special}
+		/>
+	</Tooltip>
+{/snippet}
 
 {#if itemData?.hp}
 	<DetailsSection title={m.details_hp()}>
-		<DetailRow label={m.details_base()} value={itemData.hp.minHp} />
-		<DetailRow label={m.details_mlb()} value={itemData.hp.maxHp} />
-		{#if itemData.uncap?.flb && itemData.hp.maxHpFlb}
-			<DetailRow label={m.details_flb()} value={itemData.hp.maxHpFlb} />
+		<DetailRow value={itemData.hp.minHp}>
+			{#snippet labelSlot()}{@render indicator(m.details_base(), 0)}{/snippet}
+		</DetailRow>
+		<DetailRow value={itemData.hp.maxHp}>
+			{#snippet labelSlot()}{@render indicator(m.details_mlb(), mlbLevel)}{/snippet}
+		</DetailRow>
+		{#if showFlbRow && itemData.hp.maxHpFlb}
+			<DetailRow value={itemData.hp.maxHpFlb}>
+				{#snippet labelSlot()}{@render indicator(m.details_flb(), flbLevel)}{/snippet}
+			</DetailRow>
 		{/if}
-		{#if itemData.uncap?.ulb && itemData.hp.maxHpUlb}
-			<DetailRow label={m.details_ulb()} value={itemData.hp.maxHpUlb} />
+		{#if showUlbRow && itemData.hp.maxHpUlb}
+			<DetailRow value={itemData.hp.maxHpUlb}>
+				{#snippet labelSlot()}{@render indicator(m.details_ulb(), ulbLevel)}{/snippet}
+			</DetailRow>
 		{/if}
-		{#if gridTranscendence && gridTranscendence > 0}
-			<DetailRow label={m.details_t5()} value={itemData.hp.maxHpXlb} />
+		{#if showTranscendenceRow && hpTranscendenceValue}
+			<DetailRow value={hpTranscendenceValue}>
+				{#snippet labelSlot()}{@render indicator(m.details_t5(), transcendenceLevel, 5)}{/snippet}
+			</DetailRow>
 		{/if}
 	</DetailsSection>
 {/if}
 
 {#if itemData?.atk}
 	<DetailsSection title={m.details_atk()}>
-		<DetailRow label={m.details_base()} value={itemData.atk.minAtk} />
-		<DetailRow label={m.details_mlb()} value={itemData.atk.maxAtk} />
-		{#if itemData.uncap?.flb && itemData.atk.maxAtkFlb}
-			<DetailRow label={m.details_flb()} value={itemData.atk.maxAtkFlb} />
+		<DetailRow value={itemData.atk.minAtk}>
+			{#snippet labelSlot()}{@render indicator(m.details_base(), 0)}{/snippet}
+		</DetailRow>
+		<DetailRow value={itemData.atk.maxAtk}>
+			{#snippet labelSlot()}{@render indicator(m.details_mlb(), mlbLevel)}{/snippet}
+		</DetailRow>
+		{#if showFlbRow && itemData.atk.maxAtkFlb}
+			<DetailRow value={itemData.atk.maxAtkFlb}>
+				{#snippet labelSlot()}{@render indicator(m.details_flb(), flbLevel)}{/snippet}
+			</DetailRow>
 		{/if}
-		{#if itemData.uncap?.ulb && itemData.atk.maxAtkUlb}
-			<DetailRow label={m.details_ulb()} value={itemData.atk.maxAtkUlb} />
+		{#if showUlbRow && itemData.atk.maxAtkUlb}
+			<DetailRow value={itemData.atk.maxAtkUlb}>
+				{#snippet labelSlot()}{@render indicator(m.details_ulb(), ulbLevel)}{/snippet}
+			</DetailRow>
 		{/if}
-		{#if gridTranscendence && gridTranscendence > 0}
-			<DetailRow label={m.details_t5()} value={itemData.atk.maxAtkXlb} />
+		{#if showTranscendenceRow && atkTranscendenceValue}
+			<DetailRow value={atkTranscendenceValue}>
+				{#snippet labelSlot()}{@render indicator(m.details_t5(), transcendenceLevel, 5)}{/snippet}
+			</DetailRow>
 		{/if}
 	</DetailsSection>
 {/if}

--- a/src/lib/components/sidebar/details/StatsSection.svelte
+++ b/src/lib/components/sidebar/details/StatsSection.svelte
@@ -41,7 +41,7 @@
 	const ulbLevel = $derived(flbLevel + 1)
 
 	// Transcendence row shows full uncap + transcendence stage filled to 5.
-	const transcendenceLevel = $derived(type === 'character' && !special ? 6 : 6)
+	const transcendenceLevel = 6
 
 	// Stat value for the transcendence row. Characters store it on the stat
 	// block; weapons/summons store it at the top level.

--- a/src/lib/utils/__tests__/modificationDetector.test.ts
+++ b/src/lib/utils/__tests__/modificationDetector.test.ts
@@ -3,9 +3,10 @@ import {
 	detectModifications,
 	hasAnyModification,
 	canWeaponBeModified,
-	canCharacterBeModified
+	canCharacterBeModified,
+	hasNotesOrSubstitutions
 } from '../modificationDetector'
-import type { GridCharacter, GridWeapon, GridSummon } from '$lib/types/api/party'
+import type { GridCharacter, GridWeapon, GridSummon, Substitution } from '$lib/types/api/party'
 import type { Awakening, WeaponKey } from '$lib/types/api/entities'
 import type { AugmentSkill, Befoulment } from '$lib/types/api/weaponStatModifier'
 
@@ -342,5 +343,70 @@ describe('canCharacterBeModified', () => {
 		const char = makeGridCharacter()
 		char.character.maxAwakeningLevel = 3
 		expect(canCharacterBeModified(char)).toBe(true)
+	})
+})
+
+// ============================================================================
+// hasNotesOrSubstitutions
+// ============================================================================
+
+describe('hasNotesOrSubstitutions', () => {
+	it('returns false for undefined', () => {
+		expect(hasNotesOrSubstitutions(undefined)).toBe(false)
+	})
+
+	it('returns false when item has no description and no substitutions', () => {
+		expect(hasNotesOrSubstitutions(makeGridWeapon())).toBe(false)
+	})
+
+	it('returns false for a null description', () => {
+		const weapon = makeGridWeapon({ description: null } as unknown as Partial<GridWeapon>)
+		expect(hasNotesOrSubstitutions(weapon)).toBe(false)
+	})
+
+	it('returns false for a description with no content array', () => {
+		const weapon = makeGridWeapon({ description: { type: 'doc' } } as Partial<GridWeapon>)
+		expect(hasNotesOrSubstitutions(weapon)).toBe(false)
+	})
+
+	it('returns false for a description containing only an empty paragraph', () => {
+		const weapon = makeGridWeapon({
+			description: { type: 'doc', content: [{ type: 'paragraph' }] }
+		} as Partial<GridWeapon>)
+		expect(hasNotesOrSubstitutions(weapon)).toBe(false)
+	})
+
+	it('returns true for a description with real text content', () => {
+		const weapon = makeGridWeapon({
+			description: {
+				type: 'doc',
+				content: [{ type: 'paragraph', content: [{ type: 'text', text: 'note' }] }]
+			}
+		} as Partial<GridWeapon>)
+		expect(hasNotesOrSubstitutions(weapon)).toBe(true)
+	})
+
+	it('returns true when substitutions are present', () => {
+		const weapon = makeGridWeapon({
+			substitutions: [{ id: 'sub-1', position: 0 } as Substitution]
+		})
+		expect(hasNotesOrSubstitutions(weapon)).toBe(true)
+	})
+
+	it('returns true for a character with substitutions', () => {
+		const char = makeGridCharacter({
+			substitutions: [{ id: 'sub-1', position: 0 } as Substitution]
+		} as Partial<GridCharacter>)
+		expect(hasNotesOrSubstitutions(char)).toBe(true)
+	})
+
+	it('returns true for a summon with a non-empty description', () => {
+		const summon = makeGridSummon({
+			description: {
+				type: 'doc',
+				content: [{ type: 'paragraph', content: [{ type: 'text', text: 'note' }] }]
+			}
+		} as Partial<GridSummon>)
+		expect(hasNotesOrSubstitutions(summon)).toBe(true)
 	})
 })

--- a/src/lib/utils/modificationDetector.ts
+++ b/src/lib/utils/modificationDetector.ts
@@ -1,4 +1,10 @@
-import type { GridCharacter, GridWeapon, GridSummon } from '$lib/types/api/party'
+import type {
+	GridCharacter,
+	GridWeapon,
+	GridSummon,
+	Description,
+	Substitution
+} from '$lib/types/api/party'
 import { seriesHasWeaponKeys } from '$lib/utils/weaponSeries'
 
 export interface ModificationStatus {
@@ -155,4 +161,32 @@ export function canCharacterBeModified(gridCharacter: GridCharacter | undefined)
 	const canHavePerpetuity = gridCharacter.position > 0
 
 	return hasAwakening || canHaveRings || canHaveEarring || canHavePerpetuity
+}
+
+// Mirrors the empty-description check in NotesReadOnlySection so a structurally
+// empty TipTap doc (no content, or a single empty paragraph) doesn't count.
+function descriptionHasContent(description: Description | null | undefined): boolean {
+	if (description == null) return false
+	const content = (description as { content?: unknown[] }).content
+	if (!Array.isArray(content) || content.length === 0) return false
+	if (content.length === 1) {
+		const para = content[0] as { type?: string; content?: unknown[] }
+		if (para?.type === 'paragraph' && (!para.content || para.content.length === 0)) return false
+	}
+	return true
+}
+
+/**
+ * True if the grid item has party-side notes (a non-empty description) or one
+ * or more substitutions. These are independent of whether the item itself can
+ * be modified, so they're a separate reason to surface the Team view.
+ */
+export function hasNotesOrSubstitutions(
+	item: GridCharacter | GridWeapon | GridSummon | undefined
+): boolean {
+	if (!item) return false
+	const description = (item as { description?: Description | null }).description
+	if (descriptionHasContent(description)) return true
+	const substitutions = (item as { substitutions?: Substitution[] }).substitutions
+	return Array.isArray(substitutions) && substitutions.length > 0
 }


### PR DESCRIPTION
- Segmented control now shows whenever a weapon has notes or substitutes, not just when it has modifiable properties. Default-tab rules tightened per type: weapons go to Team only with notes/subs/awakening/AX/befoulment/keys/bullets; summons only with notes/subs; characters as before.
- Stats rows replace the Base/MLB/FLB/ULB/XLB text labels with a tooltipped UncapIndicator filled to the matching uncap level. Fixes the transcendence stat lookup and surfaces the XLB row based on item capability, not grid state.
- Restores native list markers inside DescriptionPane so user-authored bullet and numbered lists render with real bullets, overriding the global ul reset.