### PR TITLE
Weapon skills tab on the database detail page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1891,5 +1891,15 @@
 	"character_skills_seconds": "{n} sec",
 	"character_skills_level": "Lv {n}",
 	"character_skills_uncap_star": "★{n}",
+	"weapon_skills_title": "Skills",
+	"weapon_skills_empty": "No skills found for this weapon",
+	"weapon_skills_slot": "Skill {n}",
+	"weapon_skills_tier_base": "Base",
+	"weapon_skills_tier_flb": "FLB",
+	"weapon_skills_tier_ulb": "ULB",
+	"weapon_skills_tier_transcendence": "T{n}",
+	"weapon_skills_level": "Lv {n}",
+	"weapon_skills_main_hand": "Main hand",
+	"weapon_skills_mc_only": "MC only",
 	"details_full_auto_skills": "Full Auto Skills"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1872,5 +1872,15 @@
 	"character_skills_seconds": "{n}秒",
 	"character_skills_level": "Lv {n}",
 	"character_skills_uncap_star": "★{n}",
+	"weapon_skills_title": "スキル",
+	"weapon_skills_empty": "この武器のスキルはありません",
+	"weapon_skills_slot": "スキル{n}",
+	"weapon_skills_tier_base": "通常",
+	"weapon_skills_tier_flb": "FLB",
+	"weapon_skills_tier_ulb": "ULB",
+	"weapon_skills_tier_transcendence": "T{n}",
+	"weapon_skills_level": "Lv {n}",
+	"weapon_skills_main_hand": "メイン装備時",
+	"weapon_skills_mc_only": "主人公のみ",
 	"details_full_auto_skills": "フルオートアビリティ"
 }

--- a/src/lib/api/adapters/entity.adapter.ts
+++ b/src/lib/api/adapters/entity.adapter.ts
@@ -30,7 +30,13 @@ import type {
 	CreateSummonSeriesPayload,
 	UpdateSummonSeriesPayload
 } from '$lib/types/api/summonSeries'
-import type { Awakening, Bullet, CharacterSkill, CharacterSkillLink } from '$lib/types/api/entities'
+import type {
+	Awakening,
+	Bullet,
+	CharacterSkill,
+	CharacterSkillLink,
+	WeaponSkill
+} from '$lib/types/api/entities'
 import type {
 	WeaponSeriesVariant,
 	CreateWeaponSeriesVariantPayload,
@@ -95,10 +101,7 @@ export interface Weapon {
 	axType?: number
 	bulletSlots?: number[]
 	skillLevelCap?: number
-	weapon_skills?: Array<{
-		name?: string
-		description?: string
-	}>
+	weaponSkills?: WeaponSkill[]
 	awakenings?: Array<{
 		id: string
 		name: Record<string, string>

--- a/src/lib/components/sidebar/details/SkillsSection.svelte
+++ b/src/lib/components/sidebar/details/SkillsSection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages'
 	import { localizedName } from '$lib/utils/locale'
+	import WeaponSkillList from '$lib/components/weapon/WeaponSkillList.svelte'
 
 	interface Props {
 		type: 'character' | 'weapon' | 'summon'
@@ -18,19 +19,10 @@
 	}
 </script>
 
-{#if type === 'weapon' && itemData?.weaponSkills && itemData.weaponSkills.length > 0}
+{#if type === 'weapon' && itemData?.weaponSkills?.length}
 	<div class="details-section">
 		<h3>{m.details_skills()}</h3>
-		<div class="skills-list">
-			{#each itemData.weaponSkills as skill (skill.id)}
-				<div class="skill-item">
-					<h4>{displayName(skill) || m.details_unknown_skill()}</h4>
-					{#if skill.description}
-						<p>{skill.description}</p>
-					{/if}
-				</div>
-			{/each}
-		</div>
+		<WeaponSkillList skills={itemData.weaponSkills} compact />
 	</div>
 {/if}
 
@@ -105,14 +97,12 @@
 		}
 	}
 
-	.skills-list,
 	.auras-list {
 		display: flex;
 		flex-direction: column;
 		gap: spacing.$unit-2x;
 	}
 
-	.skill-item,
 	.aura-item {
 		padding: spacing.$unit;
 		background: var(--page-hover);

--- a/src/lib/components/weapon/WeaponSkillList.svelte
+++ b/src/lib/components/weapon/WeaponSkillList.svelte
@@ -1,0 +1,228 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages'
+	import { localizedName, appLocale } from '$lib/utils/locale'
+	import { getWeaponSkillIcon } from '$lib/utils/images'
+	import { wikiToHtml } from '$lib/utils/wikiText'
+	import type { WeaponSkill, WeaponSkillVersion } from '$lib/types/api/entities'
+
+	interface Props {
+		skills: WeaponSkill[] | undefined
+		/** Tighter layout (smaller icon, EN-only) for narrow contexts like the sidebar. */
+		compact?: boolean
+	}
+
+	let { skills, compact = false }: Props = $props()
+
+	const locale = $derived(appLocale())
+	const slots = $derived([...(skills ?? [])].sort((a, b) => a.position - b.position))
+
+	function versions(slot: WeaponSkill): WeaponSkillVersion[] {
+		return [...(slot.versions ?? [])].sort((a, b) => a.ordinal - b.ordinal)
+	}
+
+	// Tier label derived from uncap stars + transcendence stage.
+	function tierLabel(version: WeaponSkillVersion): string {
+		if ((version.transcendenceStage ?? 0) > 0) {
+			return m.weapon_skills_tier_transcendence({ n: version.transcendenceStage as number })
+		}
+		if (version.minUncap === 5) return m.weapon_skills_tier_ulb()
+		if (version.minUncap === 4) return m.weapon_skills_tier_flb()
+		return m.weapon_skills_tier_base()
+	}
+
+	// modifier · series · size — only present for standard grid-scaling skills.
+	function scalingMeta(version: WeaponSkillVersion): string {
+		return [version.skillModifier, version.skillSeries, version.skillSize]
+			.filter(Boolean)
+			.join(' · ')
+	}
+
+	// Hide an icon that 404s rather than showing a broken-image glyph.
+	function hideBrokenIcon(event: Event) {
+		;(event.currentTarget as HTMLImageElement).style.display = 'none'
+	}
+</script>
+
+<div class="weapon-skill-list" class:compact>
+	{#each slots as slot (slot.position)}
+		<section class="slot">
+			<h5 class="slot-title">{m.weapon_skills_slot({ n: slot.position + 1 })}</h5>
+			{#each versions(slot) as version (version.ordinal)}
+				{@const descriptionEn = version.description?.en?.trim()}
+				{@const descriptionJa = version.description?.ja?.trim()}
+				{@const meta = scalingMeta(version)}
+				{@const iconUrl = getWeaponSkillIcon(version.iconStem, locale)}
+				<div class="version-card">
+					{#if iconUrl}
+						<img
+							class="icon"
+							src={iconUrl}
+							alt={localizedName(version.name)}
+							loading="lazy"
+							onerror={hideBrokenIcon}
+						/>
+					{/if}
+					<div class="info">
+						<div class="name-row">
+							<span class="name">{localizedName(version.name)}</span>
+							{#if !compact && version.name?.ja}
+								<span class="name-jp">{version.name.ja}</span>
+							{/if}
+							<span class="badge tier">{tierLabel(version)}</span>
+							{#if version.unlockLevel}
+								<span class="badge">{m.weapon_skills_level({ n: version.unlockLevel })}</span>
+							{/if}
+							{#if version.mainHandOnly}
+								<span class="badge flag">{m.weapon_skills_main_hand()}</span>
+							{/if}
+							{#if version.mcOnly}
+								<span class="badge flag">{m.weapon_skills_mc_only()}</span>
+							{/if}
+						</div>
+						{#if meta}
+							<div class="meta">{meta}</div>
+						{/if}
+						{#if descriptionEn}
+							<!-- eslint-disable-next-line svelte/no-at-html-tags -- wikiToHtml emits only whitelisted tags -->
+							<p class="description">{@html wikiToHtml(descriptionEn)}</p>
+						{/if}
+						{#if !compact && descriptionJa}
+							<!-- eslint-disable-next-line svelte/no-at-html-tags -- wikiToHtml emits only whitelisted tags -->
+							<p class="description description-jp">{@html wikiToHtml(descriptionJa)}</p>
+						{/if}
+					</div>
+				</div>
+			{/each}
+		</section>
+	{/each}
+</div>
+
+<style lang="scss">
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+	@use '$src/themes/layout' as layout;
+
+	.weapon-skill-list {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-3x;
+	}
+
+	.slot {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-half;
+	}
+
+	.slot-title {
+		font-size: typography.$font-small;
+		font-weight: typography.$medium;
+		color: var(--text-secondary);
+		margin: 0;
+	}
+
+	.version-card {
+		display: flex;
+		flex-direction: row;
+		align-items: flex-start;
+		gap: spacing.$unit;
+		background: var(--card-bg);
+		border-radius: layout.$item-corner;
+		padding: spacing.$unit 0;
+	}
+
+	.icon {
+		flex: 0 0 auto;
+		width: spacing.$unit-6x;
+		height: spacing.$unit-6x;
+		border-radius: layout.$item-corner-small;
+		object-fit: contain;
+	}
+
+	.info {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-half;
+	}
+
+	.name-row {
+		display: flex;
+		align-items: baseline;
+		flex-wrap: wrap;
+		gap: spacing.$unit-half spacing.$unit;
+	}
+
+	.name {
+		font-size: typography.$font-medium;
+		font-weight: typography.$medium;
+		color: var(--text-primary);
+	}
+
+	.name-jp {
+		font-size: typography.$font-small;
+		color: var(--text-secondary);
+	}
+
+	.badge {
+		font-size: typography.$font-tiny;
+		font-weight: typography.$medium;
+		color: var(--text-secondary);
+		background: var(--background);
+		padding: 0 spacing.$unit-half;
+		border-radius: layout.$item-corner-small;
+		line-height: 1.6;
+
+		&.tier {
+			color: var(--text-primary);
+		}
+
+		&.flag {
+			font-style: italic;
+		}
+	}
+
+	.meta {
+		font-size: typography.$font-small;
+		color: var(--text-secondary);
+	}
+
+	.description {
+		margin: 0;
+		font-size: typography.$font-small;
+		line-height: 1.5;
+		color: var(--text-primary);
+		white-space: pre-line;
+
+		:global(strong) {
+			font-weight: typography.$bold;
+		}
+
+		:global(em) {
+			font-style: italic;
+		}
+	}
+
+	.description-jp {
+		color: var(--text-secondary);
+	}
+
+	// Sidebar / narrow layout
+	.compact {
+		gap: spacing.$unit-2x;
+
+		.version-card {
+			gap: spacing.$unit-half;
+		}
+
+		.icon {
+			width: spacing.$unit-4x;
+			height: spacing.$unit-4x;
+		}
+
+		.name {
+			font-size: typography.$font-small;
+		}
+	}
+</style>

--- a/src/lib/features/database/detail/DetailScaffold.svelte
+++ b/src/lib/features/database/detail/DetailScaffold.svelte
@@ -6,7 +6,7 @@
 	import Button from '$lib/components/ui/Button.svelte'
 	import type { Snippet } from 'svelte'
 
-	export type DetailTab = 'info' | 'images' | 'raw'
+	export type DetailTab = 'info' | 'skills' | 'images' | 'raw'
 
 	interface Props {
 		type: 'character' | 'summon' | 'weapon' | 'job' | 'raid' | 'accessory'
@@ -26,6 +26,8 @@
 		currentTab?: DetailTab
 		onTabChange?: (tab: DetailTab) => void
 		showTabs?: boolean
+		/** Show a Skills tab (between Info and Images) — currently weapons only. */
+		showSkills?: boolean
 		// Image download handlers
 		onDownloadAllImages?: (force: boolean) => Promise<void>
 		onDownloadSize?: (size: string) => Promise<void>
@@ -48,6 +50,7 @@
 		currentTab = 'info',
 		onTabChange,
 		showTabs = true,
+		showSkills = false,
 		onDownloadAllImages,
 		onDownloadSize,
 		availableSizes = [],
@@ -112,6 +115,9 @@
 				size="small"
 			>
 				<Segment value="info">Info</Segment>
+				{#if showSkills}
+					<Segment value="skills">Skills</Segment>
+				{/if}
 				<Segment value="images">Images</Segment>
 				<Segment value="raw">Raw Data</Segment>
 			</SegmentedControl>

--- a/src/lib/features/database/weapons/tabs/WeaponSkillsTab.svelte
+++ b/src/lib/features/database/weapons/tabs/WeaponSkillsTab.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages'
-	import { localizedName, appLocale } from '$lib/utils/locale'
-	import { getWeaponSkillIcon } from '$lib/utils/images'
-	import { wikiToHtml } from '$lib/utils/wikiText'
-	import type { WeaponSkill, WeaponSkillVersion } from '$lib/types/api/entities'
+	import WeaponSkillList from '$lib/components/weapon/WeaponSkillList.svelte'
+	import type { WeaponSkill } from '$lib/types/api/entities'
 
 	interface Props {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic entity shape from API
@@ -12,213 +10,27 @@
 
 	let { weapon }: Props = $props()
 
-	const locale = $derived(appLocale())
-
-	// Hide an icon that 404s rather than showing a broken-image glyph.
-	function hideBrokenIcon(event: Event) {
-		;(event.currentTarget as HTMLImageElement).style.display = 'none'
-	}
-
-	const slots = $derived(
-		[...((weapon?.weaponSkills ?? []) as WeaponSkill[])].sort((a, b) => a.position - b.position)
-	)
-
-	function versions(slot: WeaponSkill): WeaponSkillVersion[] {
-		return [...(slot.versions ?? [])].sort((a, b) => a.ordinal - b.ordinal)
-	}
-
-	// Tier label derived from uncap stars + transcendence stage.
-	function tierLabel(version: WeaponSkillVersion): string {
-		if ((version.transcendenceStage ?? 0) > 0) {
-			return m.weapon_skills_tier_transcendence({ n: version.transcendenceStage as number })
-		}
-		if (version.minUncap === 5) return m.weapon_skills_tier_ulb()
-		if (version.minUncap === 4) return m.weapon_skills_tier_flb()
-		return m.weapon_skills_tier_base()
-	}
-
-	// modifier · series · size — only present for standard grid-scaling skills.
-	function scalingMeta(version: WeaponSkillVersion): string {
-		return [version.skillModifier, version.skillSeries, version.skillSize]
-			.filter(Boolean)
-			.join(' · ')
-	}
+	const skills = $derived((weapon?.weaponSkills ?? []) as WeaponSkill[])
 </script>
 
 <div class="skills-tab">
-	{#if !slots.length}
+	{#if !skills.length}
 		<div class="empty">{m.weapon_skills_empty()}</div>
 	{:else}
-		{#each slots as slot (slot.position)}
-			<section class="slot">
-				<h3 class="slot-title">{m.weapon_skills_slot({ n: slot.position + 1 })}</h3>
-				{#each versions(slot) as version (version.ordinal)}
-					{@const descriptionEn = version.description?.en?.trim()}
-					{@const descriptionJa = version.description?.ja?.trim()}
-					{@const meta = scalingMeta(version)}
-					{@const iconUrl = getWeaponSkillIcon(version.iconStem, locale)}
-					<div class="version-card">
-						{#if iconUrl}
-							<img
-								class="icon"
-								src={iconUrl}
-								alt={localizedName(version.name)}
-								loading="lazy"
-								onerror={hideBrokenIcon}
-							/>
-						{/if}
-						<div class="info">
-							<div class="name-row">
-								<span class="name">{localizedName(version.name)}</span>
-								{#if version.name?.ja}
-									<span class="name-jp">{version.name.ja}</span>
-								{/if}
-								<span class="badge tier">{tierLabel(version)}</span>
-								{#if version.unlockLevel}
-									<span class="badge">{m.weapon_skills_level({ n: version.unlockLevel })}</span>
-								{/if}
-								{#if version.mainHandOnly}
-									<span class="badge flag">{m.weapon_skills_main_hand()}</span>
-								{/if}
-								{#if version.mcOnly}
-									<span class="badge flag">{m.weapon_skills_mc_only()}</span>
-								{/if}
-							</div>
-							{#if meta}
-								<div class="meta">{meta}</div>
-							{/if}
-							{#if descriptionEn}
-								<!-- eslint-disable-next-line svelte/no-at-html-tags -- wikiToHtml emits only whitelisted tags -->
-								<p class="description">{@html wikiToHtml(descriptionEn)}</p>
-							{/if}
-							{#if descriptionJa}
-								<!-- eslint-disable-next-line svelte/no-at-html-tags -- wikiToHtml emits only whitelisted tags -->
-								<p class="description description-jp">{@html wikiToHtml(descriptionJa)}</p>
-							{/if}
-						</div>
-					</div>
-				{/each}
-			</section>
-		{/each}
+		<WeaponSkillList {skills} />
 	{/if}
 </div>
 
 <style lang="scss">
 	@use '$src/themes/spacing' as spacing;
-	@use '$src/themes/typography' as typography;
-	@use '$src/themes/layout' as layout;
 
 	.skills-tab {
-		display: flex;
-		flex-direction: column;
-		gap: spacing.$unit-3x;
 		padding: spacing.$unit-2x;
 	}
 
 	.empty {
 		text-align: center;
 		padding: spacing.$unit-4x;
-		color: var(--text-secondary);
-	}
-
-	.slot {
-		display: flex;
-		flex-direction: column;
-		gap: spacing.$unit-half;
-	}
-
-	.slot-title {
-		font-size: typography.$font-small;
-		font-weight: typography.$medium;
-		color: var(--text-secondary);
-		margin: 0;
-	}
-
-	.version-card {
-		display: flex;
-		flex-direction: row;
-		align-items: flex-start;
-		gap: spacing.$unit;
-		background: var(--card-bg);
-		border-radius: layout.$item-corner;
-		padding: spacing.$unit 0;
-	}
-
-	.icon {
-		flex: 0 0 auto;
-		width: spacing.$unit-6x;
-		height: spacing.$unit-6x;
-		border-radius: layout.$item-corner-small;
-		object-fit: contain;
-	}
-
-	.info {
-		flex: 1;
-		min-width: 0;
-		display: flex;
-		flex-direction: column;
-		gap: spacing.$unit-half;
-	}
-
-	.name-row {
-		display: flex;
-		align-items: baseline;
-		flex-wrap: wrap;
-		gap: spacing.$unit-half spacing.$unit;
-	}
-
-	.name {
-		font-size: typography.$font-medium;
-		font-weight: typography.$medium;
-		color: var(--text-primary);
-	}
-
-	.name-jp {
-		font-size: typography.$font-small;
-		color: var(--text-secondary);
-	}
-
-	.badge {
-		font-size: typography.$font-tiny;
-		font-weight: typography.$medium;
-		color: var(--text-secondary);
-		background: var(--background);
-		padding: 0 spacing.$unit-half;
-		border-radius: layout.$item-corner-small;
-		line-height: 1.6;
-
-		&.tier {
-			color: var(--text-primary);
-		}
-
-		&.flag {
-			font-style: italic;
-		}
-	}
-
-	.meta {
-		font-size: typography.$font-small;
-		color: var(--text-secondary);
-	}
-
-	.description {
-		margin: 0;
-		font-size: typography.$font-small;
-		line-height: 1.5;
-		color: var(--text-primary);
-		white-space: pre-line;
-
-		// wikiToHtml emits <strong>/<em>; ensure they render with emphasis.
-		:global(strong) {
-			font-weight: typography.$bold;
-		}
-
-		:global(em) {
-			font-style: italic;
-		}
-	}
-
-	.description-jp {
 		color: var(--text-secondary);
 	}
 </style>

--- a/src/lib/features/database/weapons/tabs/WeaponSkillsTab.svelte
+++ b/src/lib/features/database/weapons/tabs/WeaponSkillsTab.svelte
@@ -1,0 +1,224 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages'
+	import { localizedName, appLocale } from '$lib/utils/locale'
+	import { getWeaponSkillIcon } from '$lib/utils/images'
+	import { wikiToHtml } from '$lib/utils/wikiText'
+	import type { WeaponSkill, WeaponSkillVersion } from '$lib/types/api/entities'
+
+	interface Props {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic entity shape from API
+		weapon: any
+	}
+
+	let { weapon }: Props = $props()
+
+	const locale = $derived(appLocale())
+
+	// Hide an icon that 404s rather than showing a broken-image glyph.
+	function hideBrokenIcon(event: Event) {
+		;(event.currentTarget as HTMLImageElement).style.display = 'none'
+	}
+
+	const slots = $derived(
+		[...((weapon?.weaponSkills ?? []) as WeaponSkill[])].sort((a, b) => a.position - b.position)
+	)
+
+	function versions(slot: WeaponSkill): WeaponSkillVersion[] {
+		return [...(slot.versions ?? [])].sort((a, b) => a.ordinal - b.ordinal)
+	}
+
+	// Tier label derived from uncap stars + transcendence stage.
+	function tierLabel(version: WeaponSkillVersion): string {
+		if ((version.transcendenceStage ?? 0) > 0) {
+			return m.weapon_skills_tier_transcendence({ n: version.transcendenceStage as number })
+		}
+		if (version.minUncap === 5) return m.weapon_skills_tier_ulb()
+		if (version.minUncap === 4) return m.weapon_skills_tier_flb()
+		return m.weapon_skills_tier_base()
+	}
+
+	// modifier · series · size — only present for standard grid-scaling skills.
+	function scalingMeta(version: WeaponSkillVersion): string {
+		return [version.skillModifier, version.skillSeries, version.skillSize]
+			.filter(Boolean)
+			.join(' · ')
+	}
+</script>
+
+<div class="skills-tab">
+	{#if !slots.length}
+		<div class="empty">{m.weapon_skills_empty()}</div>
+	{:else}
+		{#each slots as slot (slot.position)}
+			<section class="slot">
+				<h3 class="slot-title">{m.weapon_skills_slot({ n: slot.position + 1 })}</h3>
+				{#each versions(slot) as version (version.ordinal)}
+					{@const descriptionEn = version.description?.en?.trim()}
+					{@const descriptionJa = version.description?.ja?.trim()}
+					{@const meta = scalingMeta(version)}
+					{@const iconUrl = getWeaponSkillIcon(version.iconStem, locale)}
+					<div class="version-card">
+						{#if iconUrl}
+							<img
+								class="icon"
+								src={iconUrl}
+								alt={localizedName(version.name)}
+								loading="lazy"
+								onerror={hideBrokenIcon}
+							/>
+						{/if}
+						<div class="info">
+							<div class="name-row">
+								<span class="name">{localizedName(version.name)}</span>
+								{#if version.name?.ja}
+									<span class="name-jp">{version.name.ja}</span>
+								{/if}
+								<span class="badge tier">{tierLabel(version)}</span>
+								{#if version.unlockLevel}
+									<span class="badge">{m.weapon_skills_level({ n: version.unlockLevel })}</span>
+								{/if}
+								{#if version.mainHandOnly}
+									<span class="badge flag">{m.weapon_skills_main_hand()}</span>
+								{/if}
+								{#if version.mcOnly}
+									<span class="badge flag">{m.weapon_skills_mc_only()}</span>
+								{/if}
+							</div>
+							{#if meta}
+								<div class="meta">{meta}</div>
+							{/if}
+							{#if descriptionEn}
+								<!-- eslint-disable-next-line svelte/no-at-html-tags -- wikiToHtml emits only whitelisted tags -->
+								<p class="description">{@html wikiToHtml(descriptionEn)}</p>
+							{/if}
+							{#if descriptionJa}
+								<!-- eslint-disable-next-line svelte/no-at-html-tags -- wikiToHtml emits only whitelisted tags -->
+								<p class="description description-jp">{@html wikiToHtml(descriptionJa)}</p>
+							{/if}
+						</div>
+					</div>
+				{/each}
+			</section>
+		{/each}
+	{/if}
+</div>
+
+<style lang="scss">
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+	@use '$src/themes/layout' as layout;
+
+	.skills-tab {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-3x;
+		padding: spacing.$unit-2x;
+	}
+
+	.empty {
+		text-align: center;
+		padding: spacing.$unit-4x;
+		color: var(--text-secondary);
+	}
+
+	.slot {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-half;
+	}
+
+	.slot-title {
+		font-size: typography.$font-small;
+		font-weight: typography.$medium;
+		color: var(--text-secondary);
+		margin: 0;
+	}
+
+	.version-card {
+		display: flex;
+		flex-direction: row;
+		align-items: flex-start;
+		gap: spacing.$unit;
+		background: var(--card-bg);
+		border-radius: layout.$item-corner;
+		padding: spacing.$unit 0;
+	}
+
+	.icon {
+		flex: 0 0 auto;
+		width: spacing.$unit-6x;
+		height: spacing.$unit-6x;
+		border-radius: layout.$item-corner-small;
+		object-fit: contain;
+	}
+
+	.info {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-half;
+	}
+
+	.name-row {
+		display: flex;
+		align-items: baseline;
+		flex-wrap: wrap;
+		gap: spacing.$unit-half spacing.$unit;
+	}
+
+	.name {
+		font-size: typography.$font-medium;
+		font-weight: typography.$medium;
+		color: var(--text-primary);
+	}
+
+	.name-jp {
+		font-size: typography.$font-small;
+		color: var(--text-secondary);
+	}
+
+	.badge {
+		font-size: typography.$font-tiny;
+		font-weight: typography.$medium;
+		color: var(--text-secondary);
+		background: var(--background);
+		padding: 0 spacing.$unit-half;
+		border-radius: layout.$item-corner-small;
+		line-height: 1.6;
+
+		&.tier {
+			color: var(--text-primary);
+		}
+
+		&.flag {
+			font-style: italic;
+		}
+	}
+
+	.meta {
+		font-size: typography.$font-small;
+		color: var(--text-secondary);
+	}
+
+	.description {
+		margin: 0;
+		font-size: typography.$font-small;
+		line-height: 1.5;
+		color: var(--text-primary);
+		white-space: pre-line;
+
+		// wikiToHtml emits <strong>/<em>; ensure they render with emphasis.
+		:global(strong) {
+			font-weight: typography.$bold;
+		}
+
+		:global(em) {
+			font-style: italic;
+		}
+	}
+
+	.description-jp {
+		color: var(--text-secondary);
+	}
+</style>

--- a/src/lib/types/api/entities.ts
+++ b/src/lib/types/api/entities.ts
@@ -72,6 +72,41 @@ export interface Weapon {
 	elementVariantIds?: Record<string, string> | null
 	// Bullet slots for gun-proficiency weapons (array of bullet type integers)
 	bulletSlots?: number[]
+	/** Passive weapon skills, one entry per slot, each holding its evolving version tiers. */
+	weaponSkills?: WeaponSkill[]
+}
+
+/** One uncap/transcendence tier of a weapon skill slot. */
+export interface WeaponSkillVersion {
+	name: LocalizedName
+	description: LocalizedName
+	/** Resolved CDN icon stem (internal element numbering), e.g. "skill_atk_4_4". */
+	iconStem?: string | null
+	ordinal: number
+	/** Weapon level at which this version unlocks (null for the base version). */
+	unlockLevel?: number | null
+	/** Minimum uncap stars: 3 = base/MLB, 4 = FLB, 5 = ULB. */
+	minUncap?: number | null
+	/** Transcendence stage 0–5 (0 = not transcended). */
+	transcendenceStage?: number | null
+	skillModifier?: string | null
+	skillSeries?: string | null
+	skillSize?: string | null
+	mainHandOnly?: boolean
+	mcOnly?: boolean
+	scalesWithSkillLevel?: boolean
+	skill?: {
+		id: string
+		name: LocalizedName
+		description: LocalizedName
+		skillType?: string
+	} | null
+}
+
+/** A weapon skill slot (one position) holding its evolving version tiers. */
+export interface WeaponSkill {
+	position: number
+	versions: WeaponSkillVersion[]
 }
 
 // Character entity from CharacterBlueprint

--- a/src/lib/utils/images.ts
+++ b/src/lib/utils/images.ts
@@ -30,6 +30,7 @@ export const BUCKET = {
 	proficiencies: 'icons/proficiencies',
 	rarity: 'icons/rarity',
 	awakening: 'icons/awakening',
+	weaponSkills: 'icons/weapon-skills',
 	mastery: 'icons/mastery',
 	axSkills: 'icons/ax-skills',
 	accessories: 'accessories',
@@ -551,6 +552,20 @@ export function getAwakeningImage(
 ): string {
 	if (!slug) return ''
 	return `${getBasePath()}/${BUCKET.awakening}/${slug}.${extension}`
+}
+
+/**
+ * Get a weapon skill icon URL for the given locale. The stem (e.g.
+ * "skill_atk_4_4") is the resolved, internal-element-numbered name the API
+ * exposes as `iconStem`; EN and JA variants live in language subdirectories.
+ */
+export function getWeaponSkillIcon(
+	stem: string | null | undefined,
+	locale: string = 'en'
+): string | null {
+	if (!stem) return null
+	const lang = locale === 'ja' ? 'ja' : 'en'
+	return `${getBasePath()}/${BUCKET.weaponSkills}/${lang}/${stem}.png`
 }
 
 /**

--- a/src/lib/utils/wikiText.test.ts
+++ b/src/lib/utils/wikiText.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { wikiToHtml } from './wikiText'
+
+describe('wikiToHtml', () => {
+	it('returns empty string for nullish input', () => {
+		expect(wikiToHtml(null)).toBe('')
+		expect(wikiToHtml(undefined)).toBe('')
+		expect(wikiToHtml('')).toBe('')
+	})
+
+	it('converts bold markup to <strong> and hides the apostrophes', () => {
+		expect(wikiToHtml("'''When main weapon (MC only):'''")).toBe(
+			'<strong>When main weapon (MC only):</strong>'
+		)
+		expect(wikiToHtml("'''When main weapon (MC only):'''")).not.toContain("'''")
+	})
+
+	it('converts italic markup to <em>', () => {
+		expect(wikiToHtml("''subtle''")).toBe('<em>subtle</em>')
+	})
+
+	it('renders <br> variants as line breaks', () => {
+		expect(wikiToHtml('a<br />b<br/>c<br>d')).toBe('a<br>b<br>c<br>d')
+	})
+
+	it('reduces {{status|Name|...}} to the status name', () => {
+		expect(wikiToHtml('gain {{status|DMG Mitigation|t=2T|a=3000}}.')).toBe('gain DMG Mitigation.')
+	})
+
+	it('reduces wiki links to their display text', () => {
+		expect(wikiToHtml('[[Multistrike|Double Strike]] effect')).toBe('Double Strike effect')
+		expect(wikiToHtml('[[Bonus DMG]]')).toBe('Bonus DMG')
+	})
+
+	it('strips <ref> citations', () => {
+		expect(wikiToHtml('Reduce damage.<ref name="GameWith, Hrunting">cite</ref>')).toBe(
+			'Reduce damage.'
+		)
+		expect(wikiToHtml('Reduce damage.<ref name=GameWith />')).toBe('Reduce damage.')
+	})
+
+	it('escapes stray HTML to prevent injection', () => {
+		expect(wikiToHtml('<img src=x onerror=alert(1)>')).not.toContain('<img')
+		expect(wikiToHtml('a & b')).toContain('&amp;')
+	})
+
+	it('handles a full Hrunting-style description', () => {
+		const input =
+			"'''When main weapon (MC only):'''<br />All Earth allies gain {{status|Veil|t=i}}.<ref name=GW />"
+		expect(wikiToHtml(input)).toBe(
+			'<strong>When main weapon (MC only):</strong><br>All Earth allies gain Veil.'
+		)
+	})
+})

--- a/src/lib/utils/wikiText.ts
+++ b/src/lib/utils/wikiText.ts
@@ -1,0 +1,39 @@
+import { escapeHtml } from './safeHtml'
+
+/**
+ * Converts the MediaWiki markup found in gbf.wiki skill descriptions into safe
+ * HTML. The output contains only a whitelisted set of tags (`<strong>`, `<em>`,
+ * `<br>`); everything else is HTML-escaped, so the result is safe for `{@html}`.
+ *
+ * Handles:
+ * - `'''bold'''` → `<strong>`, `''italic''` → `<em>`
+ * - `<br>` / `<br/>` / `<br />` line breaks
+ * - `{{status|Name|...}}` → `Name` (the status's display name)
+ * - other `{{template|arg|...}}` → first argument
+ * - `[[Link|Display]]` → `Display`, `[[Link]]` → `Link`
+ * - strips `<ref>` citations entirely
+ */
+export function wikiToHtml(input: string | null | undefined): string {
+	if (!input) return ''
+
+	const stripped = input
+		// Drop citation refs (paired and self-closing) before anything else.
+		.replace(/<ref\b[^>]*>[\s\S]*?<\/ref>/gi, '')
+		.replace(/<ref\b[^>]*\/?>/gi, '')
+		// Line breaks → newline (covers <br>, <br/>, <br />, and the stray <br/ >).
+		.replace(/<br\s*\/?\s*>/gi, '\n')
+		// {{status|Name|...}} → the status name (first parameter).
+		.replace(/\{\{status\|([^|}]+)[^}]*\}\}/gi, '$1')
+		// Any other {{template|arg|...}} → first argument / template name.
+		.replace(/\{\{([^|}]+)[^}]*\}\}/g, '$1')
+		// [[Link|Display]] → Display ; [[Link]] → Link.
+		.replace(/\[\[(?:[^|\]]*\|)?([^\]]+)\]\]/g, '$1')
+
+	// Escape, then convert wiki bold/italic. escapeHtml turns each apostrophe into
+	// &#39;, so '''bold''' becomes a run of six entities — match those. Bold (3)
+	// runs before italic (2) so triple-quotes aren't mistaken for italics.
+	return escapeHtml(stripped)
+		.replace(/(?:&#39;){3}(.+?)(?:&#39;){3}/g, '<strong>$1</strong>')
+		.replace(/(?:&#39;){2}(.+?)(?:&#39;){2}/g, '<em>$1</em>')
+		.replace(/\n/g, '<br>')
+}

--- a/src/routes/(app)/database/weapons/[granblueId]/+page.svelte
+++ b/src/routes/(app)/database/weapons/[granblueId]/+page.svelte
@@ -25,6 +25,7 @@
 	import WeaponGachaSection from '$lib/features/database/weapons/sections/WeaponGachaSection.svelte'
 	import WeaponAwakeningSection from '$lib/features/database/weapons/sections/WeaponAwakeningSection.svelte'
 	import WeaponForgeSection from '$lib/features/database/weapons/sections/WeaponForgeSection.svelte'
+	import WeaponSkillsTab from '$lib/features/database/weapons/tabs/WeaponSkillsTab.svelte'
 	import { BULLET_TYPES } from '$lib/types/api/entities'
 	import EntityImagesTab from '$lib/features/database/detail/tabs/EntityImagesTab.svelte'
 	import EntityRawDataTab from '$lib/features/database/detail/tabs/EntityRawDataTab.svelte'
@@ -313,6 +314,7 @@
 			onDownloadAllImages={canEdit ? handleDownloadAllImages : undefined}
 			onDownloadSize={canEdit ? handleDownloadSize : undefined}
 			availableSizes={weaponSizes}
+			showSkills={(weapon.weaponSkills?.length ?? 0) > 0}
 		>
 			{#if currentTab === 'info'}
 				<section class="details">
@@ -441,25 +443,9 @@
 							{/if}
 						</DetailItem>
 					</DetailsContainer>
-
-					<div class="weapon-skills">
-						<h3>Skills</h3>
-						<div class="skills-grid">
-							{#if weapon.weapon_skills && weapon.weapon_skills.length > 0}
-								{#each weapon.weapon_skills as skill, i (i)}
-									<div class="skill-item">
-										<h4 class="skill-name">{skill.name || 'Unknown Skill'}</h4>
-										<p class="skill-description">
-											{skill.description || 'No description available'}
-										</p>
-									</div>
-								{/each}
-							{:else}
-								<p class="no-skills">No skills available</p>
-							{/if}
-						</div>
-					</div>
 				</section>
+			{:else if currentTab === 'skills'}
+				<WeaponSkillsTab {weapon} />
 			{:else if currentTab === 'images'}
 				<EntityImagesTab
 					images={weaponImages}
@@ -515,61 +501,6 @@
 
 	.details {
 		@include database.details;
-	}
-
-	.weapon-skills {
-		padding: spacing.$unit-2x;
-		border-bottom: 1px solid var(--table-border);
-
-		&:last-child {
-			border-bottom: none;
-		}
-
-		h3 {
-			font-size: typography.$font-large;
-			font-weight: typography.$bold;
-			color: var(--text-primary);
-			margin: 0 0 spacing.$unit 0;
-		}
-
-		.skills-grid {
-			display: grid;
-			grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-			gap: spacing.$unit;
-
-			.skill-item {
-				padding: spacing.$unit;
-				background: var(--table-header-bg);
-				border-radius: layout.$item-corner-small;
-
-				.skill-name {
-					font-size: typography.$font-medium;
-					font-weight: typography.$medium;
-					margin: 0 0 spacing.$unit * 0.5 0;
-					color: var(--text-primary);
-				}
-
-				.skill-description {
-					font-size: typography.$font-small;
-					color: var(--text-secondary);
-					margin: 0;
-					line-height: 1.4;
-				}
-			}
-
-			.no-skills {
-				grid-column: 1 / -1;
-				text-align: center;
-				color: var(--text-secondary);
-				font-style: italic;
-			}
-		}
-	}
-
-	@media (max-width: 768px) {
-		.weapon-skills .skills-grid {
-			grid-template-columns: 1fr;
-		}
 	}
 
 	.nickname-tags {


### PR DESCRIPTION
## What & why

Surfaces the new weapon-skill data (from the API work in hensei-api#431) in the **weapon database detail page** — a dedicated **Skills tab** showing each slot's evolving version tiers, mirroring the character-skills UI.

Depends on hensei-api#431 (weapon `:full` serialization now returns `weapon_skills` → `versions`, each with `iconStem`).

## Changes

- **`WeaponSkillsTab`** — per slot ("Skill 1–4"), each version card shows the name (EN/JA), a tier badge (Base/FLB/ULB/T1–T5 from `minUncap`+`transcendenceStage`), unlock level, `main hand`/`MC only` flags, the `modifier · series · size` line for grid-scaling skills, a **locale-aware icon**, and the description.
- **Skills tab** added to the shared `DetailScaffold` (gated by `showSkills`); the weapon detail page renders it under `?tab=skills`.
- **`wikiToHtml`** — wiki-sourced descriptions contain MediaWiki markup (`'''bold'''`, `{{status|…}}`, `[[links]]`, `<br>`, `<ref>`); this converts them to safe, whitelisted HTML for `{@html}`. Unit-tested.
- **Types/adapter** — `WeaponSkill` / `WeaponSkillVersion` (+ `iconStem`) and `weaponSkills` on `Weapon`.
- **Icons** — `getWeaponSkillIcon(stem, locale)` builds `/icons/weapon-skills/{en|ja}/{stem}.png`. The PNGs (EN + JA) are served from `static/images/icons/weapon-skills/` locally and the CDN in prod.
- i18n: `weapon_skills_*` keys (en/ja).

## Notes

- Character skill descriptions are already clean text, so they need no markup renderer; only weapon skills fall back to raw wiki markup — hence `wikiToHtml`.
- The party-builder sidebar `SkillsSection` still uses an outdated flat `weaponSkills` shape (dormant — its data view omits weapon skills); left out of scope.

## Testing

`pnpm check` (0 errors), ESLint + Prettier clean, `wikiText` unit tests pass.


