### PR TITLE
Add local image mirror migration script

### DIFF
--- a/scripts/migrate-local-images.sh
+++ b/scripts/migrate-local-images.sh
@@ -27,6 +27,7 @@ MAP=(
 	"artifact-square:artifacts/square" "artifact-wide:artifacts/wide"
 	"bullet-square:bullets/square"
 	"ability-icons:icons/abilities" "job-skills:icons/job-skills"
+	"weapon-skill-icons:icons/weapon-skills"
 	"elements:icons/elements" "proficiencies:icons/proficiencies" "rarity:icons/rarity"
 	"awakening:icons/awakening" "mastery:icons/mastery" "ax:icons/ax-skills"
 	"fonts:app/fonts" "placeholders:app/placeholders" "external:app/external" "media:app/media"

--- a/scripts/migrate-local-images.sh
+++ b/scripts/migrate-local-images.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# migrate-local-images.sh — reorganize a LOCAL image mirror to the new bucket
+# structure (the dev-only, git-ignored copy that serves /images in development).
+# This is the local-disk equivalent of the S3 copy+cleanup, done with `mv`.
+#
+# Usage:
+#   scripts/migrate-local-images.sh <image-root> [<image-root> ...]          # dry run
+#   APPLY=1 scripts/migrate-local-images.sh <image-root> [<image-root> ...]  # do it
+#
+# <image-root> is the directory that contains character-main/, ability-icons/, etc.
+# (e.g. static/images, or a worktree's images/). Re-running is safe (idempotent).
+set -euo pipefail
+
+APPLY="${APPLY:-0}"
+
+# old:new directory pairs (excludes jobs/raids — handled specially below — and the
+# orphans weapon-raw/raid-square which are removed, not moved).
+MAP=(
+	"character-main:characters/main" "character-grid:characters/grid"
+	"character-square:characters/square" "character-detail:characters/detail"
+	"weapon-main:weapons/main" "weapon-grid:weapons/grid" "weapon-square:weapons/square"
+	"weapon-base:weapons/base"
+	"summon-main:summons/main" "summon-grid:summons/grid" "summon-square:summons/square"
+	"summon-detail:summons/detail" "summon-tall:summons/tall" "summon-wide:summons/wide"
+	"accessory-square:accessories/square" "accessory-grid:accessories/grid"
+	"artifact-square:artifacts/square" "artifact-wide:artifacts/wide"
+	"bullet-square:bullets/square"
+	"ability-icons:icons/abilities" "job-skills:icons/job-skills"
+	"elements:icons/elements" "proficiencies:icons/proficiencies" "rarity:icons/rarity"
+	"awakening:icons/awakening" "mastery:icons/mastery" "ax:icons/ax-skills"
+	"fonts:app/fonts" "placeholders:app/placeholders" "external:app/external" "media:app/media"
+)
+
+do_mv() { # do_mv <old> <new>
+	local old="$1" new="$2"
+	[ -d "$old" ] || return 0
+	if [ -e "$new" ]; then echo "  skip: $old (→ $new already exists)"; return 0; fi
+	echo "  mv $old → $new"
+	if [ "$APPLY" = 1 ]; then mkdir -p "$(dirname "$new")"; mv "$old" "$new"; fi
+}
+
+do_rm() { # do_rm <path>
+	[ -e "$1" ] || return 0
+	echo "  rm $1"
+	[ "$APPLY" = 1 ] && rm -rf "$1"
+	return 0
+}
+
+# Old flat dir -> <group>/full, where the group prefix equals the old dir name.
+stage_full() { # stage_full <name>  (e.g. jobs, raids)
+	local name="$1"
+	[ -d "$name" ] && [ ! -e "$name/full" ] || return 0
+	echo "  $name/* → $name/full/"
+	if [ "$APPLY" = 1 ]; then
+		mv "$name" ".${name}_stage" && mkdir -p "$name" && mv ".${name}_stage" "$name/full"
+	fi
+}
+
+migrate_root() {
+	local root="$1"
+	if [ ! -d "$root" ]; then echo "## $root — not found, skipping"; return 0; fi
+	echo "## $root"
+	pushd "$root" >/dev/null
+
+	for pair in "${MAP[@]}"; do do_mv "${pair%%:*}" "${pair##*:}"; done
+
+	# jobs/ and raids/ nest under their own old name: relocate the old flat dir to
+	# <group>/full FIRST (while it still holds only flat files), THEN add the variant
+	# subdirs — otherwise the variants get swept into full/.
+	stage_full jobs
+	do_mv job-icons jobs/icon
+	do_mv job-portraits jobs/portrait
+	do_mv job-wide jobs/wide
+	do_mv job-zoom jobs/zoom
+	stage_full raids
+	do_mv raid-thumbnail raids/thumbnail
+
+	# loose marketing files at the image root → app/marketing/
+	for f in about-hero.jpg about-hero2.jpg background_a.jpg port-breeze.jpg relief.png; do
+		[ -f "$f" ] || continue
+		echo "  mv $f → app/marketing/$f"
+		if [ "$APPLY" = 1 ]; then mkdir -p app/marketing && mv "$f" "app/marketing/$f"; fi
+	done
+
+	# orphans + cruft: weapon-raw (dup of weapon-base), raid-square (no source),
+	# the nested duplicate images/ dir (holds the dup extension.mp4), and .DS_Store.
+	do_rm weapon-raw
+	do_rm raid-square
+	do_rm images
+	do_rm .DS_Store
+
+	popd >/dev/null
+	echo
+}
+
+[ "$#" -ge 1 ] || { echo "usage: [APPLY=1] $0 <image-root> [<image-root> ...]" >&2; exit 1; }
+[ "$APPLY" = 1 ] || echo "(DRY RUN — set APPLY=1 to actually move/remove)"
+echo
+for root in "$@"; do migrate_root "$root"; done
+[ "$APPLY" = 1 ] || echo "(DRY RUN — nothing changed)"

--- a/src/lib/components/collection/CollectionArtifactDetailPane.svelte
+++ b/src/lib/components/collection/CollectionArtifactDetailPane.svelte
@@ -48,7 +48,7 @@
 
 	// Wide image for header
 	const wideImageUrl = $derived(getArtifactImage(artifact.artifact?.granblueId, 'wide'))
-	const reliefBackgroundUrl = `${getBasePath()}/relief.png`
+	const reliefBackgroundUrl = `${getBasePath()}/app/marketing/relief.png`
 
 	// Artifact properties
 	const isQuirk = $derived(isQuirkArtifact(artifact.artifact))

--- a/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/helpers.test.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/helpers.test.ts
@@ -57,12 +57,12 @@ describe('elementSlug', () => {
 describe('squareImageUrl', () => {
 	it('builds the character portrait with the _01 suffix', () => {
 		expect(squareImageUrl('character', '3040001000')).toBe(
-			`${base}/character-square/3040001000_01.jpg`
+			`${base}/characters/square/3040001000_01.jpg`
 		)
 	})
 	it('builds weapon and summon square URLs', () => {
-		expect(squareImageUrl('weapon', '1040001000')).toBe(`${base}/weapon-square/1040001000.jpg`)
-		expect(squareImageUrl('summon', '2040001000')).toBe(`${base}/summon-square/2040001000.jpg`)
+		expect(squareImageUrl('weapon', '1040001000')).toBe(`${base}/weapons/square/1040001000.jpg`)
+		expect(squareImageUrl('summon', '2040001000')).toBe(`${base}/summons/square/2040001000.jpg`)
 	})
 	it('returns null for skills', () => {
 		expect(squareImageUrl('skill', 'skill-1')).toBeNull()
@@ -83,11 +83,11 @@ describe('typeColorSwatch', () => {
 
 describe('mentionImageUrl', () => {
 	it('returns the square portrait for entities', () => {
-		expect(mentionImageUrl(characterToken())).toBe(`${base}/character-square/3040001000_01.jpg`)
+		expect(mentionImageUrl(characterToken())).toBe(`${base}/characters/square/3040001000_01.jpg`)
 	})
 	it('returns the ability icon for a usable skill with a game icon', () => {
 		expect(mentionImageUrl(skillToken({ slotKind: 'ability' }))).toBe(
-			`${base}/ability-icons/625_4.png`
+			`${base}/icons/abilities/625_4.png`
 		)
 	})
 	it('returns null for an ability skill without a game icon', () => {
@@ -95,12 +95,12 @@ describe('mentionImageUrl', () => {
 	})
 	it('returns the static charge-attack icon for ougi, ignoring gameIcon', () => {
 		expect(mentionImageUrl(skillToken({ slotKind: 'ougi', gameIcon: null }))).toBe(
-			`${base}/ability-icons/charge-attack.png`
+			`${base}/icons/abilities/charge-attack.png`
 		)
 	})
 	it('returns the static support icon for support skills', () => {
 		expect(mentionImageUrl(skillToken({ slotKind: 'support', gameIcon: null }))).toBe(
-			`${base}/ability-icons/support-skill.png`
+			`${base}/icons/abilities/support-skill.png`
 		)
 	})
 })

--- a/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/normalize.test.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/__tests__/normalize.test.ts
@@ -26,7 +26,7 @@ describe('entityResultToSuggestion', () => {
 		expect(suggestion.token.granblue_id).toBe('3040001000')
 		expect(suggestion.token.element).toEqual({ id: 2, slug: 'fire' })
 		expect(suggestion.token.proficiency).toEqual([1, 2])
-		expect(suggestion.imageUrl).toBe(`${base}/character-square/3040001000_01.jpg`)
+		expect(suggestion.imageUrl).toBe(`${base}/characters/square/3040001000_01.jpg`)
 		expect(suggestion.primaryLabel).toBe('Percival')
 		expect(suggestion.elementSlug).toBe('fire')
 	})
@@ -42,7 +42,7 @@ describe('entityResultToSuggestion', () => {
 		}
 		const suggestion = entityResultToSuggestion(result)
 		expect(suggestion.token.type).toBe('weapon')
-		expect(suggestion.imageUrl).toBe(`${base}/weapon-square/1040001000.jpg`)
+		expect(suggestion.imageUrl).toBe(`${base}/weapons/square/1040001000.jpg`)
 	})
 })
 
@@ -76,7 +76,7 @@ describe('skillToSuggestion', () => {
 			initialCooldown: 3,
 			character
 		})
-		expect(suggestion.imageUrl).toBe(`${base}/ability-icons/625_4.png`)
+		expect(suggestion.imageUrl).toBe(`${base}/icons/abilities/625_4.png`)
 		expect(suggestion.swatchColor).toBeNull()
 		expect(suggestion.primaryLabel).toBe('Lord of Flames')
 	})
@@ -97,7 +97,7 @@ describe('skillToSuggestion', () => {
 			{ kind: 'ougi', position: 1 },
 			character
 		)
-		expect(suggestion.imageUrl).toMatch(/ability-icons\/charge-attack\.png$/)
+		expect(suggestion.imageUrl).toMatch(/icons\/abilities\/charge-attack\.png$/)
 		expect(suggestion.swatchColor).toBeNull()
 	})
 })

--- a/src/lib/components/edra/extensions/entity-mention/mentions/helpers.ts
+++ b/src/lib/components/edra/extensions/entity-mention/mentions/helpers.ts
@@ -38,8 +38,8 @@ export function elementSlug(element: unknown): string {
 /** Square portrait URL for an entity mention; null for skills (they use an icon instead). */
 export function squareImageUrl(type: string, granblueId: string): string | null {
 	const base = getBasePath()
-	if (type === 'character') return `${base}/character-square/${granblueId}_01.jpg`
-	if (type === 'weapon' || type === 'summon') return `${base}/${type}-square/${granblueId}.jpg`
+	if (type === 'character') return `${base}/characters/square/${granblueId}_01.jpg`
+	if (type === 'weapon' || type === 'summon') return `${base}/${type}s/square/${granblueId}.jpg`
 	return null
 }
 

--- a/src/lib/components/job/JobSection.svelte
+++ b/src/lib/components/job/JobSection.svelte
@@ -48,7 +48,7 @@
 	const slotCount = $derived(getJobSkillSlotCount(job))
 	const jobIconUrl = $derived(job ? getJobIconUrl(job.granblueId) : '')
 	const jobImageUrl = $derived(job ? getJobFullImageUrl(job, gender) : '')
-	const jobBackgroundUrl = `${getBasePath()}/background_a.jpg`
+	const jobBackgroundUrl = `${getBasePath()}/app/marketing/background_a.jpg`
 
 	function handleSelectSkill(slot: number) {
 		if (onSelectSkill) {

--- a/src/lib/components/sidebar/details/ItemHeader.svelte
+++ b/src/lib/components/sidebar/details/ItemHeader.svelte
@@ -101,7 +101,7 @@
 
 	const elementName = $derived(getElementKey(itemData?.element))
 
-	const reliefBackgroundUrl = `${getBasePath()}/relief.png`
+	const reliefBackgroundUrl = `${getBasePath()}/app/marketing/relief.png`
 </script>
 
 <div class="item-header-container">

--- a/src/lib/components/ui/DetailsHeader.svelte
+++ b/src/lib/components/ui/DetailsHeader.svelte
@@ -64,11 +64,11 @@
 					}
 					const placeholder =
 						type === 'job'
-							? `${getBasePath()}/placeholders/placeholder-job.png`
+							? `${getBasePath()}/app/placeholders/placeholder-job.png`
 							: type === 'raid'
-								? `${getBasePath()}/placeholders/placeholder-raid-thumbnail.png`
+								? `${getBasePath()}/app/placeholders/placeholder-raid-thumbnail.png`
 								: type === 'accessory'
-									? `${getBasePath()}/placeholders/placeholder-weapon-grid.png`
+									? `${getBasePath()}/app/placeholders/placeholder-weapon-grid.png`
 									: getPlaceholderImage(type, 'grid')
 					img.src = placeholder
 				}}

--- a/src/lib/features/database/weapons/AwakeningModal.svelte
+++ b/src/lib/features/database/weapons/AwakeningModal.svelte
@@ -76,7 +76,7 @@
 	const existingImageUrl = $derived.by(() => {
 		if (!awakening?.slug) return null
 		const ext = awakening.slug.startsWith('character-') ? 'jpg' : 'png'
-		return `${getBasePath()}/awakening/${awakening.slug}.${ext}`
+		return `${getBasePath()}/icons/awakening/${awakening.slug}.${ext}`
 	})
 
 	function handleImageSelect(e: Event) {

--- a/src/lib/types/api/entities.ts
+++ b/src/lib/types/api/entities.ts
@@ -193,7 +193,7 @@ export interface CharacterSkillVersion {
 	name: LocalizedName
 	description: LocalizedName
 	icon?: string | null
-	/** Game asset stem "{id}_{N}" for the icon at /ability-icons/{gameIcon}.png */
+	/** Game asset stem "{id}_{N}" for the icon at /icons/abilities/{gameIcon}.png */
 	gameIcon?: string | null
 	typeColor?: 'damage' | 'heal' | 'buff' | 'debuff' | 'field' | string | null
 	cooldown?: number | null

--- a/src/lib/utils/__tests__/element.test.ts
+++ b/src/lib/utils/__tests__/element.test.ts
@@ -152,11 +152,11 @@ describe('getOppositeElement', () => {
 
 describe('getElementImage', () => {
 	it('returns element image path', () => {
-		expect(getElementImage(2)).toBe('/images/elements/fire.png')
+		expect(getElementImage(2)).toBe('/images/icons/elements/fire.png')
 	})
 
 	it('returns null element image', () => {
-		expect(getElementImage(0)).toBe('/images/elements/null.png')
+		expect(getElementImage(0)).toBe('/images/icons/elements/null.png')
 	})
 
 	it('returns empty string for undefined/null', () => {

--- a/src/lib/utils/__tests__/images.test.ts
+++ b/src/lib/utils/__tests__/images.test.ts
@@ -70,20 +70,20 @@ describe('getBasePath', () => {
 describe('getPlaceholderImage', () => {
 	it('returns placeholder path for each type/variant combo', () => {
 		expect(getPlaceholderImage('character', 'grid')).toBe(
-			'/images/placeholders/placeholder-character-grid.png'
+			'/images/app/placeholders/placeholder-character-grid.png'
 		)
 		expect(getPlaceholderImage('weapon', 'main')).toBe(
-			'/images/placeholders/placeholder-weapon-main.png'
+			'/images/app/placeholders/placeholder-weapon-main.png'
 		)
 		expect(getPlaceholderImage('summon', 'square')).toBe(
-			'/images/placeholders/placeholder-summon-square.png'
+			'/images/app/placeholders/placeholder-summon-square.png'
 		)
 	})
 })
 
 describe('getGenericPlaceholder', () => {
 	it('returns weapon-grid placeholder', () => {
-		expect(getGenericPlaceholder()).toBe('/images/placeholders/placeholder-weapon-grid.png')
+		expect(getGenericPlaceholder()).toBe('/images/app/placeholders/placeholder-weapon-grid.png')
 	})
 })
 
@@ -210,43 +210,43 @@ describe('getWeaponTransformation', () => {
 describe('getImageUrl', () => {
 	it('returns placeholder when id is null/undefined', () => {
 		expect(getImageUrl('character', null, 'grid')).toBe(
-			'/images/placeholders/placeholder-character-grid.png'
+			'/images/app/placeholders/placeholder-character-grid.png'
 		)
 		expect(getImageUrl('weapon', undefined, 'main')).toBe(
-			'/images/placeholders/placeholder-weapon-main.png'
+			'/images/app/placeholders/placeholder-weapon-main.png'
 		)
 	})
 
 	it('returns character URL with pose', () => {
 		expect(getImageUrl('character', '3040001', 'main', { pose: '02' })).toBe(
-			'/images/character-main/3040001_02.jpg'
+			'/images/characters/main/3040001_02.jpg'
 		)
 	})
 
 	it('defaults character pose to 01', () => {
 		expect(getImageUrl('character', '3040001', 'grid')).toBe(
-			'/images/character-grid/3040001_01.jpg'
+			'/images/characters/grid/3040001_01.jpg'
 		)
 	})
 
 	it('returns weapon URL without element', () => {
-		expect(getImageUrl('weapon', '1040001', 'main')).toBe('/images/weapon-main/1040001.jpg')
+		expect(getImageUrl('weapon', '1040001', 'main')).toBe('/images/weapons/main/1040001.jpg')
 	})
 
 	it('returns weapon grid URL with element suffix', () => {
 		expect(getImageUrl('weapon', '1040001', 'grid', { element: 3 })).toBe(
-			'/images/weapon-grid/1040001_3.jpg'
+			'/images/weapons/grid/1040001_3.jpg'
 		)
 	})
 
 	it('weapon grid element 0 is valid', () => {
 		expect(getImageUrl('weapon', '1040001', 'grid', { element: 0 })).toBe(
-			'/images/weapon-grid/1040001_0.jpg'
+			'/images/weapons/grid/1040001_0.jpg'
 		)
 	})
 
 	it('returns summon URL', () => {
-		expect(getImageUrl('summon', '2040001', 'main')).toBe('/images/summon-main/2040001.jpg')
+		expect(getImageUrl('summon', '2040001', 'main')).toBe('/images/summons/main/2040001.jpg')
 	})
 
 	describe('file extensions', () => {
@@ -276,11 +276,13 @@ describe('getImageUrl', () => {
 
 describe('getCharacterImage', () => {
 	it('defaults to main variant', () => {
-		expect(getCharacterImage('3040001')).toBe('/images/character-main/3040001_01.jpg')
+		expect(getCharacterImage('3040001')).toBe('/images/characters/main/3040001_01.jpg')
 	})
 
 	it('accepts pose override', () => {
-		expect(getCharacterImage('3040001', 'grid', '03')).toBe('/images/character-grid/3040001_03.jpg')
+		expect(getCharacterImage('3040001', 'grid', '03')).toBe(
+			'/images/characters/grid/3040001_03.jpg'
+		)
 	})
 
 	it('returns placeholder for null', () => {
@@ -290,13 +292,15 @@ describe('getCharacterImage', () => {
 
 describe('getCharacterDetailImage', () => {
 	it('returns detail PNG', () => {
-		expect(getCharacterDetailImage('3040001', '02')).toBe('/images/character-detail/3040001_02.png')
+		expect(getCharacterDetailImage('3040001', '02')).toBe(
+			'/images/characters/detail/3040001_02.png'
+		)
 	})
 })
 
 describe('getWeaponImage', () => {
 	it('defaults to main variant', () => {
-		expect(getWeaponImage('1040001')).toBe('/images/weapon-main/1040001.jpg')
+		expect(getWeaponImage('1040001')).toBe('/images/weapons/main/1040001.jpg')
 	})
 
 	it('returns placeholder for null', () => {
@@ -304,33 +308,33 @@ describe('getWeaponImage', () => {
 	})
 
 	it('adds element suffix for grid variant', () => {
-		expect(getWeaponImage('1040001', 'grid', 2)).toBe('/images/weapon-grid/1040001_2.jpg')
+		expect(getWeaponImage('1040001', 'grid', 2)).toBe('/images/weapons/grid/1040001_2.jpg')
 	})
 
 	it('element 0 produces _0 suffix', () => {
-		expect(getWeaponImage('1040001', 'grid', 0)).toBe('/images/weapon-grid/1040001_0.jpg')
+		expect(getWeaponImage('1040001', 'grid', 0)).toBe('/images/weapons/grid/1040001_0.jpg')
 	})
 
 	it('adds transformation suffix', () => {
 		expect(getWeaponImage('1040001', 'main', undefined, '02')).toBe(
-			'/images/weapon-main/1040001_02.jpg'
+			'/images/weapons/main/1040001_02.jpg'
 		)
 	})
 })
 
 describe('getWeaponBaseImage', () => {
 	it('returns base PNG', () => {
-		expect(getWeaponBaseImage('1040001')).toBe('/images/weapon-base/1040001.png')
+		expect(getWeaponBaseImage('1040001')).toBe('/images/weapons/base/1040001.png')
 	})
 })
 
 describe('getSummonImage', () => {
 	it('defaults to main', () => {
-		expect(getSummonImage('2040001')).toBe('/images/summon-main/2040001.jpg')
+		expect(getSummonImage('2040001')).toBe('/images/summons/main/2040001.jpg')
 	})
 
 	it('adds transformation suffix', () => {
-		expect(getSummonImage('2040001', 'main', '02')).toBe('/images/summon-main/2040001_02.jpg')
+		expect(getSummonImage('2040001', 'main', '02')).toBe('/images/summons/main/2040001_02.jpg')
 	})
 
 	it('returns placeholder for null', () => {
@@ -340,13 +344,13 @@ describe('getSummonImage', () => {
 
 describe('getSummonDetailImage', () => {
 	it('returns detail PNG', () => {
-		expect(getSummonDetailImage('2040001')).toBe('/images/summon-detail/2040001.png')
+		expect(getSummonDetailImage('2040001')).toBe('/images/summons/detail/2040001.png')
 	})
 })
 
 describe('getSummonWideImage', () => {
 	it('returns wide JPG', () => {
-		expect(getSummonWideImage('2040001')).toBe('/images/summon-wide/2040001.jpg')
+		expect(getSummonWideImage('2040001')).toBe('/images/summons/wide/2040001.jpg')
 	})
 })
 
@@ -361,27 +365,27 @@ describe('getCharacterImageWithPose', () => {
 
 	it('calculates pose from uncap/transcendence', () => {
 		expect(getCharacterImageWithPose('3040001', 'main', 3)).toBe(
-			'/images/character-main/3040001_02.jpg'
+			'/images/characters/main/3040001_02.jpg'
 		)
 		expect(getCharacterImageWithPose('3040001', 'main', 5)).toBe(
-			'/images/character-main/3040001_03.jpg'
+			'/images/characters/main/3040001_03.jpg'
 		)
 		expect(getCharacterImageWithPose('3040001', 'main', 5, 1)).toBe(
-			'/images/character-main/3040001_04.jpg'
+			'/images/characters/main/3040001_04.jpg'
 		)
 	})
 
 	it('null-element characters get element-suffixed images without gender by default', () => {
 		const url = getCharacterImageWithPose('3030182000', 'main', 3, 0, 2, null, false, false, 0)
-		expect(url).toBe('/images/character-main/3030182000_02_02.jpg')
+		expect(url).toBe('/images/characters/main/3030182000_02_02.jpg')
 
 		const lyria = getCharacterImageWithPose('3040643000', 'main', 3, 0, 3, null, false, false, 0)
-		expect(lyria).toBe('/images/character-main/3040643000_02_03.jpg')
+		expect(lyria).toBe('/images/characters/main/3040643000_02_03.jpg')
 	})
 
 	it('null-element characters get element + gender suffix when gender is provided', () => {
 		const gran = getCharacterImageWithPose('3040643000', 'main', 3, 0, 3, null, false, false, 0, 0)
-		expect(gran).toBe('/images/character-main/3040643000_02_03_0.jpg')
+		expect(gran).toBe('/images/characters/main/3040643000_02_03_0.jpg')
 
 		const djeeta = getCharacterImageWithPose(
 			'3040643000',
@@ -395,7 +399,7 @@ describe('getCharacterImageWithPose', () => {
 			0,
 			1
 		)
-		expect(djeeta).toBe('/images/character-main/3040643000_02_03_1.jpg')
+		expect(djeeta).toBe('/images/characters/main/3040643000_02_03_1.jpg')
 	})
 
 	it('gender suffix works for non-null-element characters too', () => {
@@ -411,7 +415,7 @@ describe('getCharacterImageWithPose', () => {
 			2,
 			0
 		)
-		expect(gran).toBe('/images/character-main/3040001000_02_0.jpg')
+		expect(gran).toBe('/images/characters/main/3040001000_02_0.jpg')
 
 		const djeeta = getCharacterImageWithPose(
 			'3040001000',
@@ -425,7 +429,7 @@ describe('getCharacterImageWithPose', () => {
 			2,
 			1
 		)
-		expect(djeeta).toBe('/images/character-main/3040001000_02_1.jpg')
+		expect(djeeta).toBe('/images/characters/main/3040001000_02_1.jpg')
 	})
 
 	it('null-element characters fall back to partyElement when no mainWeaponElement', () => {
@@ -455,26 +459,26 @@ describe('getCharacterImageWithPose', () => {
 			false,
 			0
 		)
-		expect(noContext).toBe('/images/character-main/3040643000_01.jpg')
+		expect(noContext).toBe('/images/characters/main/3040643000_01.jpg')
 	})
 
 	it('non-null-element characters without gender are not affected by element params', () => {
 		const normal = getCharacterImageWithPose('3040001000', 'main', 3, 0, 2, null, false, false, 2)
-		expect(normal).toBe('/images/character-main/3040001000_02.jpg')
+		expect(normal).toBe('/images/characters/main/3040001000_02.jpg')
 	})
 })
 
 describe('getWeaponGridImage', () => {
 	it('returns grid URL without element for normal weapons', () => {
-		expect(getWeaponGridImage('1040001')).toBe('/images/weapon-grid/1040001.jpg')
+		expect(getWeaponGridImage('1040001')).toBe('/images/weapons/grid/1040001.jpg')
 	})
 
 	it('handles element-changeable weapons (element === 0) with instance element', () => {
-		expect(getWeaponGridImage('1040001', 0, 3)).toBe('/images/weapon-grid/1040001_3.jpg')
+		expect(getWeaponGridImage('1040001', 0, 3)).toBe('/images/weapons/grid/1040001_3.jpg')
 	})
 
 	it('element-changeable without instanceElement defaults to 0', () => {
-		expect(getWeaponGridImage('1040001', 0)).toBe('/images/weapon-grid/1040001_0.jpg')
+		expect(getWeaponGridImage('1040001', 0)).toBe('/images/weapons/grid/1040001_0.jpg')
 	})
 
 	it('returns placeholder for null id', () => {
@@ -488,27 +492,27 @@ describe('getWeaponGridImage', () => {
 
 describe('getJobSkillIcon', () => {
 	it('returns default for undefined', () => {
-		expect(getJobSkillIcon(undefined)).toBe('/images/job-skills/default.png')
+		expect(getJobSkillIcon(undefined)).toBe('/images/icons/job-skills/default.png')
 	})
 
 	it('handles string input', () => {
-		expect(getJobSkillIcon('rage-iv')).toBe('/images/job-skills/rage-iv.png')
+		expect(getJobSkillIcon('rage-iv')).toBe('/images/icons/job-skills/rage-iv.png')
 	})
 
 	it('uses slug from object', () => {
 		expect(getJobSkillIcon({ slug: 'miserable-mist' })).toBe(
-			'/images/job-skills/miserable-mist.png'
+			'/images/icons/job-skills/miserable-mist.png'
 		)
 	})
 
 	it('returns default when object has no slug', () => {
-		expect(getJobSkillIcon({})).toBe('/images/job-skills/default.png')
+		expect(getJobSkillIcon({})).toBe('/images/icons/job-skills/default.png')
 	})
 })
 
 describe('getAccessoryImage', () => {
 	it('returns accessory URL', () => {
-		expect(getAccessoryImage('399001')).toBe('/images/accessory-square/399001.jpg')
+		expect(getAccessoryImage('399001')).toBe('/images/accessories/square/399001.jpg')
 	})
 
 	it('returns generic placeholder for undefined', () => {
@@ -522,11 +526,11 @@ describe('getAccessoryImage', () => {
 
 describe('getAwakeningImage', () => {
 	it('returns awakening URL with default jpg', () => {
-		expect(getAwakeningImage('attack')).toBe('/images/awakening/attack.jpg')
+		expect(getAwakeningImage('attack')).toBe('/images/icons/awakening/attack.jpg')
 	})
 
 	it('supports png extension', () => {
-		expect(getAwakeningImage('attack', 'png')).toBe('/images/awakening/attack.png')
+		expect(getAwakeningImage('attack', 'png')).toBe('/images/icons/awakening/attack.png')
 	})
 
 	it('returns empty string for undefined', () => {
@@ -544,7 +548,7 @@ describe('getWeaponKeyImage', () => {
 
 describe('getAxSkillImage', () => {
 	it('returns ax URL', () => {
-		expect(getAxSkillImage('might')).toBe('/images/ax/might.png')
+		expect(getAxSkillImage('might')).toBe('/images/icons/ax-skills/might.png')
 	})
 
 	it('returns empty string for undefined', () => {
@@ -554,7 +558,7 @@ describe('getAxSkillImage', () => {
 
 describe('getMasteryImage', () => {
 	it('returns mastery URL', () => {
-		expect(getMasteryImage('atk')).toBe('/images/mastery/atk.png')
+		expect(getMasteryImage('atk')).toBe('/images/icons/mastery/atk.png')
 	})
 
 	it('returns empty string for undefined', () => {
@@ -605,16 +609,16 @@ describe('getGenderLabelImage', () => {
 
 describe('getElementIcon', () => {
 	it('maps element IDs to names', () => {
-		expect(getElementIcon(1)).toBe('/images/elements/element-wind.png')
-		expect(getElementIcon(2)).toBe('/images/elements/element-fire.png')
-		expect(getElementIcon(3)).toBe('/images/elements/element-water.png')
-		expect(getElementIcon(4)).toBe('/images/elements/element-earth.png')
-		expect(getElementIcon(5)).toBe('/images/elements/element-dark.png')
-		expect(getElementIcon(6)).toBe('/images/elements/element-light.png')
+		expect(getElementIcon(1)).toBe('/images/icons/elements/element-wind.png')
+		expect(getElementIcon(2)).toBe('/images/icons/elements/element-fire.png')
+		expect(getElementIcon(3)).toBe('/images/icons/elements/element-water.png')
+		expect(getElementIcon(4)).toBe('/images/icons/elements/element-earth.png')
+		expect(getElementIcon(5)).toBe('/images/icons/elements/element-dark.png')
+		expect(getElementIcon(6)).toBe('/images/icons/elements/element-light.png')
 	})
 
 	it('returns null element for unknown element', () => {
-		expect(getElementIcon(99)).toBe('/images/elements/element-null.png')
+		expect(getElementIcon(99)).toBe('/images/icons/elements/element-null.png')
 	})
 })
 
@@ -624,11 +628,11 @@ describe('getElementIcon', () => {
 
 describe('getArtifactImage', () => {
 	it('returns square by default', () => {
-		expect(getArtifactImage('500001')).toBe('/images/artifact-square/500001.jpg')
+		expect(getArtifactImage('500001')).toBe('/images/artifacts/square/500001.jpg')
 	})
 
 	it('returns wide variant', () => {
-		expect(getArtifactImage('500001', 'wide')).toBe('/images/artifact-wide/500001.jpg')
+		expect(getArtifactImage('500001', 'wide')).toBe('/images/artifacts/wide/500001.jpg')
 	})
 
 	it('returns generic placeholder for null', () => {
@@ -694,14 +698,14 @@ describe('getGuidebookImage', () => {
 
 describe('getRaidImage', () => {
 	it('returns stored raid image by variant', () => {
-		expect(getRaidImage('proto-bahamut', 'icon')).toContain('/images/raid-icon/proto-bahamut.png')
+		expect(getRaidImage('proto-bahamut', 'icon')).toContain('/images/raids/icon/proto-bahamut.png')
 		expect(getRaidImage('proto-bahamut', 'thumbnail')).toContain(
-			'/images/raid-thumbnail/proto-bahamut.png'
+			'/images/raids/thumbnail/proto-bahamut.png'
 		)
 	})
 
 	it('defaults to thumbnail', () => {
-		expect(getRaidImage('proto-bahamut')).toContain('/images/raid-thumbnail/proto-bahamut.png')
+		expect(getRaidImage('proto-bahamut')).toContain('/images/raids/thumbnail/proto-bahamut.png')
 	})
 
 	it('includes cache-busting query parameter', () => {
@@ -758,12 +762,12 @@ describe('with remote base URL', () => {
 
 describe('getWeaponFallbackImage', () => {
 	it('returns URL without element suffix', () => {
-		expect(getWeaponFallbackImage('1040001', 'grid')).toBe('/images/weapon-grid/1040001.jpg')
+		expect(getWeaponFallbackImage('1040001', 'grid')).toBe('/images/weapons/grid/1040001.jpg')
 	})
 
 	it('returns URL with transformation suffix', () => {
 		expect(getWeaponFallbackImage('1040001', 'main', '02')).toBe(
-			'/images/weapon-main/1040001_02.jpg'
+			'/images/weapons/main/1040001_02.jpg'
 		)
 	})
 
@@ -776,29 +780,29 @@ describe('getWeaponFallbackImage', () => {
 	})
 
 	it('uses correct extension for base variant', () => {
-		expect(getWeaponFallbackImage('1040001', 'base')).toBe('/images/weapon-base/1040001.png')
+		expect(getWeaponFallbackImage('1040001', 'base')).toBe('/images/weapons/base/1040001.png')
 	})
 })
 
 describe('handleImageFallback', () => {
 	it('swaps src to fallback URL', () => {
-		const img = { src: 'https://cdn.example.com/weapon-grid/1040001_0.jpg' } as HTMLImageElement
+		const img = { src: 'https://cdn.example.com/weapons/grid/1040001_0.jpg' } as HTMLImageElement
 		const event = { currentTarget: img } as unknown as Event
-		handleImageFallback(event, 'https://cdn.example.com/weapon-grid/1040001.jpg')
-		expect(img.src).toBe('https://cdn.example.com/weapon-grid/1040001.jpg')
+		handleImageFallback(event, 'https://cdn.example.com/weapons/grid/1040001.jpg')
+		expect(img.src).toBe('https://cdn.example.com/weapons/grid/1040001.jpg')
 	})
 
 	it('does not swap when fallback matches current src', () => {
-		const img = { src: 'https://cdn.example.com/weapon-grid/1040001.jpg' } as HTMLImageElement
+		const img = { src: 'https://cdn.example.com/weapons/grid/1040001.jpg' } as HTMLImageElement
 		const event = { currentTarget: img } as unknown as Event
-		handleImageFallback(event, 'https://cdn.example.com/weapon-grid/1040001.jpg')
-		expect(img.src).toBe('https://cdn.example.com/weapon-grid/1040001.jpg')
+		handleImageFallback(event, 'https://cdn.example.com/weapons/grid/1040001.jpg')
+		expect(img.src).toBe('https://cdn.example.com/weapons/grid/1040001.jpg')
 	})
 
 	it('does nothing when no fallback provided', () => {
-		const img = { src: 'https://cdn.example.com/weapon-grid/1040001_0.jpg' } as HTMLImageElement
+		const img = { src: 'https://cdn.example.com/weapons/grid/1040001_0.jpg' } as HTMLImageElement
 		const event = { currentTarget: img } as unknown as Event
 		handleImageFallback(event, undefined)
-		expect(img.src).toBe('https://cdn.example.com/weapon-grid/1040001_0.jpg')
+		expect(img.src).toBe('https://cdn.example.com/weapons/grid/1040001_0.jpg')
 	})
 })

--- a/src/lib/utils/__tests__/jobUtils.test.ts
+++ b/src/lib/utils/__tests__/jobUtils.test.ts
@@ -26,7 +26,7 @@ vi.mock('$lib/api/adapters/config', () => ({
 }))
 
 vi.mock('../images', () => ({
-	getGenericPlaceholder: vi.fn(() => '/images/placeholders/placeholder-weapon-grid.png')
+	getGenericPlaceholder: vi.fn(() => '/images/app/placeholders/placeholder-weapon-grid.png')
 }))
 
 // ============================================================================
@@ -68,13 +68,13 @@ describe('getJobPortraitUrl', () => {
 	it('generates slug from job name with Gran (default)', () => {
 		const job = makeJob({ name: { en: 'Dark Fencer', ja: '' } })
 		const url = getJobPortraitUrl(job)
-		expect(url).toBe('/images/job-portraits/dark-fencer_a.png')
+		expect(url).toBe('/images/jobs/portrait/dark-fencer_a.png')
 	})
 
 	it('uses gender suffix b for Djeeta', () => {
 		const job = makeJob({ name: { en: 'Dark Fencer', ja: '' } })
 		const url = getJobPortraitUrl(job, Gender.Djeeta)
-		expect(url).toBe('/images/job-portraits/dark-fencer_b.png')
+		expect(url).toBe('/images/jobs/portrait/dark-fencer_b.png')
 	})
 })
 
@@ -85,8 +85,8 @@ describe('getJobFullImageUrl', () => {
 
 	it('uses granblueId with gender suffix', () => {
 		const job = makeJob({ granblueId: '100101' })
-		expect(getJobFullImageUrl(job)).toBe('/images/job-zoom/100101_a.png')
-		expect(getJobFullImageUrl(job, Gender.Djeeta)).toBe('/images/job-zoom/100101_b.png')
+		expect(getJobFullImageUrl(job)).toBe('/images/jobs/zoom/100101_a.png')
+		expect(getJobFullImageUrl(job, Gender.Djeeta)).toBe('/images/jobs/zoom/100101_b.png')
 	})
 })
 
@@ -96,7 +96,7 @@ describe('getJobIconUrl', () => {
 	})
 
 	it('generates icon path from granblueId', () => {
-		expect(getJobIconUrl('100101')).toBe('/images/job-icons/100101.png')
+		expect(getJobIconUrl('100101')).toBe('/images/jobs/icon/100101.png')
 	})
 })
 
@@ -107,7 +107,7 @@ describe('getJobWideImageUrl', () => {
 
 	it('uses jpg extension and granblueId', () => {
 		const job = makeJob({ granblueId: '100101' })
-		expect(getJobWideImageUrl(job)).toBe('/images/job-wide/100101_a.jpg')
+		expect(getJobWideImageUrl(job)).toBe('/images/jobs/wide/100101_a.jpg')
 	})
 })
 

--- a/src/lib/utils/__tests__/modifiers.test.ts
+++ b/src/lib/utils/__tests__/modifiers.test.ts
@@ -45,12 +45,12 @@ describe('getAwakeningImage', () => {
 
 	it('returns jpg for character awakenings', () => {
 		const url = getAwakeningImage({ type: { slug: 'character-attack' } as unknown as Awakening })
-		expect(url).toBe('/images/awakening/character-attack.jpg')
+		expect(url).toBe('/images/icons/awakening/character-attack.jpg')
 	})
 
 	it('returns png for weapon awakenings', () => {
 		const url = getAwakeningImage({ type: { slug: 'attack' } as unknown as Awakening })
-		expect(url).toBe('/images/awakening/attack.png')
+		expect(url).toBe('/images/icons/awakening/attack.png')
 	})
 })
 
@@ -132,7 +132,7 @@ describe('getAxSkillImage', () => {
 	})
 
 	it('returns ax image path', () => {
-		expect(getAxSkillImage({ slug: 'might' })).toBe('/images/ax/might.png')
+		expect(getAxSkillImage({ slug: 'might' })).toBe('/images/icons/ax-skills/might.png')
 	})
 })
 

--- a/src/lib/utils/element.ts
+++ b/src/lib/utils/element.ts
@@ -147,11 +147,11 @@ export function getOppositeElement(element?: number): number | undefined {
 }
 
 /**
- * Get the path to the element image from /images/elements/
+ * Get the path to the element image from /images/icons/elements/
  * Used by ElementPicker component
  */
 export function getElementImage(element?: number): string {
 	if (element === undefined || element === null) return ''
 	const key = ELEMENT_KEYS[element]?.toLowerCase() ?? 'null'
-	return `${getBasePath()}/elements/${key}.png`
+	return `${getBasePath()}/icons/elements/${key}.png`
 }

--- a/src/lib/utils/images.ts
+++ b/src/lib/utils/images.ts
@@ -14,11 +14,36 @@ export type ResourceType = 'character' | 'weapon' | 'summon'
 export type ImageVariant = 'main' | 'tall' | 'grid' | 'square' | 'detail' | 'base' | 'wide'
 
 /**
- * Maps resource type and variant to the correct directory name
+ * Single source of truth for non-entity bucket prefixes. Entity art (character/
+ * weapon/summon) is built by {@link getImageDirectory}. See the migration runbook
+ * at hensei-api/docs/follow-ups/image-bucket-reorg.md — these MUST match the bucket.
+ * Game-CDN URLs and `previews/`/`profile/`/`guidebooks/`/`labels/`/`weapon-keys/`
+ * are intentionally not listed (unchanged / external).
+ */
+export const BUCKET = {
+	placeholders: 'app/placeholders',
+	marketing: 'app/marketing',
+	external: 'app/external',
+	abilities: 'icons/abilities',
+	jobSkills: 'icons/job-skills',
+	elements: 'icons/elements',
+	proficiencies: 'icons/proficiencies',
+	rarity: 'icons/rarity',
+	awakening: 'icons/awakening',
+	mastery: 'icons/mastery',
+	axSkills: 'icons/ax-skills',
+	accessories: 'accessories',
+	artifacts: 'artifacts',
+	bullets: 'bullets',
+	raids: 'raids'
+} as const
+
+/**
+ * Maps resource type and variant to the correct directory name.
+ * Entity art is grouped per entity: characters/weapons/summons + variant subdir.
  */
 function getImageDirectory(type: ResourceType, variant: ImageVariant): string {
-	// All directories follow the pattern: {type}-{variant}
-	return `${type}-${variant}`
+	return `${type}s/${variant}`
 }
 
 /**
@@ -48,7 +73,7 @@ export function getBasePath(): string {
  * Uses AWS S3/CDN in production, local path in development
  */
 export function getPlaceholderImage(type: ResourceType, variant: ImageVariant): string {
-	return `${getBasePath()}/placeholders/placeholder-${type}-${variant}.png`
+	return `${getBasePath()}/${BUCKET.placeholders}/placeholder-${type}-${variant}.png`
 }
 
 /**
@@ -56,7 +81,7 @@ export function getPlaceholderImage(type: ResourceType, variant: ImageVariant): 
  * Used as fallback for misc image types that don't have specific placeholders
  */
 export function getGenericPlaceholder(): string {
-	return `${getBasePath()}/placeholders/placeholder-weapon-grid.png`
+	return `${getBasePath()}/${BUCKET.placeholders}/placeholder-weapon-grid.png`
 }
 
 /**
@@ -462,23 +487,23 @@ export function getWeaponGridImage(
 export function getJobSkillIcon(
 	skill: { imageId?: string; slug?: string } | string | undefined
 ): string {
-	if (!skill) return '/images/job-skills/default.png'
+	if (!skill) return `${getBasePath()}/${BUCKET.jobSkills}/default.png`
 
 	// Handle string input (backward compatibility)
 	if (typeof skill === 'string') {
-		return `${getBasePath()}/job-skills/${skill}.png`
+		return `${getBasePath()}/${BUCKET.jobSkills}/${skill}.png`
 	}
 
 	// Use slug for the image path
 	if (skill.slug) {
-		return `${getBasePath()}/job-skills/${skill.slug}.png`
+		return `${getBasePath()}/${BUCKET.jobSkills}/${skill.slug}.png`
 	}
-	return '/images/job-skills/default.png'
+	return `${getBasePath()}/${BUCKET.jobSkills}/default.png`
 }
 
 /**
  * Charge attacks (ougi) and support skills have no custom art, so they share a
- * static icon under /ability-icons keyed by slot kind.
+ * static icon under icons/abilities keyed by slot kind.
  */
 const STATIC_SKILL_ICONS: Record<string, string> = {
 	ougi: 'charge-attack',
@@ -498,9 +523,9 @@ export function getCharacterSkillIcon(
 	kind?: string | null
 ): string | null {
 	const staticIcon = kind ? STATIC_SKILL_ICONS[kind] : undefined
-	if (staticIcon) return `${getBasePath()}/ability-icons/${staticIcon}.png`
+	if (staticIcon) return `${getBasePath()}/${BUCKET.abilities}/${staticIcon}.png`
 	if (!gameIcon) return null
-	return `${getBasePath()}/ability-icons/${gameIcon}.png`
+	return `${getBasePath()}/${BUCKET.abilities}/${gameIcon}.png`
 }
 
 /**
@@ -512,7 +537,7 @@ export function getAccessoryImage(
 	variant: 'square' | 'grid' = 'square'
 ): string {
 	if (!granblueId) return getGenericPlaceholder()
-	return `${getBasePath()}/accessory-${variant}/${granblueId}.jpg`
+	return `${getBasePath()}/${BUCKET.accessories}/${variant}/${granblueId}.jpg`
 }
 
 // ===== Modification Images =====
@@ -525,7 +550,7 @@ export function getAwakeningImage(
 	extension: 'png' | 'jpg' = 'jpg'
 ): string {
 	if (!slug) return ''
-	return `${getBasePath()}/awakening/${slug}.${extension}`
+	return `${getBasePath()}/${BUCKET.awakening}/${slug}.${extension}`
 }
 
 /**
@@ -540,7 +565,7 @@ export function getWeaponKeyImage(slug: string): string {
  */
 export function getAxSkillImage(slug: string | undefined): string {
 	if (!slug) return ''
-	return `${getBasePath()}/ax/${slug}.png`
+	return `${getBasePath()}/${BUCKET.axSkills}/${slug}.png`
 }
 
 /**
@@ -548,7 +573,7 @@ export function getAxSkillImage(slug: string | undefined): string {
  */
 export function getMasteryImage(slug: string | undefined): string {
 	if (!slug) return ''
-	return `${getBasePath()}/mastery/${slug}.png`
+	return `${getBasePath()}/${BUCKET.mastery}/${slug}.png`
 }
 
 // ===== Label Images =====
@@ -591,7 +616,7 @@ export function getGenderLabelImage(genderLabel: string): string {
  */
 export function getElementIcon(element: number): string {
 	const name = getElementKey(element)
-	return `${getBasePath()}/elements/element-${name}.png`
+	return `${getBasePath()}/${BUCKET.elements}/element-${name}.png`
 }
 
 // ===== Artifact Images =====
@@ -607,8 +632,7 @@ export function getArtifactImage(
 	variant: ArtifactImageVariant = 'square'
 ): string {
 	if (!granblueId) return getGenericPlaceholder()
-	const directory = `artifact-${variant}`
-	return `${getBasePath()}/${directory}/${granblueId}.jpg`
+	return `${getBasePath()}/${BUCKET.artifacts}/${variant}/${granblueId}.jpg`
 }
 
 // ===== Bullet Images =====
@@ -618,7 +642,7 @@ export function getArtifactImage(
  */
 export function getBulletImage(granblueId: string | number | null | undefined): string {
 	if (!granblueId) return getGenericPlaceholder()
-	return `${getBasePath()}/bullet-square/${granblueId}.jpg`
+	return `${getBasePath()}/${BUCKET.bullets}/square/${granblueId}.jpg`
 }
 
 /**
@@ -698,8 +722,7 @@ export function getRaidImage(
 	variant: RaidImageVariant = 'thumbnail'
 ): string {
 	if (!slug) return getGenericPlaceholder()
-	const directory = `raid-${variant}`
-	return `${getBasePath()}/${directory}/${slug}.png?v=${BUILD_TIMESTAMP}`
+	return `${getBasePath()}/${BUCKET.raids}/${variant}/${slug}.png?v=${BUILD_TIMESTAMP}`
 }
 
 /**

--- a/src/lib/utils/jobUtils.ts
+++ b/src/lib/utils/jobUtils.ts
@@ -31,7 +31,7 @@ export enum Gender {
 
 /**
  * Generate job portrait URL for protagonist slot (CharacterRep/CharacterUnit)
- * These are smaller portrait images stored in /static/images/job-portraits/
+ * These are smaller portrait images stored in /static/images/jobs/portrait/
  */
 export function getJobPortraitUrl(job: Job | undefined, gender: Gender = Gender.Gran): string {
 	if (!job) {
@@ -42,7 +42,7 @@ export function getJobPortraitUrl(job: Job | undefined, gender: Gender = Gender.
 	const slug = job.name.en.toLowerCase().replace(/\s+/g, '-')
 	const genderSuffix = gender === Gender.Djeeta ? 'b' : 'a'
 
-	return `${getBasePath()}/job-portraits/${slug}_${genderSuffix}.png`
+	return `${getBasePath()}/jobs/portrait/${slug}_${genderSuffix}.png`
 }
 
 /**
@@ -56,7 +56,7 @@ export function getJobFullImageUrl(job: Job | undefined, gender: Gender = Gender
 
 	const genderSuffix = gender === Gender.Djeeta ? 'b' : 'a'
 
-	return `${getBasePath()}/job-zoom/${job.granblueId}_${genderSuffix}.png`
+	return `${getBasePath()}/jobs/zoom/${job.granblueId}_${genderSuffix}.png`
 }
 
 /**
@@ -68,12 +68,12 @@ export function getJobIconUrl(granblueId: string | undefined): string {
 		return getGenericPlaceholder()
 	}
 
-	return `${getBasePath()}/job-icons/${granblueId}.png`
+	return `${getBasePath()}/jobs/icon/${granblueId}.png`
 }
 
 /**
  * Generate job wide banner image URL for JobItem component
- * These are wider banner-style images stored in /static/images/job-wide/
+ * These are wider banner-style images stored in /static/images/jobs/wide/
  */
 export function getJobWideImageUrl(job: Job | undefined, gender: Gender = Gender.Gran): string {
 	if (!job) {
@@ -81,7 +81,7 @@ export function getJobWideImageUrl(job: Job | undefined, gender: Gender = Gender
 	}
 
 	const genderSuffix = gender === Gender.Djeeta ? 'b' : 'a'
-	return `${getBasePath()}/job-wide/${job.granblueId}_${genderSuffix}.jpg`
+	return `${getBasePath()}/jobs/wide/${job.granblueId}_${genderSuffix}.jpg`
 }
 
 /**

--- a/src/lib/utils/modifiers.ts
+++ b/src/lib/utils/modifiers.ts
@@ -22,7 +22,7 @@ export function getAwakeningImage(awakening?: { type?: Awakening; level?: number
 	const isCharacterAwakening = slug.startsWith('character-')
 	const extension = isCharacterAwakening ? 'jpg' : 'png'
 
-	return `${getBasePath()}/awakening/${slug}.${extension}`
+	return `${getBasePath()}/icons/awakening/${slug}.${extension}`
 }
 
 /**
@@ -74,7 +74,7 @@ export function getWeaponKeyImages(
  */
 export function getAxSkillImage(axSkill?: { slug?: string }): string | null {
 	if (!axSkill?.slug) return null
-	return `${getBasePath()}/ax/${axSkill.slug}.png`
+	return `${getBasePath()}/icons/ax-skills/${axSkill.slug}.png`
 }
 
 /**
@@ -86,7 +86,7 @@ export function getAxSkillImages(ax?: AugmentSkill[]): Array<{ url: string; alt:
 	return ax
 		.filter((skill) => skill.modifier?.slug)
 		.map((skill) => ({
-			url: `${getBasePath()}/ax/${skill.modifier.slug}.png`,
+			url: `${getBasePath()}/icons/ax-skills/${skill.modifier.slug}.png`,
 			alt: skill.modifier.nameEn || skill.modifier.slug || 'AX Skill'
 		}))
 }
@@ -101,7 +101,7 @@ export function getBefoulmentImages(
 
 	return [
 		{
-			url: `${getBasePath()}/ax/${befoulment.modifier.slug}.png`,
+			url: `${getBasePath()}/icons/ax-skills/${befoulment.modifier.slug}.png`,
 			alt: befoulment.modifier.nameEn || befoulment.modifier.slug || 'Befoulment'
 		}
 	]

--- a/src/lib/utils/proficiency.ts
+++ b/src/lib/utils/proficiency.ts
@@ -55,5 +55,5 @@ export function getProficiencyOptions() {
 export function getProficiencyImage(proficiency: number): string {
 	const key = PROFICIENCY_KEYS[proficiency]
 	if (!key || key === 'None') return ''
-	return `${getBasePath()}/proficiencies/${key.toLowerCase()}.png`
+	return `${getBasePath()}/icons/proficiencies/${key.toLowerCase()}.png`
 }

--- a/src/lib/utils/rarity.ts
+++ b/src/lib/utils/rarity.ts
@@ -41,5 +41,5 @@ export function getRarityClass(rarity: number): string {
 export function getRarityImage(rarity: number): string {
 	const label = RARITY_LABELS[rarity]
 	if (!label) return ''
-	return `${getBasePath()}/rarity/${label.toLowerCase()}.png`
+	return `${getBasePath()}/icons/rarity/${label.toLowerCase()}.png`
 }

--- a/src/routes/(app)/about/+layout.svelte
+++ b/src/routes/(app)/about/+layout.svelte
@@ -28,7 +28,10 @@
 	{#if activeTab === 'about'}
 		<div class="about-card">
 			<div class="about-hero">
-				<img src="https://siero-img.s3-us-west-2.amazonaws.com/about-hero.jpg" alt="" />
+				<img
+					src="https://siero-img.s3-us-west-2.amazonaws.com/app/marketing/about-hero.jpg"
+					alt=""
+				/>
 			</div>
 			<nav class="about-nav">
 				<SegmentedControl
@@ -59,7 +62,10 @@
 	{:else}
 		<div class="about-card">
 			<div class="about-hero">
-				<img src="https://siero-img.s3-us-west-2.amazonaws.com/about-hero.jpg" alt="" />
+				<img
+					src="https://siero-img.s3-us-west-2.amazonaws.com/app/marketing/about-hero.jpg"
+					alt=""
+				/>
 			</div>
 			<nav class="about-nav">
 				<SegmentedControl

--- a/src/routes/(app)/about/+page.svelte
+++ b/src/routes/(app)/about/+page.svelte
@@ -60,15 +60,15 @@
 	<p>{m.about_data_explanation()}</p>
 	<ul class="data-sources">
 		<li>
-			<img src="{getBasePath()}/external/gbf-wiki-en.png" alt="" width="16" height="16" />
+			<img src="{getBasePath()}/app/external/gbf-wiki-en.png" alt="" width="16" height="16" />
 			<a href="https://gbf.wiki" target="_blank" rel="noreferrer">gbf.wiki</a>
 		</li>
 		<li>
-			<img src="{getBasePath()}/external/gbf-wiki-jp.png" alt="" width="16" height="16" />
+			<img src="{getBasePath()}/app/external/gbf-wiki-jp.png" alt="" width="16" height="16" />
 			<a href="https://gbf-wiki.com/" target="_blank" rel="noreferrer">gbf-wiki</a>
 		</li>
 		<li>
-			<img src="{getBasePath()}/external/kamigame.png" alt="" width="16" height="16" />
+			<img src="{getBasePath()}/app/external/kamigame.png" alt="" width="16" height="16" />
 			<a
 				href="https://kamigame.jp/%E3%82%B0%E3%83%A9%E3%83%96%E3%83%AB/index.html"
 				target="_blank"
@@ -76,7 +76,7 @@
 			>
 		</li>
 		<li>
-			<img src="{getBasePath()}/external/gamewith.png" alt="" width="16" height="16" />
+			<img src="{getBasePath()}/app/external/gamewith.png" alt="" width="16" height="16" />
 			<a href="https://xn--bck3aza1a2if6kra4ee0hf.gamewith.jp/" target="_blank" rel="noreferrer"
 				>Gamewith</a
 			>

--- a/src/routes/(app)/database/weapons/+page.svelte
+++ b/src/routes/(app)/database/weapons/+page.svelte
@@ -89,7 +89,7 @@
 
 	function getAwakeningImageUrl(slug: string): string {
 		const ext = slug.startsWith('character-') ? 'jpg' : 'png'
-		return `${getBasePath()}/awakening/${slug}.${ext}`
+		return `${getBasePath()}/icons/awakening/${slug}.${ext}`
 	}
 
 	// Column configuration for weapons

--- a/src/routes/(app)/test/context-menu/+page.svelte
+++ b/src/routes/(app)/test/context-menu/+page.svelte
@@ -32,7 +32,7 @@
 			<UnitMenuContainer showGearButton={true}>
 				{#snippet trigger()}
 					<img
-						src="/images/placeholders/placeholder-weapon-grid.png"
+						src="/images/app/placeholders/placeholder-weapon-grid.png"
 						alt="Test weapon"
 						class="test-image"
 					/>

--- a/src/routes/auth/+layout.svelte
+++ b/src/routes/auth/+layout.svelte
@@ -11,7 +11,7 @@
 
 	let { children }: Props = $props()
 
-	const backgroundUrl = `${getBasePath()}/port-breeze.jpg`
+	const backgroundUrl = `${getBasePath()}/app/marketing/port-breeze.jpg`
 </script>
 
 <div class="authContainer" style:--auth-bg-url="url('{backgroundUrl}')">


### PR DESCRIPTION
Follow-up to the image bucket reorg (read-path PR #878, merged). Adds `scripts/migrate-local-images.sh` — the local-disk equivalent of the S3 copy/cleanup, for reorganizing a dev image mirror (the git-ignored `/images` copy) to the new structure with `mv`.

- Takes one or more image-root dirs (e.g. `static/images`, or a worktree's `images/`).
- Dry-run by default; `APPLY=1` to execute. Idempotent / re-runnable.
- Same mapping as the bucket migration: entity art → `characters/ weapons/ summons/ …`, icon sets → `icons/*`, app assets → `app/*`; stages `jobs/`→`jobs/full` (then adds `jobs/{icon,portrait,wide,zoom}`) and `raids/`→`raids/full` correctly; removes orphans (`weapon-raw`, `raid-square`, dup nested `images/`, `.DS_Store`).

Already used to migrate both local checkouts.