### PR TITLE
Remove unused party preview adapter

### DIFF
--- a/src/lib/api/adapters/party.adapter.ts
+++ b/src/lib/api/adapters/party.adapter.ts
@@ -456,40 +456,6 @@ export class PartyAdapter extends BaseAdapter {
 	}
 
 	/**
-	 * Gets party preview image
-	 */
-	async getPreview(shortcode: string): Promise<Blob> {
-		return this.request<Blob>(`/parties/${shortcode}/preview`, {
-			method: 'GET',
-			headers: {
-				Accept: 'image/png'
-			}
-		})
-	}
-
-	/**
-	 * Gets party preview status
-	 */
-	async getPreviewStatus(shortcode: string): Promise<{
-		state: string
-		generatedAt?: string
-		readyForPreview: boolean
-	}> {
-		return this.request(`/parties/${shortcode}/preview_status`, {
-			method: 'GET'
-		})
-	}
-
-	/**
-	 * Regenerates party preview
-	 */
-	async regeneratePreview(shortcode: string): Promise<{ status: string }> {
-		return this.request(`/parties/${shortcode}/regenerate_preview`, {
-			method: 'POST'
-		})
-	}
-
-	/**
 	 * Favorite a party
 	 */
 	async favorite(partyId: string, shortcode: string): Promise<void> {

--- a/src/lib/api/mutations/__tests__/party.mutations.test.ts
+++ b/src/lib/api/mutations/__tests__/party.mutations.test.ts
@@ -15,7 +15,6 @@ import {
 	remixPartyOptions,
 	favoritePartyOptions,
 	unfavoritePartyOptions,
-	regeneratePreviewOptions,
 	sharePartyWithCrewOptions,
 	removePartyShareOptions
 } from '../party.mutations'
@@ -36,7 +35,6 @@ vi.mock('$lib/api/adapters/party.adapter', () => ({
 		remix: vi.fn(),
 		favorite: vi.fn(),
 		unfavorite: vi.fn(),
-		regeneratePreview: vi.fn(),
 		shareWithCrew: vi.fn(),
 		removeShare: vi.fn()
 	}
@@ -308,22 +306,6 @@ describe('unfavoritePartyOptions', () => {
 		const keys = spy.mock.calls.map((c) => c[0]!.queryKey)
 		expect(keys).toContainEqual(['user', 'favorites'])
 		expect(keys).toContainEqual(['party', MOCK_SHORTCODE])
-	})
-})
-
-// ============================================================================
-// regeneratePreview
-// ============================================================================
-
-describe('regeneratePreviewOptions', () => {
-	it('invalidates preview key on success', () => {
-		const spy = vi.spyOn(queryClient, 'invalidateQueries')
-		const opts = regeneratePreviewOptions(queryClient)
-
-		opts.onSuccess(undefined, MOCK_SHORTCODE)
-
-		const keys = spy.mock.calls.map((c) => c[0]!.queryKey)
-		expect(keys).toContainEqual(['party', MOCK_SHORTCODE, 'preview'])
 	})
 })
 

--- a/src/lib/api/mutations/party.mutations.ts
+++ b/src/lib/api/mutations/party.mutations.ts
@@ -214,15 +214,6 @@ export function unfavoritePartyOptions(queryClient: QueryClient) {
 	}
 }
 
-export function regeneratePreviewOptions(queryClient: QueryClient) {
-	return {
-		mutationFn: (shortcode: string) => partyAdapter.regeneratePreview(shortcode),
-		onSuccess: (_data: unknown, shortcode: string) => {
-			queryClient.invalidateQueries({ queryKey: partyKeys.preview(shortcode) })
-		}
-	}
-}
-
 export function sharePartyWithCrewOptions(queryClient: QueryClient) {
 	return {
 		mutationFn: ({ partyId }: { partyId: string; shortcode: string }) =>
@@ -291,11 +282,6 @@ export function useFavoriteParty() {
 export function useUnfavoriteParty() {
 	const queryClient = useQueryClient()
 	return createMutation(() => unfavoritePartyOptions(queryClient))
-}
-
-export function useRegeneratePreview() {
-	const queryClient = useQueryClient()
-	return createMutation(() => regeneratePreviewOptions(queryClient))
 }
 
 export function useSharePartyWithCrew() {

--- a/src/lib/api/queries/__tests__/queryKeys.test.ts
+++ b/src/lib/api/queries/__tests__/queryKeys.test.ts
@@ -40,17 +40,11 @@ describe('partyKeys', () => {
 		expect(partyKeys.raidList('raid-1')).toEqual(['parties', 'raid', 'raid-1', undefined])
 		expect(partyKeys.details()).toEqual(['party'])
 		expect(partyKeys.detail('abc')).toEqual(['party', 'abc'])
-		expect(partyKeys.preview('abc')).toEqual(['party', 'abc', 'preview'])
 	})
 
 	it('detail key matches byShortcode queryKey', () => {
 		const opts = partyQueries.byShortcode('abc')
 		expect(partyKeys.detail('abc')).toEqual(opts.queryKey)
-	})
-
-	it('preview key matches previewStatus queryKey', () => {
-		const opts = partyQueries.previewStatus('abc')
-		expect(partyKeys.preview('abc')).toEqual(opts.queryKey)
 	})
 
 	it('list key matches list queryKey', () => {

--- a/src/lib/api/queries/party.queries.ts
+++ b/src/lib/api/queries/party.queries.ts
@@ -222,21 +222,6 @@ export const partyQueries = {
 			enabled: !!raidId,
 			staleTime: 1000 * 60 * 3, // 3 minutes
 			gcTime: 1000 * 60 * 15 // 15 minutes
-		}),
-
-	/**
-	 * Party preview status query options
-	 *
-	 * @param shortcode - Party shortcode identifier
-	 * @returns Query options for fetching party preview status
-	 */
-	previewStatus: (shortcode: string) =>
-		queryOptions({
-			queryKey: ['party', shortcode, 'preview'] as const,
-			queryFn: () => partyAdapter.getPreviewStatus(shortcode),
-			enabled: !!shortcode,
-			staleTime: 1000 * 30, // 30 seconds - preview status changes
-			gcTime: 1000 * 60 * 5 // 5 minutes
 		})
 }
 
@@ -268,6 +253,5 @@ export const partyKeys = {
 	raidList: (raidId: string, filters?: RaidPartiesFilters) =>
 		[...partyKeys.raidLists(), raidId, filters] as const,
 	details: () => ['party'] as const,
-	detail: (shortcode: string) => [...partyKeys.details(), shortcode] as const,
-	preview: (shortcode: string) => [...partyKeys.detail(shortcode), 'preview'] as const
+	detail: (shortcode: string) => [...partyKeys.details(), shortcode] as const
 }

--- a/src/lib/api/schemas/party.ts
+++ b/src/lib/api/schemas/party.ts
@@ -383,11 +383,6 @@ export const PartySchemaRaw = z.object({
 	source_party: z.any().nullish(),
 	remixes: z.array(z.any()).nullish().default([]),
 
-	// Preview
-	preview_state: z.number().nullish().default(0),
-	preview_generated_at: z.string().nullish(),
-	preview_s3_key: z.string().nullish(),
-
 	// Timestamps
 	created_at: z.string().nullish(),
 	updated_at: z.string().nullish(),


### PR DESCRIPTION
## Summary

Drops the dead client-side hooks for the party-preview image pipeline. None of these methods are called anywhere; the Rails endpoints they hit are being removed in [hensei-api#423](https://github.com/jedmund/hensei-api/pull/423). Image rendering is moving to a Svelte + Playwright pipeline.

## What's removed

- `partyAdapter.getPreview`, `getPreviewStatus`, `regeneratePreview`
- `regeneratePreviewOptions`, `useRegeneratePreview`
- `partyQueries.previewStatus` + `partyKeys.preview`
- `preview_state` / `preview_generated_at` / `preview_s3_key` from the party Zod schema
- Related test cases (`party.mutations.test.ts`, `queryKeys.test.ts`)

## What's kept

- `partyAdapter.previewMigrate` — anonymous-party migration preview, unrelated
- `DescriptionTile.getPreviewData` — text snippet preview, unrelated

## Test plan

- [x] \`pnpm check\` — 0 errors
- [x] \`pnpm test\` — 1612 / 1612 passing