### PR TITLE
quiet expected-error noise in frontend sentry

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,6 +1,11 @@
 import { env } from '$env/dynamic/public'
 import { handleErrorWithSentry, init } from '@sentry/sveltekit'
-import { SENTRY_DENY_URLS, SENTRY_IGNORE_ERRORS, SENTRY_TRACES_SAMPLE_RATE } from '$lib/sentry'
+import {
+	isExpectedError,
+	SENTRY_DENY_URLS,
+	SENTRY_IGNORE_ERRORS,
+	SENTRY_TRACES_SAMPLE_RATE
+} from '$lib/sentry'
 
 // Only initialize when a DSN is configured. With no DSN (dev/test, or before
 // it's set in an environment) the SDK never starts, so there's nothing to
@@ -11,7 +16,8 @@ if (env.PUBLIC_SENTRY_DSN) {
 		environment: env.PUBLIC_SENTRY_ENVIRONMENT || 'production',
 		tracesSampleRate: SENTRY_TRACES_SAMPLE_RATE,
 		ignoreErrors: SENTRY_IGNORE_ERRORS,
-		denyUrls: SENTRY_DENY_URLS
+		denyUrls: SENTRY_DENY_URLS,
+		beforeSend: (event, hint) => (isExpectedError(hint?.originalException) ? null : event)
 	})
 }
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -3,7 +3,7 @@ import { sequence } from '@sveltejs/kit/hooks'
 import { handleErrorWithSentry, init, sentryHandle } from '@sentry/sveltekit'
 import { env as publicEnv } from '$env/dynamic/public'
 import { paraglideMiddleware } from '$lib/paraglide/server'
-import { SENTRY_IGNORE_ERRORS, SENTRY_TRACES_SAMPLE_RATE } from '$lib/sentry'
+import { isExpectedError, SENTRY_IGNORE_ERRORS, SENTRY_TRACES_SAMPLE_RATE } from '$lib/sentry'
 import { dev } from '$app/environment'
 import {
 	clearAuthCookies,
@@ -21,7 +21,8 @@ if (publicEnv.PUBLIC_SENTRY_DSN) {
 		dsn: publicEnv.PUBLIC_SENTRY_DSN,
 		environment: publicEnv.PUBLIC_SENTRY_ENVIRONMENT || 'production',
 		tracesSampleRate: SENTRY_TRACES_SAMPLE_RATE,
-		ignoreErrors: SENTRY_IGNORE_ERRORS
+		ignoreErrors: SENTRY_IGNORE_ERRORS,
+		beforeSend: (event, hint) => (isExpectedError(hint?.originalException) ? null : event)
 	})
 }
 

--- a/src/lib/sentry.test.ts
+++ b/src/lib/sentry.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { isExpectedError } from './sentry'
+
+describe('isExpectedError', () => {
+	it('drops cancelled / aborted requests', () => {
+		expect(isExpectedError({ status: 0, message: 'Request was cancelled' })).toBe(true)
+		expect(isExpectedError({ name: 'AbortError', message: 'aborted' })).toBe(true)
+		expect(isExpectedError(new DOMException('aborted', 'AbortError'))).toBe(true)
+	})
+
+	it('drops expected HTTP client errors (4xx) from loads', () => {
+		expect(isExpectedError({ status: 404, body: { message: 'not found' } })).toBe(true) // SvelteKit HttpError
+		expect(isExpectedError({ status: 401 })).toBe(true)
+		expect(isExpectedError({ status: 403, code: 'FORBIDDEN' })).toBe(true) // ApiError-ish
+	})
+
+	it('keeps real server errors and unexpected exceptions', () => {
+		expect(isExpectedError({ status: 500 })).toBe(false)
+		expect(isExpectedError({ status: 502, body: 'bad gateway' })).toBe(false)
+		expect(isExpectedError(new Error('something actually broke'))).toBe(false)
+		expect(isExpectedError({ message: 'plain object with no status' })).toBe(false)
+	})
+
+	it('ignores non-objects', () => {
+		expect(isExpectedError(null)).toBe(false)
+		expect(isExpectedError(undefined)).toBe(false)
+		expect(isExpectedError('a string')).toBe(false)
+		expect(isExpectedError(404)).toBe(false)
+	})
+})

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -19,8 +19,31 @@ export const SENTRY_IGNORE_ERRORS: (string | RegExp)[] = [
 	'Failed to fetch',
 	'Load failed',
 	'AbortError',
-	'The operation was aborted.'
+	'The operation was aborted.',
+	// Injected by browser extensions / third-party scripts, not our bundle
+	"Can't find variable: require",
+	'require is not defined'
 ]
+
+// Drops errors that are normal app flow rather than bugs, used by each hook's
+// `beforeSend` (and so it catches load auto-instrumentation captures too, not
+// just handleError). Covers:
+//   - requests cancelled when the user navigates away (status 0 / AbortError)
+//   - expected HTTP responses surfaced from `load` (404/401/403/…). SvelteKit's
+//     HttpError carries { status, body }; our ApiError carries { status }.
+export function isExpectedError(err: unknown): boolean {
+	if (err == null || typeof err !== 'object') return false
+
+	const e = err as { status?: unknown; name?: unknown; message?: unknown }
+	const status = typeof e.status === 'number' ? e.status : undefined
+	const name = typeof e.name === 'string' ? e.name : ''
+	const message = typeof e.message === 'string' ? e.message : ''
+
+	if (status === 0 || name === 'AbortError' || /cancell?ed|abort/i.test(message)) return true
+	if (status !== undefined && status >= 400 && status < 500) return true
+
+	return false
+}
 
 // Browser-extension frames that inject errors we can't act on. Client-only
 // (matched against frame URLs via denyUrls).

--- a/src/routes/(app)/teams/explore/+page.ts
+++ b/src/routes/(app)/teams/explore/+page.ts
@@ -51,6 +51,10 @@ export const load: PageLoad = async ({ url, depends, fetch }) => {
 			stack: err?.stack,
 			details: err?.details
 		})
+		// status 0 means the request was cancelled (e.g. the user navigated away
+		// mid-load). Don't relabel that as a 502 server error — rethrow the
+		// original so it's treated as a cancellation, not a bug.
+		if (status === 0) throw e
 		const errorMessage = `Failed to load teams: ${message || 'Unknown error'}. Status: ${status || 'unknown'}`
 		throw error(status || 502, errorMessage)
 	}


### PR DESCRIPTION
## what

Triaging the first batch of frontend Sentry issues, most were **normal app flow, not bugs**:

- **WEB-4 / WEB-5** — "Object/HttpError captured as exception with keys: body, status": expected HTTP responses (404s from `/crew`, `/support_summons`, etc.) thrown out of `load` and captured by Sentry's load auto-instrumentation.
- **WEB-3** — a request **cancelled on navigation** (status 0) that the explore `load` then **relabeled as a 502** and reported.
- **WEB-6** — `ReferenceError: Can't find variable: require` on `/teams/explore` — injected by a browser extension (sporadic, page works fine), not our bundle.

## changes

- `src/lib/sentry.ts`: new `isExpectedError(err)` — true for cancelled/aborted requests (status 0 / `AbortError` / "cancelled") and expected 4xx responses (SvelteKit `HttpError` is `{status, body}`; our `ApiError` carries `{status}`). Added `require` messages to `ignoreErrors`.
- `hooks.client.ts` / `hooks.server.ts`: `beforeSend` drops `isExpectedError` events. Done in `beforeSend` (not just `handleError`) so it also catches the **load auto-instrumentation** captures, which is where WEB-3/4/5 came from.
- `teams/explore/+page.ts`: a cancelled request (status 0) is rethrown as-is instead of being turned into a 502.

Real server errors (5xx) and genuine exceptions are still reported.

## testing

- Unit test for `isExpectedError` (cancelled, 4xx, 5xx kept, non-objects). `pnpm check` 0 errors, lint clean, build green.

`RENDER_INTERNAL_SECRET` (HENSEI-WEB-2) is a separate, genuine issue (missing prod env var) — handled separately.