### PR TITLE
Use static icons for charge attacks and support skills

### DIFF
--- a/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/helpers.test.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/helpers.test.ts
@@ -85,11 +85,23 @@ describe('mentionImageUrl', () => {
 	it('returns the square portrait for entities', () => {
 		expect(mentionImageUrl(characterToken())).toBe(`${base}/character-square/3040001000_01.jpg`)
 	})
-	it('returns the ability icon for a skill with a game icon', () => {
-		expect(mentionImageUrl(skillToken())).toBe(`${base}/ability-icons/625_4.png`)
+	it('returns the ability icon for a usable skill with a game icon', () => {
+		expect(mentionImageUrl(skillToken({ slotKind: 'ability' }))).toBe(
+			`${base}/ability-icons/625_4.png`
+		)
 	})
-	it('returns null for a skill without a game icon', () => {
-		expect(mentionImageUrl(skillToken({ gameIcon: null }))).toBeNull()
+	it('returns null for an ability skill without a game icon', () => {
+		expect(mentionImageUrl(skillToken({ slotKind: 'ability', gameIcon: null }))).toBeNull()
+	})
+	it('returns the static charge-attack icon for ougi, ignoring gameIcon', () => {
+		expect(mentionImageUrl(skillToken({ slotKind: 'ougi', gameIcon: null }))).toBe(
+			`${base}/ability-icons/charge-attack.png`
+		)
+	})
+	it('returns the static support icon for support skills', () => {
+		expect(mentionImageUrl(skillToken({ slotKind: 'support', gameIcon: null }))).toBe(
+			`${base}/ability-icons/support-skill.png`
+		)
 	})
 })
 

--- a/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/normalize.test.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/normalize.test.ts
@@ -81,13 +81,23 @@ describe('skillToSuggestion', () => {
 		expect(suggestion.primaryLabel).toBe('Lord of Flames')
 	})
 
-	it('falls back to a type-color swatch when the version has no game icon', () => {
+	it('falls back to a type-color swatch when an ability has no game icon', () => {
+		const suggestion = skillToSuggestion(
+			version({ gameIcon: null }),
+			{ kind: 'ability', position: 1 },
+			character
+		)
+		expect(suggestion.imageUrl).toBeNull()
+		expect(suggestion.swatchColor).toBe('#d64545')
+	})
+
+	it('uses the static charge-attack icon for ougi (no swatch)', () => {
 		const suggestion = skillToSuggestion(
 			version({ gameIcon: null }),
 			{ kind: 'ougi', position: 1 },
 			character
 		)
-		expect(suggestion.imageUrl).toBeNull()
-		expect(suggestion.swatchColor).toBe('#d64545')
+		expect(suggestion.imageUrl).toMatch(/ability-icons\/charge-attack\.png$/)
+		expect(suggestion.swatchColor).toBeNull()
 	})
 })

--- a/src/lib/components/edra/extensions/entity-mention/mentions/helpers.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/helpers.ts
@@ -51,7 +51,9 @@ export function typeColorSwatch(typeColor: string | null | undefined): string | 
 
 /** Thumbnail for a mention token: skill icon for skills, square portrait otherwise. */
 export function mentionImageUrl(token: MentionToken): string | null {
-	if (token.type === 'skill') return getCharacterSkillIcon(token.skill?.gameIcon)
+	if (token.type === 'skill') {
+		return getCharacterSkillIcon(token.skill?.gameIcon, token.skill?.slotKind)
+	}
 	return squareImageUrl(token.type, token.granblue_id)
 }
 

--- a/src/lib/features/database/characters/tabs/CharacterSkillsTab.svelte
+++ b/src/lib/features/database/characters/tabs/CharacterSkillsTab.svelte
@@ -107,9 +107,18 @@
 							{@const primary = primaryVersion(slot)}
 							{#if primary}
 								<div class="slot">
-									<SkillVersionCard version={primary} badges={progressionBadges(slot)} />
+									<SkillVersionCard
+										version={primary}
+										kind={slot.kind}
+										badges={progressionBadges(slot)}
+									/>
 									{#each subVariants(slot) as sub (sub.version.id)}
-										<SkillVersionCard version={sub.version} relationLabel={sub.label} linked />
+										<SkillVersionCard
+											version={sub.version}
+											kind={slot.kind}
+											relationLabel={sub.label}
+											linked
+										/>
 									{/each}
 								</div>
 							{/if}

--- a/src/lib/features/database/characters/tabs/SkillVersionCard.svelte
+++ b/src/lib/features/database/characters/tabs/SkillVersionCard.svelte
@@ -6,6 +6,8 @@
 
 	interface Props {
 		version: CharacterSkillVersion
+		/** Slot kind ('ability' | 'ougi' | 'support'); drives the static CA/support icon. */
+		kind?: string
 		/** Connector label shown above linked sub-cards (e.g. "Transforms into"). */
 		relationLabel?: string
 		/** Progression/role badge labels rendered next to the name. */
@@ -14,9 +16,9 @@
 		linked?: boolean
 	}
 
-	let { version, relationLabel, badges = [], linked = false }: Props = $props()
+	let { version, kind, relationLabel, badges = [], linked = false }: Props = $props()
 
-	const iconUrl = $derived(getCharacterSkillIcon(version.gameIcon))
+	const iconUrl = $derived(getCharacterSkillIcon(version.gameIcon, kind))
 	let imgFailed = $state(false)
 	const showImg = $derived(!!iconUrl && !imgFailed)
 	const typeColor = $derived(version.typeColor ?? 'none')

--- a/src/lib/utils/images.ts
+++ b/src/lib/utils/images.ts
@@ -477,11 +477,28 @@ export function getJobSkillIcon(
 }
 
 /**
- * Get character ability icon URL from its game asset stem ("{id}_{N}", e.g.
- * "625_4"). Returns null when the stem is absent (ougi/support and unmatched
- * abilities have none) so callers can fall back to a type-color indicator.
+ * Charge attacks (ougi) and support skills have no custom art, so they share a
+ * static icon under /ability-icons keyed by slot kind.
  */
-export function getCharacterSkillIcon(gameIcon: string | null | undefined): string | null {
+const STATIC_SKILL_ICONS: Record<string, string> = {
+	ougi: 'charge-attack',
+	support: 'support-skill'
+}
+
+/**
+ * Get a character skill icon URL.
+ *
+ * Charge attacks and support skills use their shared static icon (they have no
+ * per-skill art). Usable abilities use their game asset stem ("{id}_{N}", e.g.
+ * "625_4"); when that stem is absent the function returns null so callers can fall
+ * back to a type-color indicator.
+ */
+export function getCharacterSkillIcon(
+	gameIcon: string | null | undefined,
+	kind?: string | null
+): string | null {
+	const staticIcon = kind ? STATIC_SKILL_ICONS[kind] : undefined
+	if (staticIcon) return `${getBasePath()}/ability-icons/${staticIcon}.png`
 	if (!gameIcon) return null
 	return `${getBasePath()}/ability-icons/${gameIcon}.png`
 }


### PR DESCRIPTION
## Summary

Charge attacks (ougi) and support skills have no per-skill art, so they should fall back to a shared static icon instead of a type-color swatch. New static images `charge-attack.png` and `support-skill.png` live under `ability-icons/`.

`getCharacterSkillIcon(gameIcon, kind?)` now resolves by slot kind:
- **ougi** → `/ability-icons/charge-attack.png`
- **support** → `/ability-icons/support-skill.png`
- **ability (usable)** → its per-skill `gameIcon` art, or `null` (→ type-color swatch) when absent — unchanged

The static icons take precedence regardless of `gameIcon` (CAs/support never have one).

## Wired through both consumers
- **Skills tab** — `CharacterSkillsTab` passes `slot.kind` into `SkillVersionCard` (primary + linked sub-cards) → the icon resolver.
- **Skill mentions** — `mentionImageUrl` passes `token.skill.slotKind`, so the dropdown row, chip, and tooltip all show the static icon. Existing CA/support mentions benefit immediately (the token already stored `slotKind`), no re-insert needed.

`fullAutoSkills` is untouched — it only handles ability slots, where the default (no kind) is already correct.

## Notes
- Requires `charge-attack.png` and `support-skill.png` to be present wherever `getBasePath()` points (CDN/S3 `ability-icons/`), not just locally, or they'll 404 in deployed environments.

## Testing
- 47 unit tests pass (added mention coverage: ougi→charge-attack, support→support-skill, ability→custom/null; updated the normalize swatch-fallback test to use an ability slot).
- `npm run check`, eslint, prettier clean on changed files.