### PR TITLE
tag tokens + sidebar polish: image variants, chip sizing, fewer tooltips

### DIFF
--- a/src/lib/components/party/info/DescriptionTile.svelte
+++ b/src/lib/components/party/info/DescriptionTile.svelte
@@ -449,16 +449,12 @@
 				</Tooltip>
 			{/if}
 			{#if solo}
-				<Tooltip content={m.battle_solo()}>
-					<span class="token solo on">{m.battle_solo()}</span>
-				</Tooltip>
+				<span class="token solo on">{m.battle_solo()}</span>
 			{/if}
 			{#each settings as setting (setting.key)}
-				<Tooltip content={setting.tooltip}>
-					<span class="token {setting.key}" class:on={setting.active} class:off={!setting.active}>
-						{setting.label}
-					</span>
-				</Tooltip>
+				<span class="token {setting.key}" class:on={setting.active} class:off={!setting.active}>
+					{setting.label}
+				</span>
 			{/each}
 			{#if formattedClearTime}
 				<Tooltip content={m.party_edit_clear_time()}>

--- a/src/lib/components/sidebar/details/CollectionPill.svelte
+++ b/src/lib/components/sidebar/details/CollectionPill.svelte
@@ -100,10 +100,10 @@
 	.collection-pill {
 		display: inline-flex;
 		align-items: center;
-		gap: spacing.$unit-half;
-		padding: spacing.$unit-half spacing.$unit;
+		gap: spacing.$unit-three-quarter;
+		padding: spacing.$unit-three-quarter calc(spacing.$unit * 1.5);
 		border-radius: 999px;
-		font-size: typography.$font-tiny;
+		font-size: typography.$font-button;
 		font-weight: 500;
 		line-height: 1;
 		backdrop-filter: blur(8px);

--- a/src/lib/components/sidebar/details/ItemHeader.svelte
+++ b/src/lib/components/sidebar/details/ItemHeader.svelte
@@ -5,6 +5,8 @@
 		getWeaponBaseImage,
 		getSummonDetailImage,
 		getCharacterPose,
+		getSummonTransformation,
+		getWeaponTransformation,
 		getBasePath
 	} from '$lib/utils/images'
 	import { getSimplePortraits } from '$lib/stores/simplePortraits.svelte'
@@ -53,9 +55,19 @@
 					)
 			return getCharacterDetailImage(id, pose)
 		} else if (type === 'weapon') {
-			return getWeaponBaseImage(id)
+			const transformation = getWeaponTransformation(
+				!!itemData?.uncap?.transcendence,
+				gridUncapLevel ?? undefined,
+				gridTranscendence ?? undefined
+			)
+			return getWeaponBaseImage(id, transformation)
 		} else {
-			return getSummonDetailImage(id)
+			const transformation = getSummonTransformation(
+				id,
+				gridUncapLevel ?? undefined,
+				gridTranscendence ?? undefined
+			)
+			return getSummonDetailImage(id, transformation)
 		}
 	}
 

--- a/src/lib/components/sidebar/details/LinksSection.svelte
+++ b/src/lib/components/sidebar/details/LinksSection.svelte
@@ -67,10 +67,10 @@
 </script>
 
 {#if links.length > 0}
-	<ul class="link-chips">
+	<ul class="link-tags">
 		{#each links as link (link.key)}
 			<li>
-				<a class="chip" href={link.href} target="_blank" rel="noopener noreferrer">
+				<a class="tag" href={link.href} target="_blank" rel="noopener noreferrer">
 					<span class="icon">
 						{#if link.iconSrc}
 							<img src={link.iconSrc} alt="" />
@@ -90,7 +90,7 @@
 	@use '$src/themes/typography' as typography;
 	@use '$src/themes/layout' as layout;
 
-	.link-chips {
+	.link-tags {
 		display: flex;
 		flex-wrap: wrap;
 		gap: spacing.$unit;
@@ -99,24 +99,21 @@
 		list-style: none;
 	}
 
-	.chip {
+	.tag {
 		display: inline-flex;
 		align-items: center;
 		gap: spacing.$unit-three-quarter;
 		padding: spacing.$unit-three-quarter calc(spacing.$unit * 1.5);
 		border-radius: layout.$full-corner;
-		background: var(--button-bg);
+		background: var(--tag-contained-bg);
 		color: var(--text-primary);
 		font-size: typography.$font-button;
 		font-weight: typography.$medium;
 		text-decoration: none;
-		transition:
-			background 0.15s,
-			transform 0.15s;
+		transition: background 0.15s;
 
 		&:hover {
-			background: var(--button-bg-hover, var(--button-bg));
-			transform: translateY(-1px);
+			background: var(--tag-contained-bg-hover);
 		}
 	}
 

--- a/src/lib/utils/images.ts
+++ b/src/lib/utils/images.ts
@@ -332,9 +332,17 @@ export function handleImageFallback(event: Event, fallbackUrl?: string): void {
 
 /**
  * Get weapon base image (PNG)
+ * @param transformation - Optional transformation suffix ('02' / '03' for transcendence stages)
  */
-export function getWeaponBaseImage(id: string | number | null | undefined): string {
-	return getImageUrl('weapon', id, 'base')
+export function getWeaponBaseImage(
+	id: string | number | null | undefined,
+	transformation?: string
+): string {
+	if (!id) return getPlaceholderImage('weapon', 'base')
+	if (!transformation) return getImageUrl('weapon', id, 'base')
+	const directory = getImageDirectory('weapon', 'base')
+	const extension = getFileExtension('weapon', 'base')
+	return `${getBasePath()}/${directory}/${id}_${transformation}${extension}`
 }
 
 /**
@@ -364,9 +372,17 @@ export function getSummonImage(
 
 /**
  * Get summon detail image (PNG)
+ * @param transformation - Optional transformation suffix ('02' FLB/ULB, '03'/'04' transcendence)
  */
-export function getSummonDetailImage(id: string | number | null | undefined): string {
-	return getImageUrl('summon', id, 'detail')
+export function getSummonDetailImage(
+	id: string | number | null | undefined,
+	transformation?: string
+): string {
+	if (!id) return getPlaceholderImage('summon', 'detail')
+	if (!transformation) return getImageUrl('summon', id, 'detail')
+	const directory = getImageDirectory('summon', 'detail')
+	const extension = getFileExtension('summon', 'detail')
+	return `${getBasePath()}/${directory}/${id}_${transformation}${extension}`
 }
 
 /**

--- a/src/themes/themes.scss
+++ b/src/themes/themes.scss
@@ -153,6 +153,15 @@
 	--notice-grey-button-text-disabled: #{colors.$notice--grey--button--text--light--disabled};
 	--notice-grey-button-bg-disabled: #{colors.$notice--grey--button--bg--light--disabled};
 
+	// Light - Tags / chips
+	// Default = subtle / flat surface for non-interactive tags.
+	// Contained = emphasis variant used by clickable / linking tags; sits
+	// against the page rather than blending into it, with a stronger hover.
+	--tag-bg: #{colors.$grey-85};
+	--tag-bg-hover: #{colors.$grey-75};
+	--tag-contained-bg: #{colors.$grey-85};
+	--tag-contained-bg-hover: #{colors.$grey-70};
+
 	// Light - Buttons
 	--button-bg: #{colors.$button--bg--light};
 	--button-bg-hover: #{colors.$button--bg--light--hover};
@@ -663,6 +672,16 @@ html[data-theme='dark'] {
 	--notice-grey-button-text-hover: #{colors.$notice--grey--button--text--dark--hover};
 	--notice-grey-button-text-disabled: #{colors.$notice--grey--button--text--dark--disabled};
 	--notice-grey-button-bg-disabled: #{colors.$notice--grey--button--bg--dark--disabled};
+
+	// Dark - Tags / chips
+	// Default tag matches the sidebar/card surface for ambient labels.
+	// Contained variant is pure black, sitting clearly below the sidebar bg;
+	// hover steps to grey-15 — still darker than the surrounding panel so it
+	// doesn't disappear into it.
+	--tag-bg: #{colors.$grey-20};
+	--tag-bg-hover: #{colors.$grey-30};
+	--tag-contained-bg: #{colors.$grey-00};
+	--tag-contained-bg-hover: #{colors.$grey-10};
 
 	// Dark - Buttons
 	--button-bg: #{colors.$button--bg--dark};


### PR DESCRIPTION
- Adds --tag-bg / --tag-contained-bg slots in both themes; LinksSection switches to a .tag class on the contained variant so dark-mode hover steps clearly off the sidebar (pure black → grey-10).
- CollectionPill matches the link tag's font size and padding so the In-collection / Out-of-sync chip lines up visually.
- Details sidebar image now picks the uncap variant: weapons threaded through getWeaponTransformation, summons through getSummonTransformation; both helpers (getWeaponBaseImage, getSummonDetailImage) gained an optional transformation suffix.
- DescriptionTile drops the redundant tooltips on the Charge Attack / Full Auto / Auto Summon / Auto Guard / Solo tokens — they already render their own label.