### PR TITLE
Full Auto skill toggles in the party details sidebar

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1889,5 +1889,5 @@
 	"character_skills_seconds": "{n} sec",
 	"character_skills_level": "Lv {n}",
 	"character_skills_uncap_star": "★{n}",
-	"details_full_auto_skills": "Full Auto"
+	"details_full_auto_skills": "Full Auto Skills"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1888,5 +1888,6 @@
 	"character_skills_turns": "{n} turns",
 	"character_skills_seconds": "{n} sec",
 	"character_skills_level": "Lv {n}",
-	"character_skills_uncap_star": "★{n}"
+	"character_skills_uncap_star": "★{n}",
+	"details_full_auto_skills": "Full Auto"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1869,5 +1869,6 @@
 	"character_skills_turns": "{n}ターン",
 	"character_skills_seconds": "{n}秒",
 	"character_skills_level": "Lv {n}",
-	"character_skills_uncap_star": "★{n}"
+	"character_skills_uncap_star": "★{n}",
+	"details_full_auto_skills": "フルオート"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1870,5 +1870,5 @@
 	"character_skills_seconds": "{n}秒",
 	"character_skills_level": "Lv {n}",
 	"character_skills_uncap_star": "★{n}",
-	"details_full_auto_skills": "フルオート"
+	"details_full_auto_skills": "フルオートアビリティ"
 }

--- a/src/lib/components/sidebar/DetailsSidebar.svelte
+++ b/src/lib/components/sidebar/DetailsSidebar.svelte
@@ -17,6 +17,7 @@
 	import OutOfSyncBanner from './details/OutOfSyncBanner.svelte'
 	import SyncToCollectionDialog from './details/SyncToCollectionDialog.svelte'
 	import { getElementKey } from '$lib/utils/element'
+	import { getAbilitySlots } from '$lib/utils/fullAutoSkills'
 	import { authStore } from '$lib/stores/auth.store.svelte'
 	import { getEditKey } from '$lib/utils/editKeys'
 	import { localizedName } from '$lib/utils/locale'
@@ -62,12 +63,21 @@
 
 	let modificationStatus = $derived(detectModifications(type, item))
 
+	// A character's Full Auto section (ability-slot toggles) lives in the Team
+	// view, so the segmented control must be reachable whenever it will render.
+	const hasFullAutoSkills = $derived(
+		type === 'character' && getAbilitySlots((item as GridCharacter).character).length > 0
+	)
+
 	// Show segmented control whenever Team view has something to show: actual
-	// modifications, a modifiable weapon, or party-side notes/substitutions.
+	// modifications, a modifiable weapon, Full Auto toggles, or party-side
+	// notes/substitutions.
 	const showSegmentedControl = $derived(
 		(type === 'weapon'
 			? canWeaponBeModified(item as GridWeapon)
-			: modificationStatus.hasModifications) || hasNotesOrSubstitutions(item)
+			: modificationStatus.hasModifications) ||
+			hasFullAutoSkills ||
+			hasNotesOrSubstitutions(item)
 	)
 
 	// Track selected view - updated reactively based on modifiability

--- a/src/lib/components/sidebar/details/FullAutoSkillsSection.svelte
+++ b/src/lib/components/sidebar/details/FullAutoSkillsSection.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import type { GridCharacter } from '$lib/types/api/party'
+	import DetailsSection from './DetailsSection.svelte'
+	import DetailRow from './DetailRow.svelte'
+	import Switch from '$lib/components/ui/switch/Switch.svelte'
+	import { getAbilitySlots } from '$lib/utils/fullAutoSkills'
+	import { useUpdateGridCharacter } from '$lib/api/mutations/grid.mutations'
+	import { partyStore } from '$lib/stores/partyStore.svelte'
+	import { getElementTypeKey } from '$lib/utils/element'
+	import * as m from '$lib/paraglide/messages'
+
+	interface Props {
+		item: GridCharacter
+		isPartyOwner?: boolean
+	}
+
+	let { item, isPartyOwner = false }: Props = $props()
+
+	const updateCharacter = useUpdateGridCharacter()
+
+	const slots = $derived(getAbilitySlots(item.character))
+	const fullAuto = $derived(item.fullAutoSkills ?? {})
+	const element = $derived(getElementTypeKey(item.character?.element))
+
+	// Absent or true => ON; only an explicit false is OFF.
+	function isOn(slot: number): boolean {
+		return fullAuto[String(slot)] !== false
+	}
+
+	function setSlot(slot: number, on: boolean) {
+		const shortcode = partyStore.party?.shortcode
+		if (!item.id || !shortcode) return
+
+		// Send the full object so persisted state stays explicit.
+		const next: Record<string, boolean> = { ...fullAuto, [String(slot)]: on }
+		updateCharacter.mutate({
+			id: item.id,
+			partyShortcode: shortcode,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- partial update only needs fullAutoSkills
+			updates: { fullAutoSkills: next } as any
+		})
+	}
+</script>
+
+{#if slots.length > 0}
+	<DetailsSection title={m.details_full_auto_skills()}>
+		{#each slots as s (s.slot)}
+			{#if s.eligible}
+				<DetailRow label={s.name} compact>
+					<Switch
+						size="small"
+						{element}
+						checked={isOn(s.slot)}
+						disabled={!isPartyOwner}
+						onCheckedChange={(checked) => {
+							// Guard against the Switch's mount-time callback firing a no-op write.
+							if (checked !== isOn(s.slot)) setSlot(s.slot, checked)
+						}}
+					/>
+				</DetailRow>
+			{:else}
+				<DetailRow compact>
+					{#snippet labelSlot()}
+						<span class="ineligible">{s.name}</span>
+					{/snippet}
+				</DetailRow>
+			{/if}
+		{/each}
+	</DetailsSection>
+{/if}
+
+<style lang="scss">
+	.ineligible {
+		color: var(--text-secondary);
+	}
+</style>

--- a/src/lib/components/sidebar/details/FullAutoSkillsSection.svelte
+++ b/src/lib/components/sidebar/details/FullAutoSkillsSection.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { GridCharacter } from '$lib/types/api/party'
 	import DetailsSection from './DetailsSection.svelte'
-	import DetailRow from './DetailRow.svelte'
 	import Switch from '$lib/components/ui/switch/Switch.svelte'
 	import { getAbilitySlots } from '$lib/utils/fullAutoSkills'
 	import { useUpdateGridCharacter } from '$lib/api/mutations/grid.mutations'
@@ -45,8 +44,20 @@
 {#if slots.length > 0}
 	<DetailsSection title={m.details_full_auto_skills()}>
 		{#each slots as s (s.slot)}
-			{#if s.eligible}
-				<DetailRow label={s.name} compact>
+			<div class="fa-row" class:ineligible={!s.eligible}>
+				<div class="thumb-wrapper">
+					{#if s.iconUrl}
+						<img
+							class="thumb"
+							src={s.iconUrl}
+							alt=""
+							loading="lazy"
+							onerror={(e) => ((e.currentTarget as HTMLImageElement).style.visibility = 'hidden')}
+						/>
+					{/if}
+				</div>
+				<span class="name">{s.name}</span>
+				{#if s.eligible}
 					<Switch
 						size="small"
 						{element}
@@ -57,20 +68,53 @@
 							if (checked !== isOn(s.slot)) setSlot(s.slot, checked)
 						}}
 					/>
-				</DetailRow>
-			{:else}
-				<DetailRow compact>
-					{#snippet labelSlot()}
-						<span class="ineligible">{s.name}</span>
-					{/snippet}
-				</DetailRow>
-			{/if}
+				{/if}
+			</div>
 		{/each}
 	</DetailsSection>
 {/if}
 
 <style lang="scss">
-	.ineligible {
-		color: var(--text-secondary);
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+	@use '$src/themes/layout' as layout;
+
+	.fa-row {
+		display: flex;
+		align-items: center;
+		gap: spacing.$unit;
+		padding: spacing.$unit;
+		border-radius: spacing.$unit;
+		font-size: typography.$font-regular;
+
+		&.ineligible .name {
+			color: var(--text-secondary);
+		}
+	}
+
+	.name {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		color: var(--text-primary);
+		font-size: typography.$font-regular;
+	}
+
+	.thumb-wrapper {
+		width: 48px;
+		height: 48px;
+		flex-shrink: 0;
+	}
+
+	.thumb {
+		display: block;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		border-radius: layout.$item-corner-small;
+		border: 1px solid var(--border-primary);
+		background: var(--placeholder-bg);
 	}
 </style>

--- a/src/lib/components/sidebar/details/TeamView.svelte
+++ b/src/lib/components/sidebar/details/TeamView.svelte
@@ -215,6 +215,10 @@
 </script>
 
 <div class="team-view">
+	{#if type === 'character'}
+		<FullAutoSkillsSection item={item as GridCharacter} {isPartyOwner} />
+	{/if}
+
 	<NotesReadOnlySection {type} {item} {isPartyOwner} mode="filled" />
 
 	<DetailsSection title={m.details_uncap_transcendence()}>
@@ -251,8 +255,6 @@
 
 	{#if type === 'character'}
 		{@const char = item as GridCharacter}
-
-		<FullAutoSkillsSection item={char} {isPartyOwner} />
 
 		{#if modificationStatus.hasAwakening}
 			<DetailsSection title={m.details_awakening()}>

--- a/src/lib/components/sidebar/details/TeamView.svelte
+++ b/src/lib/components/sidebar/details/TeamView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { GridCharacter, GridWeapon, GridSummon } from '$lib/types/api/party'
 	import DetailsSection from './DetailsSection.svelte'
+	import FullAutoSkillsSection from './FullAutoSkillsSection.svelte'
 	import DetailRow from './DetailRow.svelte'
 	import AwakeningDisplay from '../modifications/AwakeningDisplay.svelte'
 	import MasteryDisplay from '../modifications/MasteryDisplay.svelte'
@@ -250,6 +251,8 @@
 
 	{#if type === 'character'}
 		{@const char = item as GridCharacter}
+
+		<FullAutoSkillsSection item={char} {isPartyOwner} />
 
 		{#if modificationStatus.hasAwakening}
 			<DetailsSection title={m.details_awakening()}>

--- a/src/lib/types/api/party.ts
+++ b/src/lib/types/api/party.ts
@@ -144,6 +144,9 @@ export interface GridCharacter {
 	/** Stamped by the API when this grid item is rendered as a substitute —
 	 * true if current_user has the underlying character in their collection. */
 	owned?: boolean
+	/** Party-specific Full Auto toggles per ability slot ("1".."4" → used in FA).
+	 * Absent slot defaults to ON. */
+	fullAutoSkills?: Record<string, boolean>
 }
 
 // GridSummon from GridSummonBlueprint

--- a/src/lib/utils/__tests__/fullAutoSkills.test.ts
+++ b/src/lib/utils/__tests__/fullAutoSkills.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { getAbilitySlots } from '../fullAutoSkills'
+import type { Character, CharacterSkill, CharacterSkillVersion } from '$lib/types/api/entities'
+
+function version(
+	name: string,
+	opts: Partial<CharacterSkillVersion> & { target?: string } = {}
+): CharacterSkillVersion {
+	const { target, ...rest } = opts
+	return {
+		id: name,
+		name: { en: name, ja: name },
+		description: { en: '', ja: '' },
+		variantRole: 'base',
+		ordinal: 1,
+		skillEffects: target ? [{ id: 't', ordinal: 0, effectType: 'grant_status', target }] : [],
+		...rest
+	} as CharacterSkillVersion
+}
+
+function slot(kind: string, position: number, base: CharacterSkillVersion): CharacterSkill {
+	return { kind, position, versions: [base] }
+}
+
+// Modeled on Rei (3040265000): slot 1 one_ally buff (ineligible), slot 2 caster
+// buff (eligible), slot 3 all_foes debuff (eligible), slot 4 buff no-target
+// (eligible); plus a heal slot and an ougi that must be excluded/ineligible.
+function rei(): Character {
+	return {
+		skills: [
+			slot('ability', 1, version('Alaya-Vijnana', { typeColor: 'buff', target: 'one_ally' })),
+			slot('ability', 2, version('Moksha', { typeColor: 'buff', target: 'caster' })),
+			slot('ability', 3, version('Cold Stare', { typeColor: 'debuff', target: 'all_foes' })),
+			slot('ability', 4, version('Ama no Sakate', { typeColor: 'buff' })),
+			slot('ougi', 1, version('Some Ougi', { typeColor: 'damage' }))
+		]
+	} as Character
+}
+
+describe('getAbilitySlots', () => {
+	it('returns ability slots in order, excluding ougi/support', () => {
+		const slots = getAbilitySlots(rei())
+		expect(slots.map((s) => s.slot)).toEqual([1, 2, 3, 4])
+		expect(slots.map((s) => s.name)).toEqual([
+			'Alaya-Vijnana',
+			'Moksha',
+			'Cold Stare',
+			'Ama no Sakate'
+		])
+	})
+
+	it('marks one_ally-target skills ineligible but keeps other targets eligible', () => {
+		const byName = Object.fromEntries(getAbilitySlots(rei()).map((s) => [s.name, s.eligible]))
+		expect(byName['Alaya-Vijnana']).toBe(false) // one_ally
+		expect(byName['Moksha']).toBe(true) // caster
+		expect(byName['Cold Stare']).toBe(true) // all_foes
+		expect(byName['Ama no Sakate']).toBe(true) // no target
+	})
+
+	it('marks heal and field skills ineligible', () => {
+		const character = {
+			skills: [
+				slot('ability', 1, version('Heal Skill', { typeColor: 'heal' })),
+				slot('ability', 2, version('Field Skill', { typeColor: 'field' }))
+			]
+		} as Character
+		expect(getAbilitySlots(character).every((s) => !s.eligible)).toBe(true)
+	})
+
+	it('returns an empty array for a character with no skills', () => {
+		expect(getAbilitySlots({} as Character)).toEqual([])
+		expect(getAbilitySlots(undefined)).toEqual([])
+	})
+})

--- a/src/lib/utils/fullAutoSkills.ts
+++ b/src/lib/utils/fullAutoSkills.ts
@@ -1,0 +1,47 @@
+import type { Character, CharacterSkill, CharacterSkillVersion } from '$lib/types/api/entities'
+import { localizedName } from '$lib/utils/locale'
+
+/** An ability slot surfaced in the Full Auto section. */
+export interface AbilitySlot {
+	/** 1-based slot number, used as the fullAutoSkills key. */
+	slot: number
+	/** Localized base ability name. */
+	name: string
+	/** Whether the skill can be toggled (gets a Switch) in Full Auto. */
+	eligible: boolean
+}
+
+// A skill is NOT usable in Full Auto (so it gets no toggle) when its base
+// version is a heal or field skill, or when it makes the player pick a target
+// ally (target === 'one_ally', e.g. Rei's "Alaya-Vijnana").
+const INELIGIBLE_TYPE_COLORS = new Set(['heal', 'field'])
+
+function baseVersion(skill: CharacterSkill): CharacterSkillVersion | undefined {
+	return (
+		skill.versions.find((version) => version.variantRole === 'base') ??
+		[...skill.versions].sort((a, b) => a.ordinal - b.ordinal)[0]
+	)
+}
+
+function isEligible(base: CharacterSkillVersion): boolean {
+	if (base.typeColor && INELIGIBLE_TYPE_COLORS.has(base.typeColor)) return false
+	if (base.skillEffects?.some((effect) => effect.target === 'one_ally')) return false
+	return true
+}
+
+/**
+ * Returns every ability slot for a character (ougi/support excluded), in slot
+ * order, with its base-version name and Full Auto eligibility. Empty array when
+ * the character has no ability slots.
+ */
+export function getAbilitySlots(character: Character | undefined): AbilitySlot[] {
+	const skills = character?.skills ?? []
+	return skills
+		.filter((skill) => skill.kind === 'ability')
+		.sort((a, b) => a.position - b.position)
+		.flatMap((skill) => {
+			const base = baseVersion(skill)
+			if (!base) return []
+			return [{ slot: skill.position, name: localizedName(base.name), eligible: isEligible(base) }]
+		})
+}

--- a/src/lib/utils/fullAutoSkills.ts
+++ b/src/lib/utils/fullAutoSkills.ts
@@ -1,5 +1,6 @@
 import type { Character, CharacterSkill, CharacterSkillVersion } from '$lib/types/api/entities'
 import { localizedName } from '$lib/utils/locale'
+import { getCharacterSkillIcon } from '$lib/utils/images'
 
 /** An ability slot surfaced in the Full Auto section. */
 export interface AbilitySlot {
@@ -7,6 +8,8 @@ export interface AbilitySlot {
 	slot: number
 	/** Localized base ability name. */
 	name: string
+	/** Ability icon URL, or null when the base version has no game icon. */
+	iconUrl: string | null
 	/** Whether the skill can be toggled (gets a Switch) in Full Auto. */
 	eligible: boolean
 }
@@ -42,6 +45,13 @@ export function getAbilitySlots(character: Character | undefined): AbilitySlot[]
 		.flatMap((skill) => {
 			const base = baseVersion(skill)
 			if (!base) return []
-			return [{ slot: skill.position, name: localizedName(base.name), eligible: isEligible(base) }]
+			return [
+				{
+					slot: skill.position,
+					name: localizedName(base.name),
+					iconUrl: getCharacterSkillIcon(base.gameIcon),
+					eligible: isEligible(base)
+				}
+			]
 		})
 }


### PR DESCRIPTION
## Summary
Adds per-ability-slot **Full Auto** on/off toggles to the party Character details sidebar.

## Changes
- `getAbilitySlots` eligibility util: ability slots only; a slot is ineligible (no switch) when its base version is heal/field or has an effect targeting `one_ally`; returns name + icon + eligibility.
- `FullAutoSkillsSection`: a `Switch` per eligible slot (default ON), ineligible slots show the name without a switch, 48×48 ability icon, persists `fullAutoSkills` on the grid character (optimistic). Mounted at the top of the Team view; the sidebar surfaces the Team tab whenever the character has ability slots.
- `GridCharacter.fullAutoSkills` type; EN/JA key ("Full Auto Skills" / "フルオートアビリティ").

Stacked on #872 (uses the skill-graph types). Backend: **hensei-api #428** (`full_auto_skills` + skills serialization).

> Base is `feat/character-skills-tab`; retarget to `staging` once #872 merges.
