### PR TITLE
Skill mention tooltip: lockup layout + chunked descriptions

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1489,6 +1489,8 @@
 	"mention_unknown": "Unknown",
 	"mention_search_hint": "Type at least 2 characters to search",
 	"mention_no_results": "No results found",
+	"mention_skill_cooldown": "Cooldown {n}T",
+	"mention_skill_available_in": "Available in {n}T",
 
 	"modifier_unknown": "Unknown +{strength}",
 

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1471,6 +1471,8 @@
 	"mention_unknown": "不明",
 	"mention_search_hint": "2文字以上入力して検索",
 	"mention_no_results": "結果が見つかりません",
+	"mention_skill_cooldown": "使用間隔{n}T",
+	"mention_skill_available_in": "使用可能まで{n}T",
 
 	"modifier_unknown": "不明 +{strength}",
 

--- a/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/helpers.test.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/helpers.test.ts
@@ -7,7 +7,8 @@ import {
 	mentionImageUrl,
 	mentionHref,
 	mentionChipAttrs,
-	skillMentionSubheader
+	skillMentionSubheader,
+	skillDescriptionLines
 } from '../helpers'
 import type { MentionToken } from '../types'
 
@@ -150,5 +151,29 @@ describe('skillMentionSubheader', () => {
 
 	it('returns an empty string for non-skill tokens', () => {
 		expect(skillMentionSubheader(characterToken())).toBe('')
+	})
+})
+
+describe('skillDescriptionLines', () => {
+	it('splits a multi-effect description on newlines', () => {
+		expect(skillDescriptionLines('Deal damage.\nGain a buff.')).toEqual([
+			'Deal damage.',
+			'Gain a buff.'
+		])
+	})
+
+	it('normalizes stray <br> literals (including the malformed "<br/ >")', () => {
+		expect(skillDescriptionLines('At end of turn:<br/ >Consume charge.')).toEqual([
+			'At end of turn:',
+			'Consume charge.'
+		])
+	})
+
+	it('trims lines and drops blank ones', () => {
+		expect(skillDescriptionLines('  One \n\n  Two  \n')).toEqual(['One', 'Two'])
+	})
+
+	it('returns an empty array for an empty description', () => {
+		expect(skillDescriptionLines('')).toEqual([])
 	})
 })

--- a/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/normalize.test.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/normalize.test.ts
@@ -55,6 +55,8 @@ function version(overrides: Partial<CharacterSkillVersion> = {}): CharacterSkill
 		ordinal: 1,
 		typeColor: 'damage',
 		gameIcon: '625_4',
+		cooldown: 8,
+		initialCooldown: 3,
 		...overrides
 	}
 }
@@ -70,6 +72,8 @@ describe('skillToSuggestion', () => {
 			slotKind: 'ability',
 			slotPosition: 2,
 			typeColor: 'damage',
+			cooldown: 8,
+			initialCooldown: 3,
 			character
 		})
 		expect(suggestion.imageUrl).toBe(`${base}/ability-icons/625_4.png`)

--- a/src/lib/components/edra/extensions/entity-mention/mentions/helpers.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/helpers.ts
@@ -78,6 +78,19 @@ export function skillMentionSubheader(token: MentionToken): string {
 	return characterName
 }
 
+/**
+ * Splits a skill description into legible lines. Game descriptions separate effects
+ * with newlines (and occasional stray `<br>` literals); this normalizes both into a
+ * trimmed, blank-free list so the tooltip can render each as its own paragraph.
+ */
+export function skillDescriptionLines(text: string): string[] {
+	return text
+		.replace(/<br\s*\/?\s*>/gi, '\n')
+		.split('\n')
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+}
+
 /** The shared `data-*` chip attributes for both the editor node and the read-only renderer. */
 export function mentionChipAttrs(token: MentionToken): Record<string, string> {
 	const attrs: Record<string, string> = {

--- a/src/lib/components/edra/extensions/entity-mention/mentions/index.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/index.ts
@@ -6,7 +6,8 @@ export {
 	mentionImageUrl,
 	mentionHref,
 	mentionChipAttrs,
-	skillMentionSubheader
+	skillMentionSubheader,
+	skillDescriptionLines
 } from './helpers'
 export { mentionDescriptors, descriptorFor } from './registry'
 export type { MentionDescriptor, MentionSecondary } from './registry'

--- a/src/lib/components/edra/extensions/entity-mention/mentions/normalize.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/normalize.ts
@@ -41,6 +41,8 @@ export function skillToSuggestion(
 			typeColor: version.typeColor,
 			slotKind: slot.kind,
 			slotPosition: slot.position,
+			cooldown: version.cooldown,
+			initialCooldown: version.initialCooldown,
 			character
 		}
 	}

--- a/src/lib/components/edra/extensions/entity-mention/mentions/types.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/types.ts
@@ -33,6 +33,10 @@ export interface MentionToken {
 		slotKind?: string
 		/** 1-based slot position; players refer to active skills by it ("Octavia 2"). */
 		slotPosition?: number
+		/** Turns between uses; null for passives/supports. */
+		cooldown?: number | null
+		/** Turns until the skill is first usable (initial cooldown); 0/null when usable immediately. */
+		initialCooldown?: number | null
 		/** The party character the skill belongs to (for attribution + tooltip). */
 		character?: { granblue_id: string; name: LocalizedName }
 	}

--- a/src/lib/components/ui/MentionTooltip.svelte
+++ b/src/lib/components/ui/MentionTooltip.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import * as m from '$lib/paraglide/messages'
 	import { localizedName } from '$lib/utils/locale'
 	import ProficiencyLabel from '$lib/components/labels/ProficiencyLabel.svelte'
 	import CharacterTags from '$lib/components/tags/CharacterTags.svelte'
@@ -20,6 +21,7 @@
 	const imageUrl = $derived(mentionImageUrl(entity))
 	const swatchColor = $derived(typeColorSwatch(entity.skill?.typeColor))
 	const secondary = $derived(descriptorFor(entity.type).secondary)
+	const isSkill = $derived(secondary === 'skill-meta')
 
 	const proficiencies = $derived.by(() => {
 		if (entity.proficiency === undefined || entity.proficiency === null) return []
@@ -28,46 +30,69 @@
 	})
 
 	const skillDescription = $derived(entity.skill ? localizedName(entity.skill.description) : '')
+	const hasDescription = $derived(!!skillDescription && skillDescription !== '—')
 	const hasProficiencies = $derived(proficiencies.length > 0)
 </script>
 
+{#snippet thumbnail()}
+	<div class="entity-image {entity.type}">
+		{#if imageUrl}
+			<img src={imageUrl} alt="" loading="lazy" />
+		{:else}
+			<span class="entity-swatch" style:background={swatchColor ?? 'var(--border-color)'}></span>
+		{/if}
+	</div>
+{/snippet}
+
 {#if visible}
-	<div class="mention-tooltip" class:is-skill={secondary === 'skill-meta'}>
-		<div class="entity-image {entity.type}">
-			{#if imageUrl}
-				<img src={imageUrl} alt="" loading="lazy" />
-			{:else}
-				<span class="entity-swatch" style:background={swatchColor ?? 'var(--border-color)'}></span>
+	{#if isSkill}
+		<div class="mention-tooltip skill-tooltip">
+			<div class="skill-lockup">
+				{@render thumbnail()}
+				<div class="skill-headings">
+					<span class="entity-name">{localizedName(entity.name)}</span>
+					{#if entity.skill?.character}
+						<span class="skill-owner">{skillMentionSubheader(entity)}</span>
+					{/if}
+				</div>
+			</div>
+			{#if hasDescription}
+				<p class="skill-description">{skillDescription}</p>
 			{/if}
-		</div>
-		<div class="entity-info">
-			<span class="entity-name">{localizedName(entity.name)}</span>
-			{#if secondary === 'character-tags'}
-				<CharacterTags
-					character={{
-						element: entity.element?.id,
-						season: entity.season,
-						series: entity.series,
-						styleSwap: entity.styleSwap
-					}}
-				/>
-			{:else if secondary === 'skill-meta'}
-				{#if entity.skill?.character}
-					<span class="skill-owner">{skillMentionSubheader(entity)}</span>
-				{/if}
-				{#if skillDescription && skillDescription !== '—'}
-					<p class="skill-description">{skillDescription}</p>
-				{/if}
+			{#if entity.skill?.cooldown != null}
+				<div class="skill-stat">{m.mention_skill_cooldown({ n: entity.skill.cooldown })}</div>
 			{/if}
-			{#if hasProficiencies}
-				<div class="proficiencies">
-					{#each proficiencies as prof (prof)}
-						<ProficiencyLabel proficiency={prof} size="small" />
-					{/each}
+			{#if entity.skill?.initialCooldown}
+				<div class="skill-stat">
+					{m.mention_skill_available_in({ n: entity.skill.initialCooldown })}
 				</div>
 			{/if}
 		</div>
-	</div>
+	{:else}
+		<div class="mention-tooltip">
+			{@render thumbnail()}
+			<div class="entity-info">
+				<span class="entity-name">{localizedName(entity.name)}</span>
+				{#if secondary === 'character-tags'}
+					<CharacterTags
+						character={{
+							element: entity.element?.id,
+							season: entity.season,
+							series: entity.series,
+							styleSwap: entity.styleSwap
+						}}
+					/>
+				{/if}
+				{#if hasProficiencies}
+					<div class="proficiencies">
+						{#each proficiencies as prof (prof)}
+							<ProficiencyLabel proficiency={prof} size="small" />
+						{/each}
+					</div>
+				{/if}
+			</div>
+		</div>
+	{/if}
 {/if}
 
 <style lang="scss">
@@ -87,10 +112,21 @@
 		border-radius: $item-corner;
 		z-index: effects.$z-notification;
 		box-shadow: var(--shadow-md);
+	}
 
-		&.is-skill {
-			max-width: 280px;
-		}
+	// Skills stack a name/owner lockup over a full-width description + timing lines.
+	.skill-tooltip {
+		flex-direction: column;
+		gap: $unit-half;
+		max-width: 280px;
+	}
+
+	.skill-lockup {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		gap: $unit;
+		width: 100%;
 	}
 
 	.entity-image {
@@ -112,13 +148,20 @@
 		}
 	}
 
+	// Slightly smaller icon in the skill lockup.
+	.skill-lockup .entity-image {
+		width: 44px;
+		height: 44px;
+	}
+
 	.entity-swatch {
 		display: block;
 		width: 100%;
 		height: 100%;
 	}
 
-	.entity-info {
+	.entity-info,
+	.skill-headings {
 		display: flex;
 		flex-direction: column;
 		gap: $unit-half;
@@ -129,6 +172,11 @@
 		font-size: $font-regular;
 		font-weight: $medium;
 		white-space: nowrap;
+	}
+
+	// Skill names can be long; let them wrap within the lockup instead of clipping.
+	.skill-headings .entity-name {
+		white-space: normal;
 	}
 
 	.skill-owner {
@@ -143,6 +191,11 @@
 		line-height: 1.4;
 		white-space: normal;
 		opacity: 0.9;
+	}
+
+	.skill-stat {
+		font-size: $font-small;
+		opacity: 0.7;
 	}
 
 	.proficiencies {

--- a/src/lib/components/ui/MentionTooltip.svelte
+++ b/src/lib/components/ui/MentionTooltip.svelte
@@ -6,6 +6,7 @@
 	import {
 		descriptorFor,
 		mentionImageUrl,
+		skillDescriptionLines,
 		skillMentionSubheader,
 		typeColorSwatch
 	} from '$lib/components/edra/extensions/entity-mention/mentions/index.js'
@@ -30,7 +31,9 @@
 	})
 
 	const skillDescription = $derived(entity.skill ? localizedName(entity.skill.description) : '')
-	const hasDescription = $derived(!!skillDescription && skillDescription !== '—')
+	const descriptionLines = $derived(
+		skillDescription && skillDescription !== '—' ? skillDescriptionLines(skillDescription) : []
+	)
 	const hasProficiencies = $derived(proficiencies.length > 0)
 </script>
 
@@ -56,8 +59,12 @@
 					{/if}
 				</div>
 			</div>
-			{#if hasDescription}
-				<p class="skill-description">{skillDescription}</p>
+			{#if descriptionLines.length > 0}
+				<div class="skill-description">
+					{#each descriptionLines as line, i (i)}
+						<p>{line}</p>
+					{/each}
+				</div>
 			{/if}
 			{#if entity.skill?.cooldown != null}
 				<div class="skill-stat">{m.mention_skill_cooldown({ n: entity.skill.cooldown })}</div>
@@ -186,11 +193,17 @@
 	}
 
 	.skill-description {
-		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: $unit-half;
 		font-size: $font-small;
 		line-height: 1.4;
-		white-space: normal;
 		opacity: 0.9;
+
+		p {
+			margin: 0;
+			white-space: normal;
+		}
 	}
 
 	.skill-stat {


### PR DESCRIPTION
## Summary

Follow-up polish for the skill mention tooltip (builds on the merged skill-mentions feature).

**Layout — lockup over full-width description.** Skill tooltips now stack a smaller-icon name/owner lockup over a full-width description, followed by timing lines:

```
[icon] Skill Name
[icon] Character + Slot
Description goes full width
beneath the lockup…
Cooldown {n}T
Available in {n}T        (only when initialCooldown is set — rare)
```

- Lockup icon shrinks 60px → 44px; long skill names wrap instead of clipping.
- Entity tooltips (character/weapon/summon) keep their original horizontal layout; the image markup is shared via a `{#snippet thumbnail()}` so there's no duplication.

**Descriptions — chunked into paragraphs.** Game descriptions separate effects with `\n` (plus occasional malformed `<br/ >` literals). The tooltip was rendering them as one run-on block. New `skillDescriptionLines()` normalizes the `<br>` litter, splits on newlines, trims, drops blanks, and renders each effect as its own paragraph.

**Cooldown plumbing.** Added `cooldown` / `initialCooldown` to the skill token (captured at insert time from the party payload, which already serializes them) and two localized message keys: `mention_skill_cooldown` ("Cooldown {n}T") and `mention_skill_available_in` ("Available in {n}T").

## Notes
- The token is a snapshot, so **mentions inserted before this change won't show cooldown** — re-inserting captures it. (`initialCooldown` is genuinely rare in the data — 66/8156 versions — so "Available in" rarely appears, by design.)
- The description chunking benefits existing mentions too, since the description was always stored in the token.
- Effect bolding was considered and deferred: descriptions are free text with no markup, and structured `skillEffects` don't map to text spans, so clean effect-name emphasis isn't feasible yet.

## Testing
- 40 unit tests pass (added coverage for cooldown capture + `skillDescriptionLines`).
- `npm run check`, eslint, prettier clean on changed files; Paraglide compiles the new keys.