### PR TITLE
Full Auto: MC ability toggles + per-character status display

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1901,5 +1901,8 @@
 	"weapon_skills_level": "Lv {n}",
 	"weapon_skills_main_hand": "Main hand",
 	"weapon_skills_mc_only": "MC only",
-	"details_full_auto_skills": "Full Auto Skills"
+	"details_full_auto_skills": "Full Auto Skills",
+	"full_auto_skill_toggle": "Use in Full Auto",
+	"full_auto_skill_enabled": "Enabled",
+	"full_auto_skill_disabled": "Disabled"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1884,6 +1884,6 @@
 	"weapon_skills_mc_only": "主人公のみ",
 	"details_full_auto_skills": "フルオートアビリティ",
 	"full_auto_skill_toggle": "フルオートで使用",
-	"full_auto_skill_enabled": "有効",
-	"full_auto_skill_disabled": "無効"
+	"full_auto_skill_enabled": "オン",
+	"full_auto_skill_disabled": "オフ"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1882,5 +1882,8 @@
 	"weapon_skills_level": "Lv {n}",
 	"weapon_skills_main_hand": "メイン装備時",
 	"weapon_skills_mc_only": "主人公のみ",
-	"details_full_auto_skills": "フルオートアビリティ"
+	"details_full_auto_skills": "フルオートアビリティ",
+	"full_auto_skill_toggle": "フルオートで使用",
+	"full_auto_skill_enabled": "有効",
+	"full_auto_skill_disabled": "無効"
 }

--- a/src/lib/api/adapters/party.adapter.ts
+++ b/src/lib/api/adapters/party.adapter.ts
@@ -42,6 +42,8 @@ export interface UpdatePartyParams extends CreatePartyParams {
 	autoGuard?: boolean
 	autoSummon?: boolean
 	chargeAttack?: boolean
+	/** Per-slot Full Auto toggles for the MC's abilities ("0".."3" → boolean). */
+	fullAutoSkills?: Record<string, boolean>
 	// Performance metrics (null to clear)
 	clearTime?: number | null
 	buttonCount?: number | null

--- a/src/lib/components/job/JobSection.svelte
+++ b/src/lib/components/job/JobSection.svelte
@@ -21,6 +21,8 @@
 	interface Props {
 		job?: Job | undefined
 		jobSkills?: JobSkillList | undefined
+		/** Per-slot MC Full Auto toggles ("0".."3" → boolean). Absent = ON. */
+		fullAutoSkills?: Record<string, boolean> | undefined
 		accessory?: JobAccessory | undefined
 		canEdit?: boolean | undefined
 		gender?: Gender | undefined
@@ -28,19 +30,22 @@
 		onSelectJob?: (() => void) | undefined
 		onSelectSkill?: ((slot: number) => void) | undefined
 		onRemoveSkill?: ((slot: number) => void) | undefined
+		onToggleSkillFa?: ((slot: number, on: boolean) => void) | undefined
 		onSelectAccessory?: (() => void) | undefined
 	}
 
 	let {
 		job,
 		jobSkills = {},
+		fullAutoSkills = {},
 		accessory,
 		canEdit = false,
 		gender = Gender.Gran,
-		element, // eslint-disable-line @typescript-eslint/no-unused-vars
+		element,
 		onSelectJob,
 		onSelectSkill,
 		onRemoveSkill,
+		onToggleSkillFa,
 		onSelectAccessory
 	}: Props = $props()
 
@@ -60,6 +65,17 @@
 		if (onRemoveSkill) {
 			onRemoveSkill(slot)
 		}
+	}
+
+	function handleToggleFa(slot: number, on: boolean) {
+		if (onToggleSkillFa) {
+			onToggleSkillFa(slot, on)
+		}
+	}
+
+	// Absent or true => used in Full Auto; only an explicit false is OFF.
+	function isSkillFaOn(slot: number): boolean {
+		return fullAutoSkills[String(slot)] !== false
 	}
 </script>
 
@@ -155,11 +171,14 @@
 						<JobSkillSlot
 							skill={jobSkills[slot as keyof JobSkillList]}
 							{slot}
+							{element}
 							locked={isSkillSlotLocked(slot, job, jobSkills)}
 							editable={canEdit}
 							available={true}
+							faOn={isSkillFaOn(slot)}
 							onclick={() => handleSelectSkill(slot)}
 							onRemove={() => handleRemoveSkill(slot)}
+							onToggleFa={(on) => handleToggleFa(slot, on)}
 						/>
 					{/if}
 				{/each}
@@ -203,9 +222,9 @@
 	.job-image-container {
 		position: relative;
 		flex-shrink: 0;
-		width: 447px;
+		width: 360px;
 		max-width: 100%;
-		height: 252px;
+		height: 206px;
 		aspect-ratio: 7/4;
 		background-size: 500px 281px;
 		background-position: center;
@@ -229,7 +248,7 @@
 			object-fit: contain;
 			z-index: effects.$z-badge;
 			filter: drop-shadow(4px 4px 8px rgba(0, 0, 0, 0.48));
-			transform: translateY(74px);
+			transform: translateY(60px);
 		}
 
 		.overlay {

--- a/src/lib/components/job/JobSkillSlot.svelte
+++ b/src/lib/components/job/JobSkillSlot.svelte
@@ -73,7 +73,7 @@
 			onclick={handleClick}
 			type="button"
 		>
-			{@render SlotBody({ locked: false })}
+			{@render SlotBody()}
 		</button>
 		{#if isFilled}
 			{@render FaSwitch({ disabled: false })}
@@ -99,12 +99,21 @@
 			class:unavailable={isUnavailable}
 			style:--category-color={categoryColor}
 		>
-			{@render SlotBody({ locked })}
+			{@render SlotBody()}
 		</div>
 		{#if isFilled}
 			<!-- A locked main skill can't be swapped, but its Full Auto use is still
 			toggleable; gate the switch on edit permission, not the slot lock. -->
 			{@render FaSwitch({ disabled: !editable })}
+		{/if}
+		{#if locked}
+			<!-- Sits in the trailing column so it lines up with the remove (X)
+			buttons on the editable slots below. -->
+			<Tooltip content="Main skill (locked)">
+				<span class="lock-indicator">
+					<Icon name="lock" size={16} class="lock-icon" />
+				</span>
+			</Tooltip>
 		{/if}
 	</div>
 {/if}
@@ -123,9 +132,9 @@
 	</Tooltip>
 {/snippet}
 
-{#snippet SlotBody({ locked }: { locked: boolean })}
+{#snippet SlotBody()}
 	{#if isFilled}
-		{@render SkillContent({ skill: skill!, skillIconUrl, locked })}
+		{@render SkillContent({ skill: skill!, skillIconUrl })}
 	{:else if !isUnavailable}
 		{@render EmptyState({ slot })}
 	{:else}
@@ -133,15 +142,7 @@
 	{/if}
 {/snippet}
 
-{#snippet SkillContent({
-	skill,
-	skillIconUrl,
-	locked
-}: {
-	skill: JobSkill
-	skillIconUrl: string
-	locked: boolean
-})}
+{#snippet SkillContent({ skill, skillIconUrl }: { skill: JobSkill; skillIconUrl: string })}
 	<div class="skill-content">
 		{#if skillIconUrl}
 			<img src={skillIconUrl} alt={localizedName(skill.name)} class="skill-icon" loading="lazy" />
@@ -149,11 +150,6 @@
 		<div class="skill-info">
 			<span class="skill-name">{localizedName(skill.name)}</span>
 		</div>
-		{#if locked}
-			<Tooltip content="Main skill (locked)">
-				<Icon name="lock" size={16} class="lock-icon" />
-			</Tooltip>
-		{/if}
 	</div>
 {/snippet}
 
@@ -333,6 +329,17 @@
 		color: var(--text-tertiary);
 		height: 60px;
 		font-size: 18px;
+	}
+
+	// Matches the medium icon-only remove button footprint so the lock lines up
+	// with the remove (X) buttons in the editable slots.
+	.lock-indicator {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		width: calc($unit * 5.5);
+		height: calc($unit * 5.5);
 	}
 
 	:global(.lock-icon.icon) {

--- a/src/lib/components/job/JobSkillSlot.svelte
+++ b/src/lib/components/job/JobSkillSlot.svelte
@@ -4,32 +4,47 @@
 	import { getSkillCategoryColor } from '$lib/utils/jobUtils'
 	import { getJobSkillIcon } from '$lib/utils/images'
 	import { localizedName } from '$lib/utils/locale'
+	import { getElementTypeKey } from '$lib/utils/element'
 	import Icon from '$lib/components/Icon.svelte'
 	import Tooltip from '$lib/components/ui/Tooltip.svelte'
 	import Button from '$lib/components/ui/Button.svelte'
+	import Switch from '$lib/components/ui/switch/Switch.svelte'
 
 	interface Props {
 		skill?: JobSkill
 		slot: number
+		element?: number | undefined
 		locked?: boolean
 		editable?: boolean
 		available?: boolean
+		/** Whether this skill is used in Full Auto. Absent slot defaults to ON. */
+		faOn?: boolean
 		onclick?: () => void
 		onRemove?: () => void
+		onToggleFa?: (on: boolean) => void
 	}
 
 	let {
 		skill,
 		slot,
+		element,
 		locked = false,
 		editable = false,
 		available = true,
+		faOn = true,
 		onclick,
-		onRemove
+		onRemove,
+		onToggleFa
 	}: Props = $props()
 
 	const categoryColor = $derived(skill ? getSkillCategoryColor(skill) : '')
 	const skillIconUrl = $derived(skill ? getJobSkillIcon(skill) : '')
+	const elementKey = $derived(getElementTypeKey(element))
+
+	function handleToggleFa(checked: boolean) {
+		// Guard against the Switch's mount-time callback firing a no-op write.
+		if (checked !== faOn) onToggleFa?.(checked)
+	}
 
 	const isEditable = $derived(editable && !locked && available)
 	const isUnavailable = $derived(!available)
@@ -60,6 +75,9 @@
 		>
 			{@render SlotBody({ locked: false })}
 		</button>
+		{#if isFilled}
+			{@render FaSwitch({ disabled: false })}
+		{/if}
 		{#if allowsRemove}
 			<Button
 				variant="ghost"
@@ -73,16 +91,37 @@
 		{/if}
 	</div>
 {:else}
-	<div
-		class="skill-slot"
-		class:empty={!isFilled}
-		class:locked
-		class:unavailable={isUnavailable}
-		style:--category-color={categoryColor}
-	>
-		{@render SlotBody({ locked })}
+	<div class="slot-row">
+		<div
+			class="skill-slot"
+			class:empty={!isFilled}
+			class:locked
+			class:unavailable={isUnavailable}
+			style:--category-color={categoryColor}
+		>
+			{@render SlotBody({ locked })}
+		</div>
+		{#if isFilled}
+			<!-- A locked main skill can't be swapped, but its Full Auto use is still
+			toggleable; gate the switch on edit permission, not the slot lock. -->
+			{@render FaSwitch({ disabled: !editable })}
+		{/if}
 	</div>
 {/if}
+
+{#snippet FaSwitch({ disabled }: { disabled: boolean })}
+	<Tooltip content={m.full_auto_skill_toggle()}>
+		<span class="fa-switch">
+			<Switch
+				size="small"
+				element={elementKey}
+				checked={faOn}
+				{disabled}
+				onCheckedChange={handleToggleFa}
+			/>
+		</span>
+	</Tooltip>
+{/snippet}
 
 {#snippet SlotBody({ locked }: { locked: boolean })}
 	{#if isFilled}
@@ -150,12 +189,20 @@
 		gap: $unit-half;
 	}
 
+	.fa-switch {
+		display: inline-flex;
+		flex-shrink: 0;
+		margin-left: $unit-half;
+	}
+
 	.skill-slot {
 		position: relative;
 		border: none;
 		border-radius: $card-corner;
 		background: var(--button-bound-bg);
 		transition: all 0.2s ease;
+		flex: 1;
+		min-width: 0;
 		width: 100%;
 		text-align: left;
 		font: inherit;

--- a/src/lib/components/party/Party.svelte
+++ b/src/lib/components/party/Party.svelte
@@ -582,6 +582,7 @@
 							<JobSection
 								job={party.job}
 								jobSkills={party.jobSkills}
+								fullAutoSkills={party.fullAutoSkills}
 								accessory={party.accessory}
 								canEdit={canEdit()}
 								gender={party.user?.gender ?? Gender.Gran}
@@ -589,6 +590,7 @@
 								onSelectJob={jobHandlers.handleSelectJob}
 								onSelectSkill={jobHandlers.handleSelectJobSkill}
 								onRemoveSkill={jobHandlers.handleRemoveJobSkill}
+								onToggleSkillFa={jobHandlers.handleToggleJobSkillFa}
 								onSelectAccessory={jobHandlers.handleSelectAccessory}
 							/>
 							<CharacterGrid

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -12,6 +12,8 @@
 	import UncapIndicator from '$lib/components/uncap/UncapIndicator.svelte'
 	import CharacterTags from '$lib/components/tags/CharacterTags.svelte'
 	import Tooltip from '$lib/components/ui/Tooltip.svelte'
+	import RichTooltip from '$lib/components/ui/RichTooltip.svelte'
+	import { getAbilitySlots } from '$lib/utils/fullAutoSkills'
 	import { getCharacterImageWithPose, getPlaceholderImage } from '$lib/utils/images'
 	import { getSimplePortraits } from '$lib/stores/simplePortraits.svelte'
 	import {
@@ -181,6 +183,19 @@
 			console.error('Error switching style:', err)
 			toast.error(extractErrorMessage(err, 'Failed to switch style'))
 		}
+	}
+
+	// Full Auto skill display: only meaningful when the party is in Full Auto.
+	// Shows every ability as an icon; an eligible ability that is toggled off is
+	// dimmed, while ineligible abilities (heal/field/target-ally) never dim and
+	// always read as Disabled since they can't be used in Full Auto.
+	let partyFullAuto = $derived(ctx?.getParty?.()?.fullAuto ?? false)
+	let abilitySlots = $derived(item?.character ? getAbilitySlots(item.character) : [])
+	let faSkills = $derived(item?.fullAutoSkills ?? {})
+
+	// Absent or true => ON; only an explicit false is OFF.
+	function isFaSlotOn(slot: number): boolean {
+		return faSkills[String(slot)] !== false
 	}
 
 	async function togglePerpetuity(e: Event) {
@@ -405,7 +420,49 @@
 	{#if item?.character}
 		<CharacterTags character={item.character} />
 	{/if}
+	{#if item?.character && partyFullAuto && abilitySlots.length > 0}
+		<div class="fa-skills">
+			{#each abilitySlots as s (s.slot)}
+				{@const on = s.eligible && isFaSlotOn(s.slot)}
+				{@const dimmed = s.eligible && !isFaSlotOn(s.slot)}
+				<RichTooltip>
+					{#snippet content()}
+						<div class="fa-skill-tip">
+							<span class="fa-skill-tip-name">{s.name}</span>
+							<span class="fa-skill-tip-status">
+								<Icon name="full-auto" size={14} />
+								{on ? m.full_auto_skill_enabled() : m.full_auto_skill_disabled()}
+							</span>
+						</div>
+					{/snippet}
+					{#if ctx?.canEdit()}
+						<button class="fa-skill" class:dimmed onclick={() => viewDetails()} aria-label={s.name}>
+							{@render FaSkillIcon(s.iconUrl, s.name)}
+						</button>
+					{:else}
+						<span class="fa-skill" class:dimmed>
+							{@render FaSkillIcon(s.iconUrl, s.name)}
+						</span>
+					{/if}
+				</RichTooltip>
+			{/each}
+		</div>
+	{/if}
 </div>
+
+{#snippet FaSkillIcon(iconUrl: string | null, name: string)}
+	{#if iconUrl}
+		<img
+			class="fa-skill-icon"
+			src={iconUrl}
+			alt={name}
+			loading="lazy"
+			onerror={(e) => ((e.currentTarget as HTMLImageElement).style.visibility = 'hidden')}
+		/>
+	{:else}
+		<span class="fa-skill-icon placeholder"></span>
+	{/if}
+{/snippet}
 
 <RemoveUnitDialog
 	bind:open={removeConfirmOpen}
@@ -557,6 +614,65 @@
 		min-width: 0;
 		text-align: center;
 		overflow-wrap: anywhere;
+	}
+
+	.fa-skills {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: center;
+		gap: spacing.$unit-half;
+	}
+
+	.fa-skill {
+		display: inline-flex;
+		padding: 0;
+		border: none;
+		background: transparent;
+		line-height: 0;
+		transition: opacity 0.15s ease;
+
+		&.dimmed {
+			opacity: 0.35;
+		}
+	}
+
+	button.fa-skill {
+		cursor: pointer;
+
+		&:hover {
+			opacity: 0.85;
+
+			&.dimmed {
+				opacity: 0.55;
+			}
+		}
+	}
+
+	.fa-skill-icon {
+		width: 24px;
+		height: 24px;
+		object-fit: cover;
+		border-radius: layout.$item-corner-small;
+		border: 1px solid var(--border-primary);
+		background: var(--placeholder-bg);
+
+		&.placeholder {
+			display: inline-block;
+		}
+	}
+
+	:global(.fa-skill-tip) {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-quarter;
+	}
+
+	:global(.fa-skill-tip-status) {
+		display: flex;
+		align-items: center;
+		gap: spacing.$unit-half;
+		color: var(--text-secondary);
 	}
 
 	.perpetuity {

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -430,7 +430,7 @@
 						<div class="fa-skill-tip">
 							<span class="fa-skill-tip-name">{s.name}</span>
 							<span class="fa-skill-tip-status" class:enabled={on}>
-								<Icon name="full-auto" size={14} />
+								<Icon name="full-auto" size={16} />
 								{on ? m.full_auto_skill_enabled() : m.full_auto_skill_disabled()}
 							</span>
 						</div>
@@ -675,10 +675,11 @@
 		color: var(--text-secondary);
 	}
 
-	// Enabled abilities use the yellow Full Auto color for the icon (currentColor)
-	// and label.
+	// Enabled abilities use the bright Full Auto yellow for the icon (currentColor)
+	// and label. --full-auto-bg is the brand yellow and stays bright on the dark
+	// tooltip background regardless of the app theme.
 	:global(.fa-skill-tip-status.enabled) {
-		color: var(--full-auto-label-text);
+		color: var(--full-auto-bg);
 	}
 
 	.perpetuity {

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -429,7 +429,7 @@
 					{#snippet content()}
 						<div class="fa-skill-tip">
 							<span class="fa-skill-tip-name">{s.name}</span>
-							<span class="fa-skill-tip-status">
+							<span class="fa-skill-tip-status" class:enabled={on}>
 								<Icon name="full-auto" size={14} />
 								{on ? m.full_auto_skill_enabled() : m.full_auto_skill_disabled()}
 							</span>
@@ -673,6 +673,12 @@
 		align-items: center;
 		gap: spacing.$unit-half;
 		color: var(--text-secondary);
+	}
+
+	// Enabled abilities use the yellow Full Auto color for the icon (currentColor)
+	// and label.
+	:global(.fa-skill-tip-status.enabled) {
+		color: var(--full-auto-label-text);
 	}
 
 	.perpetuity {

--- a/src/lib/components/units/CharacterUnit.svelte
+++ b/src/lib/components/units/CharacterUnit.svelte
@@ -650,8 +650,8 @@
 	}
 
 	.fa-skill-icon {
-		width: 24px;
-		height: 24px;
+		width: 32px;
+		height: 32px;
 		object-fit: cover;
 		border-radius: layout.$item-corner-small;
 		border: 1px solid var(--border-primary);

--- a/src/lib/composables/job-handlers.svelte.ts
+++ b/src/lib/composables/job-handlers.svelte.ts
@@ -150,6 +150,38 @@ export function useJobHandlers(opts: JobHandlerOptions) {
 		}
 	}
 
+	// Toggles whether the MC ability in `slot` (0..3) is used in Full Auto.
+	// Persisted on the party itself (party.fullAutoSkills), mirroring the
+	// per-ability character toggles. Absent slot defaults to ON.
+	async function handleToggleJobSkillFa(slot: number, on: boolean) {
+		if (!opts.canEdit()) return
+
+		loading = true
+		error = null
+
+		try {
+			const shortcode = await getShortcode()
+			if (!shortcode) return
+
+			const party = opts.getParty()
+			if (!party.id) return
+
+			const next = { ...(party.fullAutoSkills ?? {}), [String(slot)]: on }
+
+			await opts.mutations.party.update.mutateAsync({
+				id: party.id,
+				shortcode,
+				fullAutoSkills: next
+			})
+		} catch (e) {
+			error = extractErrorMessage(e, m.toast_failed_update_skill())
+			console.error('Failed to update Full Auto skill:', e)
+			toast.error(extractErrorMessage(e, m.toast_failed_update_skill()))
+		} finally {
+			loading = false
+		}
+	}
+
 	async function handleSelectAccessory() {
 		if (!opts.canEdit()) return
 
@@ -202,6 +234,7 @@ export function useJobHandlers(opts: JobHandlerOptions) {
 		handleSelectJob,
 		handleSelectJobSkill,
 		handleRemoveJobSkill,
+		handleToggleJobSkillFa,
 		handleSelectAccessory,
 		get loading() {
 			return loading

--- a/src/lib/types/api/party.ts
+++ b/src/lib/types/api/party.ts
@@ -265,6 +265,9 @@ export interface Party {
 	summons: GridSummon[]
 	job?: Job
 	jobSkills?: JobSkillList
+	/** Per-slot Full Auto toggles for the MC's abilities ("0".."3" → used in FA).
+	 * Absent slot defaults to ON. */
+	fullAutoSkills?: Record<string, boolean>
 	accessory?: JobAccessory
 	raid?: Raid
 	guidebooks?: GuidebookList

--- a/src/lib/types/api/party.ts
+++ b/src/lib/types/api/party.ts
@@ -144,7 +144,7 @@ export interface GridCharacter {
 	/** Stamped by the API when this grid item is rendered as a substitute —
 	 * true if current_user has the underlying character in their collection. */
 	owned?: boolean
-	/** Party-specific Full Auto toggles per ability slot ("1".."4" → used in FA).
+	/** Party-specific Full Auto toggles per ability slot ("0".."3" → used in FA).
 	 * Absent slot defaults to ON. */
 	fullAutoSkills?: Record<string, boolean>
 }

--- a/src/lib/utils/__tests__/fullAutoSkills.test.ts
+++ b/src/lib/utils/__tests__/fullAutoSkills.test.ts
@@ -40,7 +40,8 @@ function rei(): Character {
 describe('getAbilitySlots', () => {
 	it('returns ability slots in order, excluding ougi/support', () => {
 		const slots = getAbilitySlots(rei())
-		expect(slots.map((s) => s.slot)).toEqual([1, 2, 3, 4])
+		// 0-based keys (API positions 1..4 shifted to "0".."3")
+		expect(slots.map((s) => s.slot)).toEqual([0, 1, 2, 3])
 		expect(slots.map((s) => s.name)).toEqual([
 			'Alaya-Vijnana',
 			'Moksha',

--- a/src/lib/utils/fullAutoSkills.ts
+++ b/src/lib/utils/fullAutoSkills.ts
@@ -4,7 +4,8 @@ import { getCharacterSkillIcon } from '$lib/utils/images'
 
 /** An ability slot surfaced in the Full Auto section. */
 export interface AbilitySlot {
-	/** 1-based slot number, used as the fullAutoSkills key. */
+	/** 0-based slot number, used as the fullAutoSkills key (matches the API's
+	 * "0".."3" convention, shared with the MC abilities). */
 	slot: number
 	/** Localized base ability name. */
 	name: string
@@ -47,7 +48,9 @@ export function getAbilitySlots(character: Character | undefined): AbilitySlot[]
 			if (!base) return []
 			return [
 				{
-					slot: skill.position,
+					// API ability positions are 1-based (1..4); shift to the 0-based
+					// "0".."3" key convention shared with the MC abilities.
+					slot: skill.position - 1,
 					name: localizedName(base.name),
 					iconUrl: getCharacterSkillIcon(base.gameIcon),
 					eligible: isEligible(base)


### PR DESCRIPTION
## Summary

Frontend for per-slot Full Auto control, pairing with the API change (hensei-api) that added MC `full_auto_skills` and unified the slot convention to `0–3`.

- **MC ability toggles**: a Full Auto switch sits beside each assigned MC ability in the job section. Owners can toggle every assigned slot (including the locked main skill — the lock only prevents swapping the skill, not toggling its Full Auto use); non-owners see the state read-only. Persisted on `party.fullAutoSkills`.
- **Narrower job-image container**: shrunk to give the skills column room for the switches.
- **Per-character status display**: when the party is in Full Auto, each character's abilities render as icons beneath the unit. Eligible-but-off abilities are dimmed; ineligible abilities (heal/field/target-ally) never dim and read as Disabled. A tooltip shows the ability name plus its Full Auto status (with the FA icon). For owners, clicking an icon opens the details sidebar.
- **Slot alignment**: `getAbilitySlots` now maps the 1-based ability `position` to the 0-based `"0".."3"` key the API expects, so the existing character Full Auto sidebar reads/writes the right slots.

## Commits

1. Align character Full Auto skill slots to 0-3
2. Add Full Auto toggles for MC abilities
3. Show per-ability Full Auto status under each character

## Testing

- `pnpm vitest run` for `fullAutoSkills` — green.
- `pnpm check` — no new type errors (2 pre-existing `@aws-sdk` errors in a database route are unrelated).
- ESLint + Prettier clean on all touched files.

## Notes / follow-ups

- Requires the companion **hensei-api** PR (#438) that adds MC `full_auto_skills` and the `0–3` slot migration. The runtime relies on the party-detail response being generically camelized (not Zod-parsed), so `fullAutoSkills` flows through without schema changes.
- **MC switches are shown whenever a skill is assigned**, regardless of the party's Full Auto flag — only the per-character icon display is gated on Full Auto. Easy to also gate the MC switches if symmetry is preferred.
- The narrower container size (360×206, keeping the 7/4 ratio) and portrait offset are a visual estimate; not yet verified in-browser.
