### PR TITLE
Hide profile header expand drawer until feature ships

### DIFF
--- a/src/lib/components/party/info/DescriptionTile.svelte
+++ b/src/lib/components/party/info/DescriptionTile.svelte
@@ -514,9 +514,7 @@
 		background: var(--card-bg);
 		border: 0.5px solid var(--button-bg);
 		border-radius: $card-corner;
-		// Bottom matches the other three sides now that there's no affordance
-		// hanging off the bottom edge.
-		padding: $unit-2x;
+		padding: $unit-2x $unit-2x $unit $unit-2x;
 		display: flex;
 		flex-direction: column;
 		gap: $unit;

--- a/src/lib/components/party/info/DescriptionTile.svelte
+++ b/src/lib/components/party/info/DescriptionTile.svelte
@@ -514,7 +514,9 @@
 		background: var(--card-bg);
 		border: 0.5px solid var(--button-bg);
 		border-radius: $card-corner;
-		padding: $unit-2x $unit-2x $unit $unit-2x;
+		// Bottom matches the other three sides now that there's no affordance
+		// hanging off the bottom edge.
+		padding: $unit-2x;
 		display: flex;
 		flex-direction: column;
 		gap: $unit;

--- a/src/lib/components/profile/ProfileHeader.svelte
+++ b/src/lib/components/profile/ProfileHeader.svelte
@@ -469,13 +469,18 @@
 		}
 	}
 
+	// TODO: profile expand drawer is hidden until the feature is ready to
+	// ship. Switch `display: none` back to `display: flex` (and re-enable
+	// .expand-spacer) when re-enabling — all the state, handlers, and DOM
+	// stay intact behind this single rule.
 	.expand-section {
-		display: flex;
+		display: none;
 		flex-direction: column;
 		padding: 0 $unit-2x $unit-2x;
 	}
 
 	.expand-spacer {
+		display: none;
 		width: 100%;
 		height: 0;
 		overflow: hidden;

--- a/src/lib/components/profile/ProfileHeader.svelte
+++ b/src/lib/components/profile/ProfileHeader.svelte
@@ -461,7 +461,10 @@
 	}
 
 	.tabs {
-		padding: 0 $unit-2x $unit;
+		// Bottom matches the horizontal inset now that the expand drawer
+		// below is hidden — without the chevron toggle catching the eye,
+		// the smaller $unit gap looked cramped against the page content.
+		padding: 0 $unit-2x $unit-2x;
 		transition: opacity effects.$duration-slide ease-in-out;
 
 		&.dimmed {


### PR DESCRIPTION
## Summary

The chevron toggle and 50dvh expand drawer on the profile header aren't user-ready yet. Hide them via \`display: none\` so we can keep moving toward the support-summon share-card ship without that affordance landing in front of users.

## Change

Two CSS rules in \`src/lib/components/profile/ProfileHeader.svelte\`:

- \`.expand-section\` (the chevron toggle wrapper): \`display: flex\` → \`display: none\`
- \`.expand-spacer\` (the animated 50dvh drawer): adds \`display: none\`

That's it. Everything else — \`expanded\` state, \`handleTabChange\`, \`bind:expanded\` to children, the chevron button, \`aria-expanded\`, the slide transition — stays exactly where it is. Re-enabling is a one-line revert when the feature is ready.

## Test plan

- [x] \`pnpm check\` — 0 errors
- [ ] Visit \`/[username]\` — no chevron visible below the tabs, no spacer between the avatar block and the tabs