### PR TITLE
summon unit: nudge quick-summon icon to right: 28%

### DIFF
--- a/src/lib/components/units/SummonUnit.svelte
+++ b/src/lib/components/units/SummonUnit.svelte
@@ -566,7 +566,7 @@
 		position: absolute;
 		z-index: effects.$z-tooltip;
 		top: -2%;
-		right: 22%;
+		right: 28%;
 		width: spacing.$unit-5x;
 		height: spacing.$unit-5x;
 		padding: 0;
@@ -584,7 +584,6 @@
 		}
 
 		&.main {
-			right: 28%;
 			width: spacing.$unit-6x;
 			height: spacing.$unit-6x;
 		}


### PR DESCRIPTION
Moves the grid-size summon's quick-summon icon to right: 28% to match the main slot, and drops the now-redundant .main right override.