### PR TITLE
Fix broken Illustrious weapon transcendence images

### DIFF
--- a/src/lib/components/collection/CollectionWeaponCard.svelte
+++ b/src/lib/components/collection/CollectionWeaponCard.svelte
@@ -7,6 +7,7 @@
 		handleImageFallback
 	} from '$lib/utils/images'
 	import { getAwakeningImage } from '$lib/utils/modifiers'
+	import { seriesHasTranscendenceArt } from '$lib/utils/weaponSeries'
 	import { localizedName } from '$lib/utils/locale'
 	import UncapIndicator from '$lib/components/uncap/UncapIndicator.svelte'
 	interface Props {
@@ -30,7 +31,7 @@
 	// Get transformation suffix for transcendence
 	const transformation = $derived(
 		getWeaponTransformation(
-			weapon.weapon?.uncap?.transcendence,
+			seriesHasTranscendenceArt(weapon.weapon?.series),
 			weapon.uncapLevel,
 			weapon.transcendenceStep
 		)

--- a/src/lib/components/reps/WeaponRep.svelte
+++ b/src/lib/components/reps/WeaponRep.svelte
@@ -6,6 +6,7 @@
 		getWeaponFallbackImage,
 		handleImageFallback
 	} from '$lib/utils/images'
+	import { seriesHasTranscendenceArt } from '$lib/utils/weaponSeries'
 	interface Props {
 		party?: Party
 		weapons?: GridWeapon[]
@@ -29,7 +30,7 @@
 		if (w?.element) return undefined
 		const variant = isMain ? 'main' : 'grid'
 		const transformation = getWeaponTransformation(
-			w?.weapon?.uncap?.transcendence,
+			seriesHasTranscendenceArt(w?.weapon?.series),
 			w?.uncapLevel,
 			w?.transcendenceStep
 		)
@@ -42,7 +43,7 @@
 		// Mainhand images don't have a null-element variant, so default to fire (2).
 		const element = w?.weapon?.element === 0 ? (w?.element ?? (isMain ? 2 : 0)) : undefined
 		const transformation = getWeaponTransformation(
-			w?.weapon?.uncap?.transcendence,
+			seriesHasTranscendenceArt(w?.weapon?.series),
 			w?.uncapLevel,
 			w?.transcendenceStep
 		)

--- a/src/lib/components/sidebar/details/ItemHeader.svelte
+++ b/src/lib/components/sidebar/details/ItemHeader.svelte
@@ -12,6 +12,7 @@
 	import { getSimplePortraits } from '$lib/stores/simplePortraits.svelte'
 	import { localizedName } from '$lib/utils/locale'
 	import { getElementKey } from '$lib/utils/element'
+	import { seriesHasTranscendenceArt } from '$lib/utils/weaponSeries'
 	import perpetuityFilled from '$src/assets/icons/perpetuity/filled.svg'
 	import CollectionPill from './CollectionPill.svelte'
 
@@ -56,7 +57,7 @@
 			return getCharacterDetailImage(id, pose)
 		} else if (type === 'weapon') {
 			const transformation = getWeaponTransformation(
-				!!itemData?.uncap?.transcendence,
+				seriesHasTranscendenceArt(itemData?.series),
 				gridUncapLevel ?? undefined,
 				gridTranscendence ?? undefined
 			)

--- a/src/lib/components/units/WeaponUnit.svelte
+++ b/src/lib/components/units/WeaponUnit.svelte
@@ -18,6 +18,7 @@
 		getWeaponFallbackImage,
 		handleImageFallback
 	} from '$lib/utils/images'
+	import { seriesHasTranscendenceArt } from '$lib/utils/weaponSeries'
 	import {
 		openDetailsSidebar,
 		openWeaponEditSidebar
@@ -60,7 +61,7 @@
 		// Mainhand images don't have a null-element variant, so default to fire (2).
 		const element = item?.weapon?.element === 0 ? (item?.element ?? (isMain ? 2 : 0)) : undefined
 		const transformation = getWeaponTransformation(
-			item?.weapon?.uncap?.transcendence,
+			seriesHasTranscendenceArt(item?.weapon?.series),
 			item?.uncapLevel,
 			item?.transcendenceStep
 		)
@@ -82,7 +83,7 @@
 		const isMain = position === -1 || item?.mainhand
 		const variant = isMain ? 'main' : 'grid'
 		const transformation = getWeaponTransformation(
-			item?.weapon?.uncap?.transcendence,
+			seriesHasTranscendenceArt(item?.weapon?.series),
 			item?.uncapLevel,
 			item?.transcendenceStep
 		)

--- a/src/lib/utils/__tests__/weaponSeries.test.ts
+++ b/src/lib/utils/__tests__/weaponSeries.test.ts
@@ -8,6 +8,8 @@ import {
 	seriesHasAwakening,
 	seriesIsElementChangeable,
 	seriesIsExtra,
+	seriesHasTranscendenceArt,
+	WEAPON_TRANSCENDENCE_ART_SLUGS,
 	isWeaponSeriesRef
 } from '../weaponSeries'
 import type { WeaponSeriesRef } from '$lib/types/api/weaponSeries'
@@ -70,6 +72,34 @@ describe('isOpusDraconicSeries', () => {
 	it('returns false for null/undefined', () => {
 		expect(isOpusDraconicSeries(null)).toBe(false)
 		expect(isOpusDraconicSeries(undefined)).toBe(false)
+	})
+})
+
+// ============================================================================
+// seriesHasTranscendenceArt
+// ============================================================================
+
+describe('seriesHasTranscendenceArt', () => {
+	it('returns true for Dark Opus (ships stage-specific art)', () => {
+		expect(seriesHasTranscendenceArt(makeSeries({ slug: 'dark-opus' }))).toBe(true)
+	})
+
+	it('returns false for Illustrious (transcends but reuses base art)', () => {
+		expect(seriesHasTranscendenceArt(makeSeries({ slug: 'illustrious' }))).toBe(false)
+	})
+
+	it('returns false for other transcendable series', () => {
+		expect(seriesHasTranscendenceArt(makeSeries({ slug: 'ultima' }))).toBe(false)
+		expect(seriesHasTranscendenceArt(makeSeries({ slug: 'draconic-providence' }))).toBe(false)
+	})
+
+	it('only Dark Opus is currently in the allow-list', () => {
+		expect(WEAPON_TRANSCENDENCE_ART_SLUGS).toEqual(['dark-opus'])
+	})
+
+	it('returns false for null/undefined', () => {
+		expect(seriesHasTranscendenceArt(null)).toBe(false)
+		expect(seriesHasTranscendenceArt(undefined)).toBe(false)
 	})
 })
 

--- a/src/lib/utils/images.ts
+++ b/src/lib/utils/images.ts
@@ -174,14 +174,18 @@ export function getSummonTransformation(
 
 /**
  * Returns the list of available transformation stages for a weapon.
- * Uses the uncap flags (transcendence) to determine which stages exist.
+ *
+ * Stage-specific art only exists for series that ship it (see
+ * {@link seriesHasTranscendenceArt}); pass that result as `hasTranscendenceArt`.
+ * Weapons that transcend but reuse their base art (e.g. Illustrious) expose only
+ * the Base stage so we never request a non-existent {id}_02/{id}_03 image.
  */
-export function getWeaponTransformationStages(uncap?: {
-	transcendence?: boolean
-}): TransformationStage[] {
+export function getWeaponTransformationStages(
+	hasTranscendenceArt?: boolean
+): TransformationStage[] {
 	const stages: TransformationStage[] = [{ id: '01', label: 'Base', suffix: undefined }]
 
-	if (uncap?.transcendence) {
+	if (hasTranscendenceArt) {
 		stages.push(
 			{ id: '02', label: 'Transcendence (1)', suffix: '02' },
 			{ id: '03', label: 'Transcendence (5)', suffix: '03' }
@@ -194,14 +198,18 @@ export function getWeaponTransformationStages(uncap?: {
 /**
  * Calculates the weapon transformation suffix based on transcendence step.
  * Returns undefined for base art, '02' for transcendence 1-4, '03' for transcendence 5.
- * Only applies to weapons that have transcendence and are at uncap level 6.
+ *
+ * Only weapons whose series ships stage-specific art swap images — pass
+ * {@link seriesHasTranscendenceArt} as `hasTranscendenceArt`. Weapons that
+ * transcend but reuse their base art (e.g. Illustrious) always return undefined
+ * so their grid keeps the base image.
  */
 export function getWeaponTransformation(
-	hasTranscendence?: boolean,
+	hasTranscendenceArt?: boolean,
 	uncapLevel?: number,
 	transcendenceStep?: number
 ): string | undefined {
-	if (!hasTranscendence || uncapLevel !== 6) return undefined
+	if (!hasTranscendenceArt || uncapLevel !== 6) return undefined
 	if (transcendenceStep === 5) return '03'
 	if (transcendenceStep && transcendenceStep >= 1) return '02'
 	return undefined

--- a/src/lib/utils/weaponSeries.ts
+++ b/src/lib/utils/weaponSeries.ts
@@ -18,6 +18,29 @@ import { localizedName } from '$lib/utils/locale'
 export const OPUS_DRACONIC_SLUGS = ['dark-opus', 'draconic', 'draconic-providence']
 
 /**
+ * Slugs for series that ship distinct artwork per transcendence stage
+ * ({id}_02 at stage 1, {id}_03 at stage 5).
+ *
+ * Most transcendable weapons (e.g. Illustrious) reuse their base art at every
+ * stage, so they must NOT be included here — requesting a stage-suffixed image
+ * for them 404s. Only Dark Opus weapons currently have stage-specific art.
+ */
+export const WEAPON_TRANSCENDENCE_ART_SLUGS = ['dark-opus']
+
+/**
+ * Check whether a weapon series has distinct artwork at its transcendence stages.
+ *
+ * @param series - The series to check (WeaponSeriesRef or null)
+ * @returns True if the series ships stage-specific transcendence art
+ */
+export function seriesHasTranscendenceArt(series: WeaponSeriesRef | null | undefined): boolean {
+	if (!isWeaponSeriesRef(series)) {
+		return false
+	}
+	return WEAPON_TRANSCENDENCE_ART_SLUGS.includes(series.slug)
+}
+
+/**
  * Check if a series belongs to the Opus/Draconic conflict group.
  *
  * @param series - The series to check (WeaponSeriesRef or null)

--- a/src/routes/(app)/database/weapons/[granblueId]/+page.svelte
+++ b/src/routes/(app)/database/weapons/[granblueId]/+page.svelte
@@ -39,6 +39,7 @@
 		getWeaponFallbackImage
 	} from '$lib/utils/images'
 	import { getElementLabel, ELEMENT_DISPLAY_ORDER } from '$lib/utils/element'
+	import { seriesHasTranscendenceArt } from '$lib/utils/weaponSeries'
 	import {
 		buildWikiEnUrl,
 		buildWikiJaUrl,
@@ -171,7 +172,9 @@
 				}
 			}
 		} else {
-			const transformations = getWeaponTransformationStages(weapon.uncap)
+			const transformations = getWeaponTransformationStages(
+				seriesHasTranscendenceArt(weapon.series)
+			)
 
 			for (const transformation of transformations) {
 				for (const variant of variants) {


### PR DESCRIPTION
## what

Illustrious weapons got transcendence, but they reuse their base art at every stage. We were keying art swaps off the \`uncap.transcendence\` flag, so transcended Illustrious weapons started requesting \`{id}_02\`/\`{id}_03\` images that don't exist → broken images in grids/collection/details.

## fix

Gate the art swap on the weapon **series** instead of the flag, mirroring the summon alt-art approach. Added \`WEAPON_TRANSCENDENCE_ART_SLUGS\` (just \`dark-opus\` for now) + \`seriesHasTranscendenceArt()\`, and the 5 call sites pass that instead of \`uncap.transcendence\`.

Dark Opus keeps its t1/t5 art; everything else stays on base art. No API change. Future series with stage art = add the slug.

## test

- new \`seriesHasTranscendenceArt\` tests (Dark Opus swaps, Illustrious/Ultima/Draconic-Providence don't)
- \`pnpm test\` green (1691), \`pnpm check\` clean (2 pre-existing aws-sdk errors unrelated)