### PR TITLE
Add character skill mentions to descriptions and notes

### DIFF
--- a/src/lib/components/DescriptionRenderer.svelte
+++ b/src/lib/components/DescriptionRenderer.svelte
@@ -4,18 +4,9 @@
 	import { escapeHtml, safeHref } from '$lib/utils/safeHtml'
 	import { computePosition, flip, shift, offset } from '@floating-ui/dom'
 	import MentionTooltip from '$lib/components/ui/MentionTooltip.svelte'
+	import { mentionChipAttrs, mentionHref } from './edra/extensions/entity-mention/mentions/index.js'
+	import type { MentionToken } from './edra/extensions/entity-mention/mentions/index.js'
 	import * as m from '$lib/paraglide/messages'
-
-	interface MentionEntity {
-		granblue_id: string
-		name: { en: string; ja: string }
-		type: string
-		element: { id: number; slug: string }
-		proficiency?: number | number[]
-		season?: number | null
-		series?: number[] | { id: string; slug: string; name: { en: string; ja: string } }[] | null
-		styleSwap?: boolean
-	}
 
 	interface Props {
 		content?: string
@@ -26,7 +17,7 @@
 	let { content, truncate = false, maxLines = 3 }: Props = $props()
 
 	// Tooltip state
-	let tooltipEntity: MentionEntity | null = $state(null)
+	let tooltipEntity: MentionToken | null = $state(null)
 	let tooltipVisible = $state(false)
 	let tooltipEl: HTMLDivElement | null = $state(null)
 	let containerEl: HTMLDivElement | null = $state(null)
@@ -35,7 +26,7 @@
 	// The collector map is passed in rather than mutating module-level state
 	function jsonToHtml(
 		node: JSONContent,
-		collector: Map<number, MentionEntity>,
+		collector: Map<number, MentionToken>,
 		counter: { value: number }
 	): string {
 		if (!node) return ''
@@ -175,30 +166,40 @@
 			}
 
 			case 'mention': {
-				// Handle game item mentions
+				// Handle game item / skill mentions
 				const attrs = node.attrs?.id
-				const wikiName = attrs?.name?.en || attrs?.granblue_en || 'Unknown'
-				const mentionName = localizedName(attrs?.name)
-				const displayName = mentionName !== '—' ? mentionName : attrs?.granblue_en || 'Unknown'
-				const wikiUrl = `https://gbf.wiki/${encodeURIComponent(wikiName)}`
-				const elementSlug = attrs?.element?.slug ?? ''
-				const entityType = attrs?.type ?? ''
-
-				// Store entity data for tooltip
-				const idx = counter.value++
-				collector.set(idx, {
+				const token: MentionToken = {
+					type: attrs?.type ?? attrs?.searchableType?.toLowerCase() ?? 'unknown',
 					granblue_id: attrs?.granblue_id ?? '',
-					name: attrs?.name ?? { en: wikiName, ja: wikiName },
-					type: entityType,
-					element: attrs?.element ?? { id: 0, slug: 'null' },
+					name: attrs?.name ?? { en: 'Unknown', ja: 'Unknown' },
+					element: attrs?.element,
 					proficiency: attrs?.proficiency,
 					season: attrs?.season,
 					series: attrs?.series,
-					styleSwap: attrs?.styleSwap
-				})
+					styleSwap: attrs?.styleSwap,
+					skill: attrs?.skill
+				}
+				const mentionName = localizedName(token.name)
+				const displayName = mentionName !== '—' ? mentionName : (attrs?.granblue_en ?? 'Unknown')
 
-				const entityJson = escapeHtml(JSON.stringify(collector.get(idx)))
-				return `<a href="${safeHref(wikiUrl)}" target="_blank" rel="noopener noreferrer" class="mention" data-type="mention" data-id="${entityJson}" data-element="${escapeHtml(elementSlug)}" data-entity-type="${escapeHtml(entityType)}" data-mention-index="${idx}">${escapeHtml(displayName)}</a>`
+				// Store the token for the hover tooltip.
+				const idx = counter.value++
+				collector.set(idx, token)
+
+				// Shared chip attributes (data-type/element/entity-type/skill-color) come
+				// from the single helper so the chip matches the editor node exactly.
+				const chipAttrs = Object.entries(mentionChipAttrs(token))
+					.map(([key, value]) => `${key}="${escapeHtml(value)}"`)
+					.join(' ')
+				const entityJson = escapeHtml(JSON.stringify(token))
+				const shared = `class="mention" ${chipAttrs} data-id="${entityJson}" data-mention-index="${idx}"`
+
+				// Skills have no wiki page, so they render as a non-linking span.
+				const href = mentionHref(token)
+				if (href) {
+					return `<a href="${safeHref(href)}" target="_blank" rel="noopener noreferrer" ${shared}>${escapeHtml(displayName)}</a>`
+				}
+				return `<span ${shared}>${escapeHtml(displayName)}</span>`
 			}
 
 			default:
@@ -213,11 +214,11 @@
 	// Parse content - handle both JSON and plain text
 	function parseContent(content?: string): {
 		html: string
-		entities: Map<number, MentionEntity>
+		entities: Map<number, MentionToken>
 	} {
 		if (!content) return { html: '', entities: new Map() }
 
-		const collector = new Map<number, MentionEntity>()
+		const collector = new Map<number, MentionToken>()
 		const counter = { value: 0 }
 
 		// Try to parse as JSON first
@@ -437,6 +438,32 @@
 				&[data-element='light'] {
 					background: var(--light-mention-bg);
 					color: var(--light-text);
+				}
+
+				// Skill mentions tint by skill type color rather than element.
+				&[data-skill-color='damage'] {
+					background: color-mix(in srgb, #d64545 18%, transparent);
+					color: #d64545;
+				}
+
+				&[data-skill-color='heal'] {
+					background: color-mix(in srgb, #3fa34d 18%, transparent);
+					color: #3fa34d;
+				}
+
+				&[data-skill-color='buff'] {
+					background: color-mix(in srgb, #e0a93b 18%, transparent);
+					color: #b9831f;
+				}
+
+				&[data-skill-color='debuff'] {
+					background: color-mix(in srgb, #4a6fd6 18%, transparent);
+					color: #4a6fd6;
+				}
+
+				&[data-skill-color='field'] {
+					background: color-mix(in srgb, #8b5cf6 18%, transparent);
+					color: #8b5cf6;
 				}
 			}
 

--- a/src/lib/components/edra/editor.css
+++ b/src/lib/components/edra/editor.css
@@ -549,3 +549,30 @@ input[type='checkbox'] {
 	background: var(--light-mention-bg);
 	color: var(--light-text);
 }
+
+/* Skill mentions: tinted by skill type color (damage/heal/buff/debuff/field)
+   rather than element, matching the Skills tab / Full Auto chips. */
+.tiptap span.entity-mention[data-skill-color='damage'] {
+	background: color-mix(in srgb, #d64545 18%, transparent);
+	color: #d64545;
+}
+
+.tiptap span.entity-mention[data-skill-color='heal'] {
+	background: color-mix(in srgb, #3fa34d 18%, transparent);
+	color: #3fa34d;
+}
+
+.tiptap span.entity-mention[data-skill-color='buff'] {
+	background: color-mix(in srgb, #e0a93b 18%, transparent);
+	color: #b9831f;
+}
+
+.tiptap span.entity-mention[data-skill-color='debuff'] {
+	background: color-mix(in srgb, #4a6fd6 18%, transparent);
+	color: #4a6fd6;
+}
+
+.tiptap span.entity-mention[data-skill-color='field'] {
+	background: color-mix(in srgb, #8b5cf6 18%, transparent);
+	color: #8b5cf6;
+}

--- a/src/lib/components/edra/extensions/entity-mention/EntityMention.ts
+++ b/src/lib/components/edra/extensions/entity-mention/EntityMention.ts
@@ -9,37 +9,8 @@ import Mention from '@tiptap/extension-mention'
 import { mergeAttributes } from '@tiptap/core'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { localizedName } from '$lib/utils/locale'
-
-/** Element ID to slug mapping */
-const ELEMENT_SLUGS: Record<number, string> = {
-	0: 'null',
-	1: 'wind',
-	2: 'fire',
-	3: 'water',
-	4: 'earth',
-	5: 'dark',
-	6: 'light'
-}
-
-/**
- * Gets the element slug from various attribute formats
- * Handles both legacy (object with slug) and new (numeric) formats
- */
-function getElementSlug(element: unknown): string {
-	if (!element) return 'null'
-
-	// Handle object format: { id: number, slug: string, ... }
-	if (typeof element === 'object' && element !== null && 'slug' in element) {
-		return (element as { slug: string }).slug
-	}
-
-	// Handle numeric format
-	if (typeof element === 'number') {
-		return ELEMENT_SLUGS[element] ?? 'null'
-	}
-
-	return 'null'
-}
+import { mentionChipAttrs } from './mentions/index.js'
+import type { MentionToken } from './mentions/index.js'
 
 export const EntityMention = Mention.extend({
 	name: 'mention',
@@ -97,21 +68,15 @@ export const EntityMention = Mention.extend({
 		const localized = localizedName(id?.name)
 		const displayName = localized !== '—' ? localized : (id?.granblue_en ?? 'Unknown')
 
-		// Get element slug for styling
-		const elementSlug = getElementSlug(id?.element)
-
-		// Get entity type for additional styling/tracking
-		const entityType = id?.type ?? id?.searchableType?.toLowerCase() ?? 'unknown'
+		// Normalize the type for legacy nodes that stored `searchableType` instead.
+		const token = {
+			...id,
+			type: id?.type ?? id?.searchableType?.toLowerCase() ?? 'unknown'
+		} as MentionToken
 
 		return [
 			'span',
-			mergeAttributes(
-				{ 'data-type': this.name },
-				{ 'data-element': elementSlug },
-				{ 'data-entity-type': entityType },
-				this.options.HTMLAttributes,
-				HTMLAttributes
-			),
+			mergeAttributes(mentionChipAttrs(token), this.options.HTMLAttributes, HTMLAttributes),
 			displayName
 		]
 	}

--- a/src/lib/components/edra/extensions/entity-mention/EntityMentionList.svelte
+++ b/src/lib/components/edra/extensions/entity-mention/EntityMentionList.svelte
@@ -2,30 +2,20 @@
 	/**
 	 * EntityMentionList - Dropdown for entity mention suggestions
 	 *
-	 * Shows search results for characters, weapons, and summons when typing @
-	 * Supports keyboard navigation and displays entity images with element colors.
+	 * Shows characters, weapons, summons (global search) and the active party's
+	 * character skills when typing `@`. Rows are precomputed MentionSuggestions, so
+	 * this component only paints; per-type presentation lives in the mentions module.
 	 */
 	import * as m from '$lib/paraglide/messages'
-	import { getBasePath } from '$lib/utils/images'
-	import type { UnifiedSearchResult } from '$lib/api/adapters/search.adapter'
+	import { localizedName } from '$lib/utils/locale'
 	import CharacterTags from '$lib/components/tags/CharacterTags.svelte'
+	import { descriptorFor } from './mentions/index.js'
+	import type { MentionSuggestion, MentionToken } from './mentions/index.js'
 
 	interface Props {
-		items: UnifiedSearchResult[]
-		command: (item: EntityMentionData) => void
+		items: MentionSuggestion[]
+		command: (token: MentionToken) => void
 		query: string
-	}
-
-	/** Data structure passed to the mention command */
-	export interface EntityMentionData {
-		granblue_id: string
-		name: { en: string; ja: string }
-		type: string
-		element: { id: number; slug: string }
-		proficiency?: number | number[]
-		season?: number | null
-		series?: number[] | { id: string; slug: string; name: { en: string; ja: string } }[] | null
-		styleSwap?: boolean
 	}
 
 	let { items, command, query }: Props = $props()
@@ -45,53 +35,10 @@
 		item?.scrollIntoView({ block: 'nearest' })
 	})
 
-	function getEntityImageUrl(item: UnifiedSearchResult): string {
-		const base = getBasePath()
-		const type = item.searchableType.toLowerCase()
-		const id = item.granblueId
-
-		if (type === 'character') {
-			return `${base}/character-square/${id}_01.jpg`
-		}
-		return `${base}/${type}-square/${id}.jpg`
-	}
-
-	function getElementSlug(element?: number): string {
-		const slugs: Record<number, string> = {
-			0: 'null',
-			1: 'wind',
-			2: 'fire',
-			3: 'water',
-			4: 'earth',
-			5: 'dark',
-			6: 'light'
-		}
-		return slugs[element ?? 0] ?? 'null'
-	}
-
 	function selectItem(index: number) {
 		const item = items[index]
 		if (!item) return
-
-		command({
-			granblue_id: item.granblueId,
-			name: {
-				en: item.nameEn ?? m.mention_unknown(),
-				ja: item.nameJp ?? m.mention_unknown()
-			},
-			type: item.searchableType.toLowerCase(),
-			element: {
-				id: item.element ?? 0,
-				slug: getElementSlug(item.element)
-			},
-			proficiency: item.proficiency,
-			season: item.season,
-			series: item.series as
-				| number[]
-				| { id: string; slug: string; name: { en: string; ja: string } }[]
-				| undefined,
-			styleSwap: item.styleSwap
-		})
+		command(item.token)
 	}
 
 	function upHandler() {
@@ -126,22 +73,35 @@
 
 <div class="entity-mention-list" bind:this={listEl}>
 	{#if items.length > 0}
-		{#each items as item, index (item.searchableId)}
+		{#each items as item, index (item.key)}
+			{@const token = item.token}
+			{@const secondary = descriptorFor(token.type).secondary}
 			<button
 				type="button"
 				class="mention-item"
 				class:selected={index === selectedIndex}
 				onclick={() => selectItem(index)}
 			>
-				<div class="item-image {item.searchableType.toLowerCase()}">
-					<img src={getEntityImageUrl(item)} alt={item.nameEn ?? ''} loading="lazy" />
+				<div class="item-image {token.type}">
+					{#if item.imageUrl}
+						<img src={item.imageUrl} alt={item.primaryLabel} loading="lazy" />
+					{:else}
+						<span class="item-swatch" style:background={item.swatchColor ?? 'var(--border-color)'}
+						></span>
+					{/if}
 				</div>
 				<div class="item-info">
-					<span class="item-name">{item.nameEn ?? item.nameJp ?? m.mention_unknown()}</span>
-					{#if item.searchableType === 'Character'}
+					<span class="item-name">{item.primaryLabel || m.mention_unknown()}</span>
+					{#if secondary === 'character-tags'}
 						<CharacterTags
-							character={{ element: item.element, season: item.season, series: item.series }}
+							character={{
+								element: token.element?.id,
+								season: token.season,
+								series: token.series
+							}}
 						/>
+					{:else if secondary === 'skill-meta' && token.skill?.character}
+						<span class="item-meta">{localizedName(token.skill.character.name)}</span>
 					{/if}
 				</div>
 			</button>
@@ -209,6 +169,17 @@
 			height: 100%;
 			object-fit: cover;
 		}
+
+		// Skill icons are transparent PNGs; don't crop them.
+		&.skill img {
+			object-fit: contain;
+		}
+	}
+
+	.item-swatch {
+		display: block;
+		width: 100%;
+		height: 100%;
 	}
 
 	.item-info {
@@ -222,6 +193,14 @@
 	.item-name {
 		font-size: $font-small;
 		color: var(--text-primary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.item-meta {
+		font-size: $font-tiny;
+		color: var(--text-secondary);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/src/lib/components/edra/extensions/entity-mention/EntityMentionList.svelte
+++ b/src/lib/components/edra/extensions/entity-mention/EntityMentionList.svelte
@@ -7,9 +7,8 @@
 	 * this component only paints; per-type presentation lives in the mentions module.
 	 */
 	import * as m from '$lib/paraglide/messages'
-	import { localizedName } from '$lib/utils/locale'
 	import CharacterTags from '$lib/components/tags/CharacterTags.svelte'
-	import { descriptorFor } from './mentions/index.js'
+	import { descriptorFor, skillMentionSubheader } from './mentions/index.js'
 	import type { MentionSuggestion, MentionToken } from './mentions/index.js'
 
 	interface Props {
@@ -101,7 +100,7 @@
 							}}
 						/>
 					{:else if secondary === 'skill-meta' && token.skill?.character}
-						<span class="item-meta">{localizedName(token.skill.character.name)}</span>
+						<span class="item-meta">{skillMentionSubheader(token)}</span>
 					{/if}
 				</div>
 			</button>

--- a/src/lib/components/edra/extensions/entity-mention/index.ts
+++ b/src/lib/components/edra/extensions/entity-mention/index.ts
@@ -1,3 +1,5 @@
 export { EntityMention } from './EntityMention.js'
 export { createEntityMentionSuggestion } from './suggestion.js'
-export type { EntityMentionData } from './EntityMentionList.svelte'
+export type { MentionToken, MentionSuggestion, MentionType } from './mentions/index.js'
+/** @deprecated Use {@link MentionToken} instead. Kept for backwards-compatible imports. */
+export type { MentionToken as EntityMentionData } from './mentions/index.js'

--- a/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/helpers.test.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/helpers.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import { getBasePath } from '$lib/utils/images'
+import {
+	elementSlug,
+	squareImageUrl,
+	typeColorSwatch,
+	mentionImageUrl,
+	mentionHref,
+	mentionChipAttrs
+} from '../helpers'
+import type { MentionToken } from '../types'
+
+const base = getBasePath()
+
+function characterToken(overrides: Partial<MentionToken> = {}): MentionToken {
+	return {
+		type: 'character',
+		granblue_id: '3040001000',
+		name: { en: 'Percival', ja: 'パーシヴァル' },
+		element: { id: 2, slug: 'fire' },
+		...overrides
+	}
+}
+
+function skillToken(overrides: Partial<MentionToken['skill']> = {}): MentionToken {
+	return {
+		type: 'skill',
+		granblue_id: 'skill-1',
+		name: { en: 'Lord of Flames', ja: '焔の貴公子' },
+		skill: {
+			description: { en: 'Big fire damage.', ja: '' },
+			gameIcon: '625_4',
+			typeColor: 'damage',
+			...overrides
+		}
+	}
+}
+
+describe('elementSlug', () => {
+	it('reads the slug from an object element', () => {
+		expect(elementSlug({ id: 2, slug: 'fire' })).toBe('fire')
+	})
+	it('maps a numeric element id to its slug', () => {
+		expect(elementSlug(2)).toBe('fire')
+		expect(elementSlug(0)).toBe('null')
+	})
+	it('falls back to null for unknown / missing values', () => {
+		expect(elementSlug(undefined)).toBe('null')
+		expect(elementSlug(null)).toBe('null')
+		expect(elementSlug(99)).toBe('null')
+		expect(elementSlug('fire')).toBe('null')
+	})
+})
+
+describe('squareImageUrl', () => {
+	it('builds the character portrait with the _01 suffix', () => {
+		expect(squareImageUrl('character', '3040001000')).toBe(
+			`${base}/character-square/3040001000_01.jpg`
+		)
+	})
+	it('builds weapon and summon square URLs', () => {
+		expect(squareImageUrl('weapon', '1040001000')).toBe(`${base}/weapon-square/1040001000.jpg`)
+		expect(squareImageUrl('summon', '2040001000')).toBe(`${base}/summon-square/2040001000.jpg`)
+	})
+	it('returns null for skills', () => {
+		expect(squareImageUrl('skill', 'skill-1')).toBeNull()
+	})
+})
+
+describe('typeColorSwatch', () => {
+	it('maps known type colors to hex', () => {
+		expect(typeColorSwatch('damage')).toBe('#d64545')
+		expect(typeColorSwatch('buff')).toBe('#e0a93b')
+	})
+	it('returns null for unknown / missing colors', () => {
+		expect(typeColorSwatch(null)).toBeNull()
+		expect(typeColorSwatch(undefined)).toBeNull()
+		expect(typeColorSwatch('rainbow')).toBeNull()
+	})
+})
+
+describe('mentionImageUrl', () => {
+	it('returns the square portrait for entities', () => {
+		expect(mentionImageUrl(characterToken())).toBe(`${base}/character-square/3040001000_01.jpg`)
+	})
+	it('returns the ability icon for a skill with a game icon', () => {
+		expect(mentionImageUrl(skillToken())).toBe(`${base}/ability-icons/625_4.png`)
+	})
+	it('returns null for a skill without a game icon', () => {
+		expect(mentionImageUrl(skillToken({ gameIcon: null }))).toBeNull()
+	})
+})
+
+describe('mentionHref', () => {
+	it('links entities to gbf.wiki by English name', () => {
+		expect(mentionHref(characterToken())).toBe('https://gbf.wiki/Percival')
+	})
+	it('encodes special characters in the wiki name', () => {
+		expect(mentionHref(characterToken({ name: { en: 'Sandalphon (Summer)', ja: '' } }))).toBe(
+			'https://gbf.wiki/Sandalphon%20(Summer)'
+		)
+	})
+	it('returns null for skills (no wiki page)', () => {
+		expect(mentionHref(skillToken())).toBeNull()
+	})
+	it('returns null for entities without an English name', () => {
+		expect(mentionHref(characterToken({ name: { en: '', ja: 'x' } }))).toBeNull()
+	})
+})
+
+describe('mentionChipAttrs', () => {
+	it('emits type/element/entity-type for entities, no skill color', () => {
+		expect(mentionChipAttrs(characterToken())).toEqual({
+			'data-type': 'mention',
+			'data-element': 'fire',
+			'data-entity-type': 'character'
+		})
+	})
+	it('adds data-skill-color for skills with a type color', () => {
+		expect(mentionChipAttrs(skillToken())).toEqual({
+			'data-type': 'mention',
+			'data-element': 'null',
+			'data-entity-type': 'skill',
+			'data-skill-color': 'damage'
+		})
+	})
+	it('omits data-skill-color when a skill has no type color', () => {
+		expect(mentionChipAttrs(skillToken({ typeColor: null }))).not.toHaveProperty('data-skill-color')
+	})
+})

--- a/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/helpers.test.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/helpers.test.ts
@@ -6,7 +6,8 @@ import {
 	typeColorSwatch,
 	mentionImageUrl,
 	mentionHref,
-	mentionChipAttrs
+	mentionChipAttrs,
+	skillMentionSubheader
 } from '../helpers'
 import type { MentionToken } from '../types'
 
@@ -126,5 +127,28 @@ describe('mentionChipAttrs', () => {
 	})
 	it('omits data-skill-color when a skill has no type color', () => {
 		expect(mentionChipAttrs(skillToken({ typeColor: null }))).not.toHaveProperty('data-skill-color')
+	})
+})
+
+describe('skillMentionSubheader', () => {
+	const character = { granblue_id: '3040001000', name: { en: 'Octavia', ja: 'オクタヴィア' } }
+
+	it('appends the slot number for active (ability) skills', () => {
+		expect(
+			skillMentionSubheader(skillToken({ slotKind: 'ability', slotPosition: 2, character }))
+		).toBe('Octavia 2')
+	})
+
+	it('shows just the character name for CAs and support skills', () => {
+		expect(
+			skillMentionSubheader(skillToken({ slotKind: 'ougi', slotPosition: 1, character }))
+		).toBe('Octavia')
+		expect(
+			skillMentionSubheader(skillToken({ slotKind: 'support', slotPosition: 1, character }))
+		).toBe('Octavia')
+	})
+
+	it('returns an empty string for non-skill tokens', () => {
+		expect(skillMentionSubheader(characterToken())).toBe('')
 	})
 })

--- a/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/normalize.test.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/normalize.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { getBasePath } from '$lib/utils/images'
+import type { UnifiedSearchResult } from '$lib/api/adapters/search.adapter'
+import type { CharacterSkillVersion } from '$lib/types/api/entities'
+import { entityResultToSuggestion, skillToSuggestion } from '../normalize'
+
+const base = getBasePath()
+
+describe('entityResultToSuggestion', () => {
+	it('maps a character search result into a suggestion (parity with the old selectItem)', () => {
+		const result: UnifiedSearchResult = {
+			searchableId: 'abc-123',
+			searchableType: 'Character',
+			granblueId: '3040001000',
+			nameEn: 'Percival',
+			nameJp: 'パーシヴァル',
+			element: 2,
+			season: null,
+			series: [{ id: 's1', slug: 'standard', name: { en: 'Standard', ja: '' } }],
+			proficiency: [1, 2],
+			styleSwap: false
+		}
+		const suggestion = entityResultToSuggestion(result)
+		expect(suggestion.key).toBe('character:abc-123')
+		expect(suggestion.token.type).toBe('character')
+		expect(suggestion.token.granblue_id).toBe('3040001000')
+		expect(suggestion.token.element).toEqual({ id: 2, slug: 'fire' })
+		expect(suggestion.token.proficiency).toEqual([1, 2])
+		expect(suggestion.imageUrl).toBe(`${base}/character-square/3040001000_01.jpg`)
+		expect(suggestion.primaryLabel).toBe('Percival')
+		expect(suggestion.elementSlug).toBe('fire')
+	})
+
+	it('maps a weapon result to its square image and weapon type', () => {
+		const result: UnifiedSearchResult = {
+			searchableId: 'w-1',
+			searchableType: 'Weapon',
+			granblueId: '1040001000',
+			nameEn: 'Sword',
+			element: 3,
+			proficiency: 1
+		}
+		const suggestion = entityResultToSuggestion(result)
+		expect(suggestion.token.type).toBe('weapon')
+		expect(suggestion.imageUrl).toBe(`${base}/weapon-square/1040001000.jpg`)
+	})
+})
+
+function version(overrides: Partial<CharacterSkillVersion> = {}): CharacterSkillVersion {
+	return {
+		id: 'v1',
+		name: { en: 'Lord of Flames', ja: '焔の貴公子' },
+		description: { en: 'Big fire damage.', ja: '炎ダメージ' },
+		variantRole: 'base',
+		ordinal: 1,
+		typeColor: 'damage',
+		gameIcon: '625_4',
+		...overrides
+	}
+}
+
+describe('skillToSuggestion', () => {
+	const character = { granblue_id: '3040001000', name: { en: 'Percival', ja: 'パーシヴァル' } }
+
+	it('builds a skill token attributed to its character', () => {
+		const suggestion = skillToSuggestion(version(), 'ability', character)
+		expect(suggestion.key).toBe('skill:3040001000:Lord of Flames')
+		expect(suggestion.token.type).toBe('skill')
+		expect(suggestion.token.skill).toMatchObject({
+			slotKind: 'ability',
+			typeColor: 'damage',
+			character
+		})
+		expect(suggestion.imageUrl).toBe(`${base}/ability-icons/625_4.png`)
+		expect(suggestion.swatchColor).toBeNull()
+		expect(suggestion.primaryLabel).toBe('Lord of Flames')
+	})
+
+	it('falls back to a type-color swatch when the version has no game icon', () => {
+		const suggestion = skillToSuggestion(version({ gameIcon: null }), 'ougi', character)
+		expect(suggestion.imageUrl).toBeNull()
+		expect(suggestion.swatchColor).toBe('#d64545')
+	})
+})

--- a/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/normalize.test.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/normalize.test.ts
@@ -62,12 +62,13 @@ function version(overrides: Partial<CharacterSkillVersion> = {}): CharacterSkill
 describe('skillToSuggestion', () => {
 	const character = { granblue_id: '3040001000', name: { en: 'Percival', ja: 'パーシヴァル' } }
 
-	it('builds a skill token attributed to its character', () => {
-		const suggestion = skillToSuggestion(version(), 'ability', character)
+	it('builds a skill token attributed to its character + slot', () => {
+		const suggestion = skillToSuggestion(version(), { kind: 'ability', position: 2 }, character)
 		expect(suggestion.key).toBe('skill:3040001000:Lord of Flames')
 		expect(suggestion.token.type).toBe('skill')
 		expect(suggestion.token.skill).toMatchObject({
 			slotKind: 'ability',
+			slotPosition: 2,
 			typeColor: 'damage',
 			character
 		})
@@ -77,7 +78,11 @@ describe('skillToSuggestion', () => {
 	})
 
 	it('falls back to a type-color swatch when the version has no game icon', () => {
-		const suggestion = skillToSuggestion(version({ gameIcon: null }), 'ougi', character)
+		const suggestion = skillToSuggestion(
+			version({ gameIcon: null }),
+			{ kind: 'ougi', position: 1 },
+			character
+		)
 		expect(suggestion.imageUrl).toBeNull()
 		expect(suggestion.swatchColor).toBe('#d64545')
 	})

--- a/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/skillMentions.test.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/skillMentions.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import type { Character, CharacterSkill, CharacterSkillVersion } from '$lib/types/api/entities'
+import type { GridCharacter } from '$lib/types/api/party'
+import { buildPartySkillMentions, matchSkills } from '../skillMentions'
+
+function version(nameEn: string, opts: Partial<CharacterSkillVersion> = {}): CharacterSkillVersion {
+	return {
+		id: nameEn,
+		name: { en: nameEn, ja: nameEn },
+		description: { en: '', ja: '' },
+		variantRole: 'base',
+		ordinal: 1,
+		...opts
+	} as CharacterSkillVersion
+}
+
+function slot(kind: string, position: number, versions: CharacterSkillVersion[]): CharacterSkill {
+	return { kind, position, versions }
+}
+
+function gridChar(granblueId: string, nameEn: string, skills: CharacterSkill[]): GridCharacter {
+	return {
+		character: {
+			granblueId,
+			name: { en: nameEn, ja: nameEn },
+			skills
+		} as Character
+	} as GridCharacter
+}
+
+describe('buildPartySkillMentions', () => {
+	it('returns an empty list for an empty party or characters without skills', () => {
+		expect(buildPartySkillMentions([])).toEqual([])
+		expect(buildPartySkillMentions([gridChar('1', 'Lyria', [])])).toEqual([])
+	})
+
+	it('picks the base version, else the lowest-ordinal version, per slot', () => {
+		const character = gridChar('1', 'Percival', [
+			slot('ability', 1, [
+				version('Enhanced', { variantRole: 'enhanced', ordinal: 2 }),
+				version('Base Skill', { variantRole: 'base', ordinal: 1 })
+			]),
+			slot('ability', 2, [
+				version('Second', { variantRole: 'enhanced', ordinal: 3 }),
+				version('First', { variantRole: 'enhanced', ordinal: 1 })
+			])
+		])
+		const names = buildPartySkillMentions([character]).map((s) => s.token.name.en)
+		expect(names).toEqual(['Base Skill', 'First'])
+	})
+
+	it('includes all slot kinds (ability, ougi, support)', () => {
+		const character = gridChar('1', 'Percival', [
+			slot('ability', 1, [version('Ability')]),
+			slot('ougi', 1, [version('Ougi')]),
+			slot('support', 1, [version('Support')])
+		])
+		expect(buildPartySkillMentions([character]).map((s) => s.token.name.en)).toEqual([
+			'Ability',
+			'Ougi',
+			'Support'
+		])
+	})
+
+	it('dedupes same-named skills within one character', () => {
+		const character = gridChar('1', 'Percival', [
+			slot('ability', 1, [version('Twin Skill')]),
+			slot('ability', 2, [version('Twin Skill')])
+		])
+		expect(buildPartySkillMentions([character])).toHaveLength(1)
+	})
+
+	it('keeps same-named skills on different characters as separate rows', () => {
+		const a = gridChar('1', 'Percival', [slot('ability', 1, [version('Shared')])])
+		const b = gridChar('2', 'Lancelot', [slot('ability', 1, [version('Shared')])])
+		const result = buildPartySkillMentions([a, b])
+		expect(result).toHaveLength(2)
+		expect(result.map((s) => s.token.skill?.character?.granblue_id)).toEqual(['1', '2'])
+	})
+})
+
+describe('matchSkills', () => {
+	const party = [
+		gridChar('1', 'Percival', [slot('ability', 1, [version('Lord of Flames')])]),
+		gridChar('2', 'Lancelot', [slot('ability', 1, [version('White Dragon')])])
+	]
+	const suggestions = buildPartySkillMentions(party)
+
+	it('matches by skill name (EN, case-insensitive substring)', () => {
+		expect(matchSkills(suggestions, 'flam').map((s) => s.token.name.en)).toEqual(['Lord of Flames'])
+	})
+
+	it('matches by owning character name', () => {
+		expect(matchSkills(suggestions, 'lancel').map((s) => s.token.name.en)).toEqual(['White Dragon'])
+	})
+
+	it('matches by Japanese name', () => {
+		const jp = buildPartySkillMentions([
+			gridChar('1', 'Percival', [
+				slot('ability', 1, [
+					{
+						id: 'x',
+						name: { en: 'Lord of Flames', ja: '焔の貴公子' },
+						description: { en: '', ja: '' },
+						variantRole: 'base',
+						ordinal: 1
+					} as CharacterSkillVersion
+				])
+			])
+		])
+		expect(matchSkills(jp, '焔').map((s) => s.token.name.en)).toEqual(['Lord of Flames'])
+	})
+
+	it('returns nothing for an empty query', () => {
+		expect(matchSkills(suggestions, '   ')).toEqual([])
+	})
+
+	it('caps the number of results', () => {
+		const many = buildPartySkillMentions([
+			gridChar(
+				'1',
+				'Percival',
+				Array.from({ length: 10 }, (_, i) => slot('ability', i, [version(`Flame Skill ${i}`)]))
+			)
+		])
+		expect(matchSkills(many, 'flame').length).toBe(5)
+	})
+})

--- a/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/skillMentions.test.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/skillMentions.test.ts
@@ -49,17 +49,27 @@ describe('buildPartySkillMentions', () => {
 		expect(names).toEqual(['Base Skill', 'First'])
 	})
 
-	it('includes all slot kinds (ability, ougi, support)', () => {
+	it('orders slots active → CA → support, then by position, regardless of input order', () => {
 		const character = gridChar('1', 'Percival', [
-			slot('ability', 1, [version('Ability')]),
+			slot('support', 1, [version('Support')]),
 			slot('ougi', 1, [version('Ougi')]),
-			slot('support', 1, [version('Support')])
+			slot('ability', 2, [version('Ability 2')]),
+			slot('ability', 1, [version('Ability 1')])
 		])
 		expect(buildPartySkillMentions([character]).map((s) => s.token.name.en)).toEqual([
-			'Ability',
+			'Ability 1',
+			'Ability 2',
 			'Ougi',
 			'Support'
 		])
+	})
+
+	it('records the slot kind and position on each skill token', () => {
+		const character = gridChar('1', 'Percival', [slot('ability', 3, [version('Third')])])
+		const suggestions = buildPartySkillMentions([character])
+		expect(suggestions).toHaveLength(1)
+		expect(suggestions[0]?.token.skill?.slotKind).toBe('ability')
+		expect(suggestions[0]?.token.skill?.slotPosition).toBe(3)
 	})
 
 	it('dedupes same-named skills within one character', () => {
@@ -115,14 +125,14 @@ describe('matchSkills', () => {
 		expect(matchSkills(suggestions, '   ')).toEqual([])
 	})
 
-	it('caps the number of results', () => {
+	it('returns every match (no per-skill cap) so all of a character’s skills stay visible', () => {
 		const many = buildPartySkillMentions([
 			gridChar(
 				'1',
 				'Percival',
-				Array.from({ length: 10 }, (_, i) => slot('ability', i, [version(`Flame Skill ${i}`)]))
+				Array.from({ length: 10 }, (_, i) => slot('ability', i + 1, [version(`Flame Skill ${i}`)]))
 			)
 		])
-		expect(matchSkills(many, 'flame').length).toBe(5)
+		expect(matchSkills(many, 'flame').length).toBe(10)
 	})
 })

--- a/src/lib/components/edra/extensions/entity-mention/mentions/helpers.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/helpers.ts
@@ -1,0 +1,76 @@
+import { getBasePath, getCharacterSkillIcon } from '$lib/utils/images'
+import type { MentionToken } from './types'
+
+/** Element ID → slug. The single copy (previously duplicated in EntityMention + EntityMentionList). */
+const ELEMENT_SLUGS: Record<number, string> = {
+	0: 'null',
+	1: 'wind',
+	2: 'fire',
+	3: 'water',
+	4: 'earth',
+	5: 'dark',
+	6: 'light'
+}
+
+/** Type color → swatch CSS, matching the Skills tab / Full Auto chips. */
+const TYPE_COLOR_CSS: Record<string, string> = {
+	damage: '#d64545',
+	heal: '#3fa34d',
+	buff: '#e0a93b',
+	debuff: '#4a6fd6',
+	field: '#8b5cf6'
+}
+
+/**
+ * Resolves an element slug from any stored shape: a `{ slug }` object (token),
+ * a numeric element id (search result), or undefined.
+ */
+export function elementSlug(element: unknown): string {
+	if (element === null || element === undefined) return 'null'
+	if (typeof element === 'object' && 'slug' in element) {
+		return (element as { slug: string }).slug
+	}
+	if (typeof element === 'number') return ELEMENT_SLUGS[element] ?? 'null'
+	return 'null'
+}
+
+/** Square portrait URL for an entity mention; null for skills (they use an icon instead). */
+export function squareImageUrl(type: string, granblueId: string): string | null {
+	const base = getBasePath()
+	if (type === 'character') return `${base}/character-square/${granblueId}_01.jpg`
+	if (type === 'weapon' || type === 'summon') return `${base}/${type}-square/${granblueId}.jpg`
+	return null
+}
+
+/** Swatch background for a skill type color, or null when the color is unknown. */
+export function typeColorSwatch(typeColor: string | null | undefined): string | null {
+	if (!typeColor) return null
+	return TYPE_COLOR_CSS[typeColor] ?? null
+}
+
+/** Thumbnail for a mention token: skill icon for skills, square portrait otherwise. */
+export function mentionImageUrl(token: MentionToken): string | null {
+	if (token.type === 'skill') return getCharacterSkillIcon(token.skill?.gameIcon)
+	return squareImageUrl(token.type, token.granblue_id)
+}
+
+/** gbf.wiki link for a mention, or null when it should not link (skills have no wiki page). */
+export function mentionHref(token: MentionToken): string | null {
+	if (token.type === 'skill') return null
+	const wikiName = token.name?.en
+	if (!wikiName) return null
+	return `https://gbf.wiki/${encodeURIComponent(wikiName)}`
+}
+
+/** The shared `data-*` chip attributes for both the editor node and the read-only renderer. */
+export function mentionChipAttrs(token: MentionToken): Record<string, string> {
+	const attrs: Record<string, string> = {
+		'data-type': 'mention',
+		'data-element': elementSlug(token.element),
+		'data-entity-type': token.type
+	}
+	if (token.type === 'skill' && token.skill?.typeColor) {
+		attrs['data-skill-color'] = token.skill.typeColor
+	}
+	return attrs
+}

--- a/src/lib/components/edra/extensions/entity-mention/mentions/helpers.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/helpers.ts
@@ -1,4 +1,5 @@
 import { getBasePath, getCharacterSkillIcon } from '$lib/utils/images'
+import { localizedName } from '$lib/utils/locale'
 import type { MentionToken } from './types'
 
 /** Element ID → slug. The single copy (previously duplicated in EntityMention + EntityMentionList). */
@@ -60,6 +61,21 @@ export function mentionHref(token: MentionToken): string | null {
 	const wikiName = token.name?.en
 	if (!wikiName) return null
 	return `https://gbf.wiki/${encodeURIComponent(wikiName)}`
+}
+
+/**
+ * Attribution subheader for a skill mention: the owning character's name, plus the
+ * slot number for active skills (e.g. "Octavia 2"), which is how players refer to them.
+ * Returns '' for non-skill tokens or skills without an attributed character.
+ */
+export function skillMentionSubheader(token: MentionToken): string {
+	const skill = token.skill
+	if (!skill?.character) return ''
+	const characterName = localizedName(skill.character.name)
+	if (skill.slotKind === 'ability' && skill.slotPosition) {
+		return `${characterName} ${skill.slotPosition}`
+	}
+	return characterName
 }
 
 /** The shared `data-*` chip attributes for both the editor node and the read-only renderer. */

--- a/src/lib/components/edra/extensions/entity-mention/mentions/index.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/index.ts
@@ -1,0 +1,13 @@
+export type { MentionType, MentionToken, MentionSuggestion } from './types'
+export {
+	elementSlug,
+	squareImageUrl,
+	typeColorSwatch,
+	mentionImageUrl,
+	mentionHref,
+	mentionChipAttrs
+} from './helpers'
+export { mentionDescriptors, descriptorFor } from './registry'
+export type { MentionDescriptor, MentionSecondary } from './registry'
+export { entityResultToSuggestion, skillToSuggestion } from './normalize'
+export { buildPartySkillMentions, matchSkills, partySkillMentionsProvider } from './skillMentions'

--- a/src/lib/components/edra/extensions/entity-mention/mentions/index.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/index.ts
@@ -5,7 +5,8 @@ export {
 	typeColorSwatch,
 	mentionImageUrl,
 	mentionHref,
-	mentionChipAttrs
+	mentionChipAttrs,
+	skillMentionSubheader
 } from './helpers'
 export { mentionDescriptors, descriptorFor } from './registry'
 export type { MentionDescriptor, MentionSecondary } from './registry'

--- a/src/lib/components/edra/extensions/entity-mention/mentions/normalize.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/normalize.ts
@@ -1,5 +1,5 @@
 import type { UnifiedSearchResult } from '$lib/api/adapters/search.adapter'
-import type { CharacterSkillVersion, LocalizedName } from '$lib/types/api/entities'
+import type { CharacterSkill, CharacterSkillVersion, LocalizedName } from '$lib/types/api/entities'
 import { elementSlug, mentionImageUrl, typeColorSwatch } from './helpers'
 import type { MentionSuggestion, MentionToken } from './types'
 
@@ -28,7 +28,7 @@ export function entityResultToSuggestion(result: UnifiedSearchResult): MentionSu
 /** Maps a character skill version (one slot) into a dropdown suggestion, attributed to its character. */
 export function skillToSuggestion(
 	version: CharacterSkillVersion,
-	slotKind: string,
+	slot: Pick<CharacterSkill, 'kind' | 'position'>,
 	character: { granblue_id: string; name: LocalizedName }
 ): MentionSuggestion {
 	const token: MentionToken = {
@@ -39,7 +39,8 @@ export function skillToSuggestion(
 			description: { en: version.description?.en ?? '', ja: version.description?.ja ?? '' },
 			gameIcon: version.gameIcon,
 			typeColor: version.typeColor,
-			slotKind,
+			slotKind: slot.kind,
+			slotPosition: slot.position,
 			character
 		}
 	}

--- a/src/lib/components/edra/extensions/entity-mention/mentions/normalize.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/normalize.ts
@@ -1,0 +1,57 @@
+import type { UnifiedSearchResult } from '$lib/api/adapters/search.adapter'
+import type { CharacterSkillVersion, LocalizedName } from '$lib/types/api/entities'
+import { elementSlug, mentionImageUrl, typeColorSwatch } from './helpers'
+import type { MentionSuggestion, MentionToken } from './types'
+
+/** Maps a unified search result into a dropdown suggestion (lifted from the old selectItem). */
+export function entityResultToSuggestion(result: UnifiedSearchResult): MentionSuggestion {
+	const type = result.searchableType.toLowerCase() as MentionToken['type']
+	const token: MentionToken = {
+		type,
+		granblue_id: result.granblueId,
+		name: { en: result.nameEn ?? '', ja: result.nameJp ?? '' },
+		element: { id: result.element ?? 0, slug: elementSlug(result.element) },
+		proficiency: result.proficiency,
+		season: result.season,
+		series: result.series,
+		styleSwap: result.styleSwap
+	}
+	return {
+		key: `${type}:${result.searchableId}`,
+		token,
+		imageUrl: mentionImageUrl(token),
+		primaryLabel: result.nameEn ?? result.nameJp ?? '',
+		elementSlug: token.element!.slug
+	}
+}
+
+/** Maps a character skill version (one slot) into a dropdown suggestion, attributed to its character. */
+export function skillToSuggestion(
+	version: CharacterSkillVersion,
+	slotKind: string,
+	character: { granblue_id: string; name: LocalizedName }
+): MentionSuggestion {
+	const token: MentionToken = {
+		type: 'skill',
+		granblue_id: version.id,
+		name: { en: version.name?.en ?? '', ja: version.name?.ja ?? '' },
+		skill: {
+			description: { en: version.description?.en ?? '', ja: version.description?.ja ?? '' },
+			gameIcon: version.gameIcon,
+			typeColor: version.typeColor,
+			slotKind,
+			character
+		}
+	}
+	const imageUrl = mentionImageUrl(token)
+	return {
+		// Keyed per character + skill name so the same-named skill on a different
+		// character stays a distinct row, but a slot's duplicates collapse.
+		key: `skill:${character.granblue_id}:${token.name.en || token.name.ja}`,
+		token,
+		imageUrl,
+		swatchColor: imageUrl ? null : typeColorSwatch(version.typeColor),
+		primaryLabel: token.name.en || token.name.ja,
+		elementSlug: 'null'
+	}
+}

--- a/src/lib/components/edra/extensions/entity-mention/mentions/registry.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/registry.ts
@@ -1,0 +1,30 @@
+import type { MentionType } from './types'
+
+/** Which secondary content a surface renders under a mention's name. */
+export type MentionSecondary = 'character-tags' | 'skill-meta' | 'none'
+
+export interface MentionDescriptor {
+	type: MentionType
+	/** Whether the read-only renderer wraps the chip in a gbf.wiki link. */
+	links: boolean
+	/** Secondary content (dropdown row + tooltip pick their own layout from this). */
+	secondary: MentionSecondary
+}
+
+export const mentionDescriptors: Record<MentionType, MentionDescriptor> = {
+	character: { type: 'character', links: true, secondary: 'character-tags' },
+	weapon: { type: 'weapon', links: true, secondary: 'none' },
+	summon: { type: 'summon', links: true, secondary: 'none' },
+	skill: { type: 'skill', links: false, secondary: 'skill-meta' }
+}
+
+/** Safe fallback so unknown/legacy token types render as a plain linked chip rather than throwing. */
+const DEFAULT_DESCRIPTOR: MentionDescriptor = {
+	type: 'character',
+	links: true,
+	secondary: 'none'
+}
+
+export function descriptorFor(type: string | undefined): MentionDescriptor {
+	return mentionDescriptors[type as MentionType] ?? DEFAULT_DESCRIPTOR
+}

--- a/src/lib/components/edra/extensions/entity-mention/mentions/skillMentions.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/skillMentions.ts
@@ -1,0 +1,68 @@
+import { partyStore } from '$lib/stores/partyStore.svelte'
+import type { CharacterSkill, CharacterSkillVersion } from '$lib/types/api/entities'
+import type { GridCharacter } from '$lib/types/api/party'
+import { skillToSuggestion } from './normalize'
+import type { MentionSuggestion } from './types'
+
+/** Max skill rows surfaced for a single query. */
+const SKILL_RESULT_CAP = 5
+
+/** The canonical version of a slot: the base variant, else the lowest ordinal. */
+function canonicalVersion(skill: CharacterSkill): CharacterSkillVersion | undefined {
+	return (
+		skill.versions.find((version) => version.variantRole === 'base') ??
+		[...skill.versions].sort((a, b) => a.ordinal - b.ordinal)[0]
+	)
+}
+
+/**
+ * Flattens a party's characters into skill suggestions — one canonical version per
+ * slot, attributed to its character. Duplicates within a character collapse (by key),
+ * but a same-named skill on a different character stays a separate row.
+ */
+export function buildPartySkillMentions(characters: GridCharacter[]): MentionSuggestion[] {
+	const suggestions: MentionSuggestion[] = []
+	const seen = new Set<string>()
+
+	for (const gridCharacter of characters) {
+		const character = gridCharacter.character
+		if (!character?.skills?.length) continue
+
+		const attribution = { granblue_id: character.granblueId, name: character.name }
+		for (const slot of character.skills) {
+			const version = canonicalVersion(slot)
+			if (!version) continue
+
+			const suggestion = skillToSuggestion(version, slot.kind, attribution)
+			if (seen.has(suggestion.key)) continue
+			seen.add(suggestion.key)
+			suggestions.push(suggestion)
+		}
+	}
+
+	return suggestions
+}
+
+/** Filters skill suggestions by query, matching the skill name or its character's name (EN/JA). */
+export function matchSkills(suggestions: MentionSuggestion[], query: string): MentionSuggestion[] {
+	const needle = query.trim().toLowerCase()
+	if (!needle) return []
+
+	return suggestions
+		.filter((suggestion) => {
+			const { name, skill } = suggestion.token
+			const character = skill?.character?.name
+			return (
+				name.en.toLowerCase().includes(needle) ||
+				name.ja.toLowerCase().includes(needle) ||
+				(character?.en.toLowerCase().includes(needle) ?? false) ||
+				(character?.ja.toLowerCase().includes(needle) ?? false)
+			)
+		})
+		.slice(0, SKILL_RESULT_CAP)
+}
+
+/** Default sync provider: party-scoped skill mentions, read straight from the global party store. */
+export function partySkillMentionsProvider(query: string): MentionSuggestion[] {
+	return matchSkills(buildPartySkillMentions(partyStore.party?.characters ?? []), query)
+}

--- a/src/lib/components/edra/extensions/entity-mention/mentions/skillMentions.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/skillMentions.ts
@@ -4,8 +4,9 @@ import type { GridCharacter } from '$lib/types/api/party'
 import { skillToSuggestion } from './normalize'
 import type { MentionSuggestion } from './types'
 
-/** Max skill rows surfaced for a single query. */
-const SKILL_RESULT_CAP = 5
+// Slots are surfaced in the order players refer to them: active skills, then the
+// charge attack (CA / ougi), then support skills.
+const SLOT_KIND_ORDER: Record<string, number> = { ability: 0, ougi: 1, support: 2 }
 
 /** The canonical version of a slot: the base variant, else the lowest ordinal. */
 function canonicalVersion(skill: CharacterSkill): CharacterSkillVersion | undefined {
@@ -15,10 +16,21 @@ function canonicalVersion(skill: CharacterSkill): CharacterSkillVersion | undefi
 	)
 }
 
+/** Sorts a character's slots by kind (ability → ougi → support), then slot position. */
+function orderedSlots(skills: CharacterSkill[]): CharacterSkill[] {
+	return [...skills].sort((a, b) => {
+		const kindA = SLOT_KIND_ORDER[a.kind] ?? 99
+		const kindB = SLOT_KIND_ORDER[b.kind] ?? 99
+		if (kindA !== kindB) return kindA - kindB
+		return a.position - b.position
+	})
+}
+
 /**
  * Flattens a party's characters into skill suggestions — one canonical version per
- * slot, attributed to its character. Duplicates within a character collapse (by key),
- * but a same-named skill on a different character stays a separate row.
+ * slot, attributed to its character, ordered active → CA → support within each
+ * character. Duplicates within a character collapse (by key), but a same-named skill
+ * on a different character stays a separate row.
  */
 export function buildPartySkillMentions(characters: GridCharacter[]): MentionSuggestion[] {
 	const suggestions: MentionSuggestion[] = []
@@ -29,11 +41,11 @@ export function buildPartySkillMentions(characters: GridCharacter[]): MentionSug
 		if (!character?.skills?.length) continue
 
 		const attribution = { granblue_id: character.granblueId, name: character.name }
-		for (const slot of character.skills) {
+		for (const slot of orderedSlots(character.skills)) {
 			const version = canonicalVersion(slot)
 			if (!version) continue
 
-			const suggestion = skillToSuggestion(version, slot.kind, attribution)
+			const suggestion = skillToSuggestion(version, slot, attribution)
 			if (seen.has(suggestion.key)) continue
 			seen.add(suggestion.key)
 			suggestions.push(suggestion)
@@ -43,23 +55,25 @@ export function buildPartySkillMentions(characters: GridCharacter[]): MentionSug
 	return suggestions
 }
 
-/** Filters skill suggestions by query, matching the skill name or its character's name (EN/JA). */
+/**
+ * Filters skill suggestions by query, matching the skill name or its character's name
+ * (EN/JA). Returns every match — once a character's name is typed, narrowing it further
+ * won't reveal different skills, so all of that character's skills should stay visible.
+ */
 export function matchSkills(suggestions: MentionSuggestion[], query: string): MentionSuggestion[] {
 	const needle = query.trim().toLowerCase()
 	if (!needle) return []
 
-	return suggestions
-		.filter((suggestion) => {
-			const { name, skill } = suggestion.token
-			const character = skill?.character?.name
-			return (
-				name.en.toLowerCase().includes(needle) ||
-				name.ja.toLowerCase().includes(needle) ||
-				(character?.en.toLowerCase().includes(needle) ?? false) ||
-				(character?.ja.toLowerCase().includes(needle) ?? false)
-			)
-		})
-		.slice(0, SKILL_RESULT_CAP)
+	return suggestions.filter((suggestion) => {
+		const { name, skill } = suggestion.token
+		const character = skill?.character?.name
+		return (
+			name.en.toLowerCase().includes(needle) ||
+			name.ja.toLowerCase().includes(needle) ||
+			(character?.en.toLowerCase().includes(needle) ?? false) ||
+			(character?.ja.toLowerCase().includes(needle) ?? false)
+		)
+	})
 }
 
 /** Default sync provider: party-scoped skill mentions, read straight from the global party store. */

--- a/src/lib/components/edra/extensions/entity-mention/mentions/types.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/types.ts
@@ -1,0 +1,56 @@
+import type { LocalizedName } from '$lib/types/api/entities'
+import type { UnifiedSearchSeriesRef } from '$lib/api/adapters/search.adapter'
+
+/** Every kind of thing that can be mentioned with `@` in a description / notes field. */
+export type MentionType = 'character' | 'weapon' | 'summon' | 'skill'
+
+/**
+ * The object persisted in a mention node's `data-id` attribute (JSON round-tripped).
+ *
+ * It is a superset of the legacy entity payload and keeps the original `type` field,
+ * so documents saved before skills existed parse with zero migration. Only `type`,
+ * `granblue_id`, and `name` are guaranteed; `element`/`proficiency`/… are entity-only
+ * and `skill` is skill-only.
+ */
+export interface MentionToken {
+	type: MentionType
+	granblue_id: string
+	name: LocalizedName
+
+	// entity-only (character / weapon / summon)
+	element?: { id: number; slug: string }
+	proficiency?: number | number[]
+	season?: number | null
+	series?: number[] | UnifiedSearchSeriesRef[] | null
+	styleSwap?: boolean
+
+	// skill-only
+	skill?: {
+		description: LocalizedName
+		gameIcon?: string | null
+		typeColor?: string | null
+		/** The slot kind this skill came from: 'ability' | 'ougi' | 'support'. */
+		slotKind?: string
+		/** The party character the skill belongs to (for attribution + tooltip). */
+		character?: { granblue_id: string; name: LocalizedName }
+	}
+}
+
+/**
+ * A single row in the `@`-mention dropdown. Presentation is precomputed here so the
+ * list component stays dumb (no per-type branching for images/labels/links).
+ */
+export interface MentionSuggestion {
+	/** Stable identity for `{#each}` keys and cross-provider de-duplication. */
+	key: string
+	/** Exactly what gets committed to the document when this row is selected. */
+	token: MentionToken
+	/** Thumbnail URL, or null to render a colored swatch instead. */
+	imageUrl: string | null
+	/** Swatch background used when `imageUrl` is null (skills without a game icon). */
+	swatchColor?: string | null
+	/** EN-first display label. */
+	primaryLabel: string
+	/** Element accent slug for the row styling. */
+	elementSlug: string
+}

--- a/src/lib/components/edra/extensions/entity-mention/mentions/types.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/types.ts
@@ -31,6 +31,8 @@ export interface MentionToken {
 		typeColor?: string | null
 		/** The slot kind this skill came from: 'ability' | 'ougi' | 'support'. */
 		slotKind?: string
+		/** 1-based slot position; players refer to active skills by it ("Octavia 2"). */
+		slotPosition?: number
 		/** The party character the skill belongs to (for attribution + tooltip). */
 		character?: { granblue_id: string; name: LocalizedName }
 	}

--- a/src/lib/components/edra/extensions/entity-mention/suggestion.ts
+++ b/src/lib/components/edra/extensions/entity-mention/suggestion.ts
@@ -15,8 +15,9 @@ import type { MentionSuggestion, MentionToken } from './mentions/index.js'
 
 /** Require at least this many characters before any provider runs. */
 const MIN_QUERY_LENGTH = 2
-/** Cap on the merged result set across all providers. */
-const TOTAL_RESULT_CAP = 8
+/** Cap on the merged result set across all providers (a character + all its skills
+ * is already ~8 rows, so this is generous; the dropdown scrolls past it). */
+const TOTAL_RESULT_CAP = 25
 
 /** A suggestion source. Sync providers resolve immediately; async ones are awaited together. */
 type SuggestionProvider =
@@ -60,6 +61,44 @@ function dedupe(suggestions: MentionSuggestion[]): MentionSuggestion[] {
 }
 
 /**
+ * Orders the merged list so each character is immediately followed by its own skills
+ * (active → CA → support, already sorted upstream). Typing "@Octavia" therefore shows
+ * Octavia, then her skills. Skills whose character isn't among the entity hits (e.g. a
+ * direct skill-name match) trail at the end, grouped by character.
+ */
+function mergeGroupedByCharacter(
+	entities: MentionSuggestion[],
+	skills: MentionSuggestion[]
+): MentionSuggestion[] {
+	const skillsByCharacter = new Map<string, MentionSuggestion[]>()
+	for (const skill of skills) {
+		const characterId = skill.token.skill?.character?.granblue_id ?? ''
+		const group = skillsByCharacter.get(characterId)
+		if (group) group.push(skill)
+		else skillsByCharacter.set(characterId, [skill])
+	}
+
+	const ordered: MentionSuggestion[] = []
+	const placedCharacters = new Set<string>()
+	for (const entity of entities) {
+		ordered.push(entity)
+		if (entity.token.type !== 'character') continue
+		const characterSkills = skillsByCharacter.get(entity.token.granblue_id)
+		if (characterSkills) {
+			ordered.push(...characterSkills)
+			placedCharacters.add(entity.token.granblue_id)
+		}
+	}
+
+	for (const [characterId, characterSkills] of skillsByCharacter) {
+		if (placedCharacters.has(characterId)) continue
+		ordered.push(...characterSkills)
+	}
+
+	return dedupe(ordered)
+}
+
+/**
  * Creates the suggestion configuration for entity mentions.
  *
  * Providers default to the global entity search + party skill provider; both are
@@ -75,7 +114,6 @@ export function createEntityMentionSuggestion(
 		items: async ({ query }): Promise<MentionSuggestion[]> => {
 			if (query.length < MIN_QUERY_LENGTH) return []
 
-			// Skills (sync) come first so a character's own skills sit above global hits.
 			const sync = providers
 				.filter((provider) => provider.mode === 'sync')
 				.flatMap((provider) => provider.fn(query))
@@ -85,7 +123,10 @@ export function createEntityMentionSuggestion(
 					.map((provider) => provider.fn(query))
 			)
 
-			return dedupe([...sync, ...async.flat()]).slice(0, TOTAL_RESULT_CAP)
+			// Entities lead, each character trailed by its skills; skill-only matches follow.
+			const entities = async.flat()
+			const skills = sync
+			return mergeGroupedByCharacter(entities, skills).slice(0, TOTAL_RESULT_CAP)
 		},
 
 		render: () => {

--- a/src/lib/components/edra/extensions/entity-mention/suggestion.ts
+++ b/src/lib/components/edra/extensions/entity-mention/suggestion.ts
@@ -1,42 +1,91 @@
 /**
  * Entity Mention Suggestion Configuration
  *
- * Configures the Tiptap suggestion plugin for entity mentions.
- * Handles search API calls and renders the dropdown using Svelte.
+ * Configures the Tiptap suggestion plugin for entity mentions. Suggestions come
+ * from a list of providers — an async global entity search plus a sync, party-scoped
+ * skill provider that reads the global party store — so adding a new mention source
+ * is one more provider, not another branch here.
  */
 import type { SuggestionOptions, SuggestionProps, SuggestionKeyDownProps } from '@tiptap/suggestion'
 import { searchAdapter } from '$lib/api/adapters/search.adapter'
-import type { UnifiedSearchResult } from '$lib/api/adapters/search.adapter'
 import { mount, unmount } from 'svelte'
 import EntityMentionList from './EntityMentionList.svelte'
-import type { EntityMentionData } from './EntityMentionList.svelte'
+import { entityResultToSuggestion, partySkillMentionsProvider } from './mentions/index.js'
+import type { MentionSuggestion, MentionToken } from './mentions/index.js'
 
-type MentionItem = UnifiedSearchResult
+/** Require at least this many characters before any provider runs. */
+const MIN_QUERY_LENGTH = 2
+/** Cap on the merged result set across all providers. */
+const TOTAL_RESULT_CAP = 8
+
+/** A suggestion source. Sync providers resolve immediately; async ones are awaited together. */
+type SuggestionProvider =
+	| { mode: 'sync'; fn: (query: string) => MentionSuggestion[] }
+	| { mode: 'async'; fn: (query: string) => Promise<MentionSuggestion[]> }
+
+/** Global character/weapon/summon search via the unified search endpoint. */
+const globalEntityProvider: SuggestionProvider = {
+	mode: 'async',
+	fn: async (query) => {
+		try {
+			const response = await searchAdapter.searchAll({ query, per: 5 })
+			return response.results.map(entityResultToSuggestion)
+		} catch (error) {
+			if (import.meta.env.DEV) {
+				console.error('Entity mention search failed:', error)
+			}
+			return []
+		}
+	}
+}
+
+/** Party-scoped character skills, surfaced by skill name or owning character name. */
+const skillProvider: SuggestionProvider = {
+	mode: 'sync',
+	fn: partySkillMentionsProvider
+}
+
+const DEFAULT_PROVIDERS: SuggestionProvider[] = [skillProvider, globalEntityProvider]
+
+/** De-duplicates merged suggestions by their stable key, preserving order. */
+function dedupe(suggestions: MentionSuggestion[]): MentionSuggestion[] {
+	const seen = new Set<string>()
+	const result: MentionSuggestion[] = []
+	for (const suggestion of suggestions) {
+		if (seen.has(suggestion.key)) continue
+		seen.add(suggestion.key)
+		result.push(suggestion)
+	}
+	return result
+}
 
 /**
- * Creates the suggestion configuration for entity mentions
+ * Creates the suggestion configuration for entity mentions.
+ *
+ * Providers default to the global entity search + party skill provider; both are
+ * harmless in editors without a loaded party (the skill provider just returns []).
  */
-export function createEntityMentionSuggestion(): Omit<SuggestionOptions<MentionItem>, 'editor'> {
+export function createEntityMentionSuggestion(
+	providers: SuggestionProvider[] = DEFAULT_PROVIDERS
+): Omit<SuggestionOptions<MentionSuggestion>, 'editor'> {
 	return {
 		char: '@',
 		allowSpaces: false,
 
-		items: async ({ query }): Promise<MentionItem[]> => {
-			// Require at least 2 characters to search
-			if (query.length < 2) return []
+		items: async ({ query }): Promise<MentionSuggestion[]> => {
+			if (query.length < MIN_QUERY_LENGTH) return []
 
-			try {
-				const response = await searchAdapter.searchAll({
-					query,
-					per: 7
-				})
-				return response.results
-			} catch (error) {
-				if (import.meta.env.DEV) {
-					console.error('Entity mention search failed:', error)
-				}
-				return []
-			}
+			// Skills (sync) come first so a character's own skills sit above global hits.
+			const sync = providers
+				.filter((provider) => provider.mode === 'sync')
+				.flatMap((provider) => provider.fn(query))
+			const async = await Promise.all(
+				providers
+					.filter((provider) => provider.mode === 'async')
+					.map((provider) => provider.fn(query))
+			)
+
+			return dedupe([...sync, ...async.flat()]).slice(0, TOTAL_RESULT_CAP)
 		},
 
 		render: () => {
@@ -44,56 +93,37 @@ export function createEntityMentionSuggestion(): Omit<SuggestionOptions<MentionI
 			let component: ReturnType<typeof mount> | null = null
 			let componentInstance: { onKeyDown: (event: KeyboardEvent) => boolean } | null = null
 
+			const mountList = (props: SuggestionProps<MentionSuggestion>) => {
+				if (!container) return
+				component = mount(EntityMentionList, {
+					target: container,
+					props: {
+						items: props.items,
+						command: (token: MentionToken) => props.command({ id: token }),
+						query: props.query
+					}
+				})
+				componentInstance = component as unknown as {
+					onKeyDown: (event: KeyboardEvent) => boolean
+				}
+			}
+
 			return {
-				onStart: (props: SuggestionProps<MentionItem>) => {
-					// Create container element
+				onStart: (props: SuggestionProps<MentionSuggestion>) => {
 					container = document.createElement('div')
 					container.className = 'entity-mention-popup'
 					document.body.appendChild(container)
 
-					// Mount Svelte component
-					component = mount(EntityMentionList, {
-						target: container,
-						props: {
-							items: props.items,
-							command: (item: EntityMentionData) => {
-								props.command({ id: item })
-							},
-							query: props.query
-						}
-					})
-
-					// Store reference for keyboard handling
-					// The component exports onKeyDown
-					componentInstance = component as unknown as {
-						onKeyDown: (event: KeyboardEvent) => boolean
-					}
-
-					// Position the popup
+					mountList(props)
 					updatePosition(container, props.clientRect)
 				},
 
-				onUpdate: (props: SuggestionProps<MentionItem>) => {
+				onUpdate: (props: SuggestionProps<MentionSuggestion>) => {
 					if (!component || !container) return
 
-					// Update component props - Svelte 5 style
-					// We need to remount with new props since mount() doesn't return reactive props
+					// Svelte 5 mount() props aren't reactive, so remount on each update.
 					unmount(component)
-					component = mount(EntityMentionList, {
-						target: container,
-						props: {
-							items: props.items,
-							command: (item: EntityMentionData) => {
-								props.command({ id: item })
-							},
-							query: props.query
-						}
-					})
-					componentInstance = component as unknown as {
-						onKeyDown: (event: KeyboardEvent) => boolean
-					}
-
-					// Update position
+					mountList(props)
 					updatePosition(container, props.clientRect)
 				},
 
@@ -101,12 +131,9 @@ export function createEntityMentionSuggestion(): Omit<SuggestionOptions<MentionI
 					if (props.event.key === 'Escape') {
 						return true
 					}
-
-					// Delegate to component for arrow/enter handling
 					if (componentInstance?.onKeyDown) {
 						return componentInstance.onKeyDown(props.event)
 					}
-
 					return false
 				},
 

--- a/src/lib/components/sidebar/EditDescriptionPane.svelte
+++ b/src/lib/components/sidebar/EditDescriptionPane.svelte
@@ -8,6 +8,7 @@
 	import EdraEditor from '$lib/components/edra/headless/editor.svelte'
 	import LinkDialog from '$lib/components/edra/LinkDialog.svelte'
 	import MentionTooltip from '$lib/components/ui/MentionTooltip.svelte'
+	import type { MentionToken } from '$lib/components/edra/extensions/entity-mention/mentions/index.js'
 	import { linkDialogState } from '$lib/stores/linkDialog.svelte'
 	import { sidebar } from '$lib/stores/sidebar.svelte'
 	import { usePaneStack } from '$lib/stores/paneStack.svelte'
@@ -135,18 +136,7 @@
 	}
 
 	// Mention tooltip state
-	interface MentionEntity {
-		granblue_id: string
-		name: { en: string; ja: string }
-		type: string
-		element: { id: number; slug: string }
-		proficiency?: number | number[]
-		season?: number | null
-		series?: number[] | { id: string; slug: string; name: { en: string; ja: string } }[] | null
-		styleSwap?: boolean
-	}
-
-	let tooltipEntity: MentionEntity | null = $state(null)
+	let tooltipEntity: MentionToken | null = $state(null)
 	let tooltipVisible = $state(false)
 	let tooltipEl: HTMLDivElement | null = $state(null)
 
@@ -186,14 +176,15 @@
 		if (!attrs) return
 
 		tooltipEntity = {
+			type: attrs.type ?? attrs.searchableType?.toLowerCase() ?? 'unknown',
 			granblue_id: attrs.granblue_id ?? '',
 			name: attrs.name ?? { en: 'Unknown', ja: 'Unknown' },
-			type: attrs.type ?? '',
-			element: attrs.element ?? { id: 0, slug: 'null' },
+			element: attrs.element,
 			proficiency: attrs.proficiency,
 			season: attrs.season,
 			series: attrs.series,
-			styleSwap: attrs.styleSwap
+			styleSwap: attrs.styleSwap,
+			skill: attrs.skill
 		}
 		tooltipVisible = true
 

--- a/src/lib/components/ui/MentionTooltip.svelte
+++ b/src/lib/components/ui/MentionTooltip.svelte
@@ -1,34 +1,24 @@
 <script lang="ts">
-	import { getBasePath } from '$lib/utils/images'
 	import { localizedName } from '$lib/utils/locale'
 	import ProficiencyLabel from '$lib/components/labels/ProficiencyLabel.svelte'
 	import CharacterTags from '$lib/components/tags/CharacterTags.svelte'
-
-	interface MentionEntity {
-		granblue_id: string
-		name: { en: string; ja: string }
-		type: string
-		element: { id: number; [key: string]: unknown }
-		proficiency?: number | number[]
-		season?: number | null
-		series?: number[] | { id: string; slug: string; name: { en: string; ja: string } }[] | null
-		styleSwap?: boolean
-	}
+	import {
+		descriptorFor,
+		mentionImageUrl,
+		typeColorSwatch
+	} from '$lib/components/edra/extensions/entity-mention/mentions/index.js'
+	import type { MentionToken } from '$lib/components/edra/extensions/entity-mention/mentions/index.js'
 
 	interface Props {
-		entity: MentionEntity
+		entity: MentionToken
 		visible: boolean
 	}
 
 	let { entity, visible }: Props = $props()
 
-	const imageUrl = $derived.by(() => {
-		const base = getBasePath()
-		if (entity.type === 'character') {
-			return `${base}/character-square/${entity.granblue_id}_01.jpg`
-		}
-		return `${base}/${entity.type}-square/${entity.granblue_id}.jpg`
-	})
+	const imageUrl = $derived(mentionImageUrl(entity))
+	const swatchColor = $derived(typeColorSwatch(entity.skill?.typeColor))
+	const secondary = $derived(descriptorFor(entity.type).secondary)
 
 	const proficiencies = $derived.by(() => {
 		if (entity.proficiency === undefined || entity.proficiency === null) return []
@@ -36,24 +26,37 @@
 		return entity.proficiency > 0 ? [entity.proficiency] : []
 	})
 
-	const isCharacter = $derived(entity.type === 'character')
+	const skillDescription = $derived(entity.skill ? localizedName(entity.skill.description) : '')
 	const hasProficiencies = $derived(proficiencies.length > 0)
 </script>
 
 {#if visible}
-	<div class="mention-tooltip">
-		<img class="entity-image" src={imageUrl} alt="" loading="lazy" />
+	<div class="mention-tooltip" class:is-skill={secondary === 'skill-meta'}>
+		<div class="entity-image {entity.type}">
+			{#if imageUrl}
+				<img src={imageUrl} alt="" loading="lazy" />
+			{:else}
+				<span class="entity-swatch" style:background={swatchColor ?? 'var(--border-color)'}></span>
+			{/if}
+		</div>
 		<div class="entity-info">
 			<span class="entity-name">{localizedName(entity.name)}</span>
-			{#if isCharacter}
+			{#if secondary === 'character-tags'}
 				<CharacterTags
 					character={{
-						element: entity.element.id,
+						element: entity.element?.id,
 						season: entity.season,
 						series: entity.series,
 						styleSwap: entity.styleSwap
 					}}
 				/>
+			{:else if secondary === 'skill-meta'}
+				{#if entity.skill?.character}
+					<span class="skill-owner">{localizedName(entity.skill.character.name)}</span>
+				{/if}
+				{#if skillDescription && skillDescription !== '—'}
+					<p class="skill-description">{skillDescription}</p>
+				{/if}
 			{/if}
 			{#if hasProficiencies}
 				<div class="proficiencies">
@@ -83,14 +86,35 @@
 		border-radius: $item-corner;
 		z-index: effects.$z-notification;
 		box-shadow: var(--shadow-md);
+
+		&.is-skill {
+			max-width: 280px;
+		}
 	}
 
 	.entity-image {
 		width: 60px;
 		height: 60px;
 		border-radius: $item-corner-small;
-		object-fit: cover;
+		overflow: hidden;
 		flex-shrink: 0;
+
+		img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+
+		// Skill icons are transparent PNGs; show them whole.
+		&.skill img {
+			object-fit: contain;
+		}
+	}
+
+	.entity-swatch {
+		display: block;
+		width: 100%;
+		height: 100%;
 	}
 
 	.entity-info {
@@ -104,6 +128,20 @@
 		font-size: $font-regular;
 		font-weight: $medium;
 		white-space: nowrap;
+	}
+
+	.skill-owner {
+		font-size: $font-small;
+		color: var(--tooltip-text, white);
+		opacity: 0.7;
+	}
+
+	.skill-description {
+		margin: 0;
+		font-size: $font-small;
+		line-height: 1.4;
+		white-space: normal;
+		opacity: 0.9;
 	}
 
 	.proficiencies {

--- a/src/lib/components/ui/MentionTooltip.svelte
+++ b/src/lib/components/ui/MentionTooltip.svelte
@@ -5,6 +5,7 @@
 	import {
 		descriptorFor,
 		mentionImageUrl,
+		skillMentionSubheader,
 		typeColorSwatch
 	} from '$lib/components/edra/extensions/entity-mention/mentions/index.js'
 	import type { MentionToken } from '$lib/components/edra/extensions/entity-mention/mentions/index.js'
@@ -52,7 +53,7 @@
 				/>
 			{:else if secondary === 'skill-meta'}
 				{#if entity.skill?.character}
-					<span class="skill-owner">{localizedName(entity.skill.character.name)}</span>
+					<span class="skill-owner">{skillMentionSubheader(entity)}</span>
 				{/if}
 				{#if skillDescription && skillDescription !== '—'}
 					<p class="skill-description">{skillDescription}</p>


### PR DESCRIPTION
## Summary

Lets users `@`-mention a party character's **skills** in the party description and per-grid-item notes, alongside the existing character/weapon/summon mentions. A skill surfaces by typing its **name** or the **owning character's name**, scoped to the active party. Selecting it inserts a type-color-tinted chip with a hover tooltip showing the skill description (no wiki link — skills have no wiki page).

Rather than bolt `if type === 'skill'` onto five surfaces, this refactors the mention extension around a normalized model + a thin per-type registry, collapsing logic that was previously duplicated (`getElementSlug` ×2, the square-image URL ×3, a per-type branch in each surface).

## What changed

**New `entity-mention/mentions/` module** (single source of truth):
- `types.ts` — `MentionToken` (persisted node payload; superset of the legacy shape, keeps the existing `type` field → **no migration**) and `MentionSuggestion` (precomputed dropdown row).
- `helpers.ts` — the de-duplicated `elementSlug`, `squareImageUrl`, `typeColorSwatch`, `mentionImageUrl`, `mentionHref` (null for skills), `mentionChipAttrs`.
- `registry.ts` — per-type descriptor (`links` + `secondary`) with a safe fallback for unknown/legacy types.
- `normalize.ts` — `entityResultToSuggestion` (lifted from the old `selectItem`) + `skillToSuggestion`.
- `skillMentions.ts` — `buildPartySkillMentions` / `matchSkills` / `partySkillMentionsProvider`.

**5 surfaces rewritten to consume the module** — `suggestion.ts` (provider list: global entity search + party-skill provider), `EntityMentionList`, `EntityMention` node, `DescriptionRenderer` (skills render as a non-linking `<span>`), `MentionTooltip` (skill description body); `EditDescriptionPane` passes `skill` through. Editor + renderer get type-color chip CSS.

**Zero prop threading** — the skill provider is a default that reads `partyStore`, which `Party.svelte` already syncs with the full party (incl. `character.skills`). `editor.ts` and the editor/pane wiring are untouched.

## Back-compat
- Existing mentions already carry `type`; reused as-is → no migration. Old saved descriptions render identically (links intact).
- `descriptorFor` falls back safely so unknown/legacy token types never throw.

## Testing
- 32 new unit tests (helpers, normalize, skillMentions) pass.
- `npm run check`, eslint, prettier clean on changed files.
- Manual: typeahead surfaces skills by skill/character name; chip tints by type color; hover shows description; save/reload persists; legacy entity mentions still link.