### PR TITLE
Database skills admin: summon Auras tab, re-parse actions, weapon-skills editor

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1735,5 +1735,6 @@
 	"calculator_foe_element": "Foe Element",
 	"calculator_hp_value": "HP: {percent}%",
 	"calculator_turn_value": "Turn {turn}",
-	"calculator_alpha_notice": "This feature is in alpha and may display incorrect data. If you find incorrect calculations, please report in Discord."
+	"calculator_alpha_notice": "This feature is in alpha and may display incorrect data. If you find incorrect calculations, please report in Discord.",
+	"nav_weapon_skills": "Weapon Skills"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1716,5 +1716,6 @@
 	"calculator_foe_element": "敵の属性",
 	"calculator_hp_value": "HP: {percent}%",
 	"calculator_turn_value": "{turn}ターン目",
-	"calculator_alpha_notice": "この機能はアルファ版のため、正しくないデータが表示される場合があります。計算の誤りを見つけた場合は、Discordでご報告ください。"
+	"calculator_alpha_notice": "この機能はアルファ版のため、正しくないデータが表示される場合があります。計算の誤りを見つけた場合は、Discordでご報告ください。",
+	"nav_weapon_skills": "武器スキル"
 }

--- a/src/lib/api/adapters/entity.adapter.ts
+++ b/src/lib/api/adapters/entity.adapter.ts
@@ -35,6 +35,7 @@ import type {
 	Bullet,
 	CharacterSkill,
 	CharacterSkillLink,
+	SummonAura,
 	WeaponSkill
 } from '$lib/types/api/entities'
 import type {
@@ -63,6 +64,8 @@ export interface Weapon {
 	promotions?: number[]
 	/** Human-readable promotion names */
 	promotionNames?: string[]
+	/** Structured per-tier auras parsed from the wiki (the calculator's source) */
+	summonAuras?: SummonAura[]
 	minHp?: number
 	maxHp?: number
 	minAttack?: number
@@ -273,6 +276,8 @@ export interface Summon {
 	promotions?: number[]
 	/** Human-readable promotion names */
 	promotionNames?: string[]
+	/** Structured per-tier auras parsed from the wiki (the calculator's source) */
+	summonAuras?: SummonAura[]
 	minHp?: number
 	maxHp?: number
 	minAttack?: number
@@ -1377,6 +1382,33 @@ export class EntityAdapter extends BaseAdapter {
 	 */
 	async fetchSummonWiki(id: string): Promise<EntityRawData> {
 		return this.request<EntityRawData>(`/summons/${id}/fetch_wiki`, {
+			method: 'POST'
+		})
+	}
+
+	// ============================================
+	// Re-parse Methods (editor-only)
+	// ============================================
+
+	/**
+	 * Re-parses an entity's stored wikitext into structured rows (weapon
+	 * skills / summon auras / character skills). Pass refetch to pull fresh
+	 * wikitext from the wiki first. Requires editor role (>= 7).
+	 */
+	async reparseWeapon(id: string, refetch = false): Promise<Weapon> {
+		return this.request<Weapon>(`/weapons/${id}/reparse${refetch ? '?refetch=true' : ''}`, {
+			method: 'POST'
+		})
+	}
+
+	async reparseSummon(id: string, refetch = false): Promise<Summon> {
+		return this.request<Summon>(`/summons/${id}/reparse${refetch ? '?refetch=true' : ''}`, {
+			method: 'POST'
+		})
+	}
+
+	async reparseCharacter(id: string, refetch = false): Promise<Character> {
+		return this.request<Character>(`/characters/${id}/reparse${refetch ? '?refetch=true' : ''}`, {
 			method: 'POST'
 		})
 	}

--- a/src/lib/api/adapters/entity.adapter.ts
+++ b/src/lib/api/adapters/entity.adapter.ts
@@ -39,6 +39,12 @@ import type {
 	WeaponSkill
 } from '$lib/types/api/entities'
 import type {
+	DeleteImpact,
+	PanelValidation,
+	WeaponSkillFamily,
+	WeaponSkillFamilySummary
+} from '$lib/types/api/weaponSkillFamily'
+import type {
 	WeaponSeriesVariant,
 	CreateWeaponSeriesVariantPayload,
 	UpdateWeaponSeriesVariantPayload
@@ -1411,6 +1417,111 @@ export class EntityAdapter extends BaseAdapter {
 		return this.request<Character>(`/characters/${id}/reparse${refetch ? '?refetch=true' : ''}`, {
 			method: 'POST'
 		})
+	}
+
+	// ============================================
+	// Weapon Skill Family Methods (admin editor)
+	// ============================================
+
+	async getWeaponSkillFamilies(filters?: {
+		q?: string
+		series?: string
+		size?: string
+		boostType?: string
+	}): Promise<WeaponSkillFamilySummary[]> {
+		const query = new URLSearchParams()
+		if (filters?.q) query.set('q', filters.q)
+		if (filters?.series) query.set('series', filters.series)
+		if (filters?.size) query.set('size', filters.size)
+		if (filters?.boostType) query.set('boost_type', filters.boostType)
+		const qs = query.size > 0 ? `?${query.toString()}` : ''
+		const response = await this.request<{ weaponSkillFamilies: WeaponSkillFamilySummary[] }>(
+			`/weapon_skill_families${qs}`
+		)
+		return response.weaponSkillFamilies
+	}
+
+	async getWeaponSkillFamily(modifier: string): Promise<WeaponSkillFamily> {
+		const response = await this.request<{ weaponSkillFamily: WeaponSkillFamily }>(
+			`/weapon_skill_families/${encodeURIComponent(modifier)}`
+		)
+		return response.weaponSkillFamily
+	}
+
+	async createWeaponSkillDatum(payload: Record<string, unknown>): Promise<unknown> {
+		return this.request('/weapon_skill_data', {
+			method: 'POST',
+			body: { weapon_skill_datum: payload }
+		})
+	}
+
+	async updateWeaponSkillDatum(id: string, payload: Record<string, unknown>): Promise<unknown> {
+		return this.request(`/weapon_skill_data/${id}`, {
+			method: 'PATCH',
+			body: { weapon_skill_datum: payload }
+		})
+	}
+
+	async deleteWeaponSkillDatum(id: string, force = false): Promise<DeleteImpact> {
+		return this.request<DeleteImpact>(`/weapon_skill_data/${id}${force ? '?force=true' : ''}`, {
+			method: 'DELETE'
+		})
+	}
+
+	async createWeaponSkillEffect(payload: Record<string, unknown>): Promise<unknown> {
+		return this.request('/weapon_skill_effects', {
+			method: 'POST',
+			body: { weapon_skill_effect: payload }
+		})
+	}
+
+	async updateWeaponSkillEffect(id: string, payload: Record<string, unknown>): Promise<unknown> {
+		return this.request(`/weapon_skill_effects/${id}`, {
+			method: 'PATCH',
+			body: { weapon_skill_effect: payload }
+		})
+	}
+
+	async deleteWeaponSkillEffect(id: string, force = false): Promise<DeleteImpact> {
+		return this.request<DeleteImpact>(`/weapon_skill_effects/${id}${force ? '?force=true' : ''}`, {
+			method: 'DELETE'
+		})
+	}
+
+	async updateWeaponSkillVersion(id: string, payload: Record<string, unknown>): Promise<unknown> {
+		return this.request(`/weapon_skill_versions/${id}`, {
+			method: 'PATCH',
+			body: { weapon_skill_version: payload }
+		})
+	}
+
+	async updateSkillLabels(
+		id: string,
+		payload: {
+			name_en?: string
+			name_jp?: string
+			description_en?: string
+			description_jp?: string
+		}
+	): Promise<{ sharedByCount: number }> {
+		return this.request<{ sharedByCount: number }>(`/skills/${id}`, {
+			method: 'PATCH',
+			body: { skill: payload }
+		})
+	}
+
+	async updateWeaponKey(
+		id: string,
+		payload: { name_en?: string; name_jp?: string }
+	): Promise<unknown> {
+		return this.request(`/weapon_keys/${id}`, {
+			method: 'PATCH',
+			body: { weapon_key: payload }
+		})
+	}
+
+	async validatePanels(): Promise<PanelValidation> {
+		return this.request<PanelValidation>('/calculator/validate_panels', { method: 'POST' })
 	}
 
 	// ============================================

--- a/src/lib/components/DatabaseNavigation.svelte
+++ b/src/lib/components/DatabaseNavigation.svelte
@@ -21,6 +21,7 @@
 	const databaseJobsHref = $derived(localizeHref('/database/jobs'))
 	const databaseGwEventsHref = $derived(localizeHref('/database/gw-events'))
 	const databaseArtifactSkillsHref = $derived(localizeHref('/database/artifact-skills'))
+	const databaseWeaponSkillsHref = $derived(localizeHref('/database/weapon-skills'))
 	const databaseBulletsHref = $derived(localizeHref('/database/bullets'))
 	const databaseRaidsHref = $derived(localizeHref('/database/raids'))
 	const databaseRaidGroupsHref = $derived(localizeHref('/database/raid-groups'))
@@ -126,6 +127,9 @@
 						<DropdownMenu.Separator class="dropdown-separator" />
 						<DropdownItem>
 							<a href={databaseArtifactSkillsHref}>{m.nav_artifact_skills()}</a>
+						</DropdownItem>
+						<DropdownItem>
+							<a href={databaseWeaponSkillsHref}>{m.nav_weapon_skills()}</a>
 						</DropdownItem>
 						<DropdownItem>
 							<a href={databaseBulletsHref}>{m.nav_bullets()}</a>

--- a/src/lib/features/database/detail/DetailScaffold.svelte
+++ b/src/lib/features/database/detail/DetailScaffold.svelte
@@ -28,6 +28,8 @@
 		showTabs?: boolean
 		/** Show a Skills tab (between Info and Images) — currently weapons only. */
 		showSkills?: boolean
+		/** Label for the skills tab segment (summons use it for Auras) */
+		skillsLabel?: string
 		// Image download handlers
 		onDownloadAllImages?: (force: boolean) => Promise<void>
 		onDownloadSize?: (size: string) => Promise<void>
@@ -51,6 +53,7 @@
 		onTabChange,
 		showTabs = true,
 		showSkills = false,
+		skillsLabel = 'Skills',
 		onDownloadAllImages,
 		onDownloadSize,
 		availableSizes = [],
@@ -116,7 +119,7 @@
 			>
 				<Segment value="info">Info</Segment>
 				{#if showSkills}
-					<Segment value="skills">Skills</Segment>
+					<Segment value="skills">{skillsLabel}</Segment>
 				{/if}
 				<Segment value="images">Images</Segment>
 				<Segment value="raw">Raw Data</Segment>

--- a/src/lib/features/database/detail/tabs/EntityRawDataTab.svelte
+++ b/src/lib/features/database/detail/tabs/EntityRawDataTab.svelte
@@ -11,6 +11,8 @@
 		isLoading?: boolean
 		canEdit?: boolean
 		onFetchWiki?: () => Promise<EntityRawData>
+		/** Re-parses stored wikitext into structured rows (skills/auras); receives fetch-first */
+		onReparse?: (refetch: boolean) => Promise<unknown>
 	}
 
 	let {
@@ -19,15 +21,36 @@
 		gameRawJp,
 		isLoading = false,
 		canEdit = false,
-		onFetchWiki
+		onFetchWiki,
+		onReparse
 	}: Props = $props()
 
 	let selectedLang = $state('en')
 	let isFetching = $state(false)
 	let fetchError = $state<string | null>(null)
+	let isReparsing = $state(false)
+	let reparseFetchFirst = $state(false)
+	let reparseMessage = $state<string | null>(null)
 
 	const currentGameRaw = $derived(selectedLang === 'en' ? gameRawEn : gameRawJp)
 	const formattedGameRaw = $derived(currentGameRaw ? JSON.stringify(currentGameRaw, null, 2) : null)
+
+	async function handleReparse() {
+		if (!onReparse) return
+
+		isReparsing = true
+		fetchError = null
+		reparseMessage = null
+
+		try {
+			await onReparse(reparseFetchFirst)
+			reparseMessage = 'Re-parsed successfully.'
+		} catch (err: unknown) {
+			fetchError = err instanceof Error ? err.message : 'Failed to re-parse'
+		} finally {
+			isReparsing = false
+		}
+	}
 
 	async function handleFetchWiki() {
 		if (!onFetchWiki) return
@@ -52,14 +75,40 @@
 		<section class="raw-section">
 			<div class="section-header">
 				<h3>Wiki Raw</h3>
-				{#if canEdit && onFetchWiki}
-					<Button variant="secondary" size="small" onclick={handleFetchWiki} disabled={isFetching}>
-						{isFetching ? 'Fetching...' : 'Fetch Wiki'}
-					</Button>
+				{#if canEdit}
+					<div class="section-actions">
+						{#if onReparse}
+							<label class="reparse-option">
+								<input type="checkbox" bind:checked={reparseFetchFirst} />
+								Fetch fresh wikitext first
+							</label>
+							<Button
+								variant="secondary"
+								size="small"
+								onclick={handleReparse}
+								disabled={isReparsing || isFetching}
+							>
+								{isReparsing ? 'Re-parsing...' : 'Re-parse'}
+							</Button>
+						{/if}
+						{#if onFetchWiki}
+							<Button
+								variant="secondary"
+								size="small"
+								onclick={handleFetchWiki}
+								disabled={isFetching || isReparsing}
+							>
+								{isFetching ? 'Fetching...' : 'Fetch Wiki'}
+							</Button>
+						{/if}
+					</div>
 				{/if}
 			</div>
 			{#if fetchError}
 				<p class="error">{fetchError}</p>
+			{/if}
+			{#if reparseMessage}
+				<p class="success">{reparseMessage}</p>
 			{/if}
 			{#if wikiRaw}
 				<pre class="raw-content">{wikiRaw}</pre>
@@ -147,5 +196,26 @@
 		color: var(--danger);
 		font-size: typography.$font-small;
 		margin: 0 0 spacing.$unit 0;
+	}
+
+	.success {
+		color: var(--text-secondary);
+		font-size: typography.$font-small;
+		margin: 0 0 spacing.$unit 0;
+	}
+
+	.section-actions {
+		display: flex;
+		align-items: center;
+		gap: spacing.$unit;
+	}
+
+	.reparse-option {
+		display: inline-flex;
+		align-items: center;
+		gap: spacing.$unit-half;
+		font-size: typography.$font-small;
+		color: var(--text-secondary);
+		cursor: pointer;
 	}
 </style>

--- a/src/lib/features/database/summons/tabs/SummonAurasTab.svelte
+++ b/src/lib/features/database/summons/tabs/SummonAurasTab.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+	import type { SummonAura } from '$lib/types/api/entities'
+
+	interface Props {
+		auras: SummonAura[]
+	}
+
+	let { auras }: Props = $props()
+
+	const mainAuras = $derived(auras.filter((a) => a.slot === 'main'))
+	const subAuras = $derived(auras.filter((a) => a.slot === 'sub'))
+
+	/** "MLB" / "FLB" / "ULB" / "Lv N" transcendence tier badge, matching WeaponSkillList's idiom */
+	function tierLabel(aura: SummonAura): string {
+		if (aura.transcendenceStage > 0) return `Trans. ${aura.transcendenceStage}`
+		switch (aura.uncapLevel) {
+			case 0:
+				return 'Base'
+			case 3:
+				return 'MLB'
+			case 4:
+				return 'FLB'
+			case 5:
+				return 'ULB'
+			default:
+				return `${aura.uncapLevel}★`
+		}
+	}
+
+	function formatValue(aura: SummonAura): string {
+		if (aura.value == null) return '—'
+		return `${aura.value}%`
+	}
+
+	const targetLabels: Record<string, string> = {
+		normal_frame: 'Optimus frame',
+		omega_frame: 'Omega frame',
+		odious_frame: 'Odious frame',
+		elemental_atk: 'Elemental ATK',
+		normal_atk: 'Normal ATK',
+		omega_atk: 'Omega ATK',
+		atk: 'ATK',
+		multiattack: 'Multiattack',
+		other: 'Other'
+	}
+</script>
+
+{#snippet auraGroup(title: string, groupAuras: SummonAura[])}
+	{#if groupAuras.length > 0}
+		<section class="aura-group">
+			<h3>{title}</h3>
+			<table class="aura-table">
+				<thead>
+					<tr>
+						<th>Tier</th>
+						<th>Target</th>
+						<th>Value</th>
+						<th>Description</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each groupAuras as aura (aura.id)}
+						<tr>
+							<td><span class="tier-badge">{tierLabel(aura)}</span></td>
+							<td>
+								<span class="target-chip" class:frame={aura.target.endsWith('_frame')}>
+									{targetLabels[aura.target] ?? aura.target}
+								</span>
+							</td>
+							<td class="value">{formatValue(aura)}</td>
+							<td class="description">
+								{aura.description?.en ?? '—'}
+								{#if aura.condition}
+									<span class="condition">({aura.condition})</span>
+								{/if}
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</section>
+	{/if}
+{/snippet}
+
+<div class="auras-tab">
+	{#if auras.length === 0}
+		<p class="empty">No structured aura data. Re-parse from the Raw Data tab to generate it.</p>
+	{:else}
+		{@render auraGroup('Main Aura', mainAuras)}
+		{@render auraGroup('Sub Aura', subAuras)}
+	{/if}
+</div>
+
+<style lang="scss">
+	@use '$src/themes/spacing' as *;
+	@use '$src/themes/layout' as *;
+	@use '$src/themes/typography' as *;
+
+	.auras-tab {
+		display: flex;
+		flex-direction: column;
+		gap: $unit-3x;
+	}
+
+	.empty {
+		color: var(--text-tertiary);
+		font-size: $font-regular;
+		text-align: center;
+		padding: $unit-4x 0;
+	}
+
+	.aura-group {
+		display: flex;
+		flex-direction: column;
+		gap: $unit;
+
+		h3 {
+			font-size: $font-regular;
+			font-weight: $medium;
+			color: var(--text-primary);
+			margin: 0;
+		}
+	}
+
+	.aura-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: $font-small;
+
+		th {
+			text-align: left;
+			font-weight: $medium;
+			color: var(--text-secondary);
+			padding: $unit-half $unit;
+			border-bottom: 1px solid var(--border-primary, var(--border-color));
+		}
+
+		td {
+			padding: $unit-half $unit;
+			border-bottom: 1px solid var(--border-secondary, transparent);
+			vertical-align: top;
+			color: var(--text-primary);
+		}
+	}
+
+	.tier-badge {
+		display: inline-block;
+		padding: 0 $unit-half;
+		border-radius: $item-corner-small;
+		background: var(--button-bg);
+		color: var(--text-secondary);
+		font-size: $font-tiny;
+		font-weight: $medium;
+		white-space: nowrap;
+	}
+
+	.target-chip {
+		display: inline-block;
+		padding: 0 $unit-half;
+		border-radius: $item-corner-small;
+		background: var(--button-bg);
+		color: var(--text-secondary);
+		font-size: $font-tiny;
+		white-space: nowrap;
+
+		&.frame {
+			background: var(--accent-bg, var(--button-bg));
+			color: var(--text-primary);
+			font-weight: $medium;
+		}
+	}
+
+	.value {
+		font-variant-numeric: tabular-nums;
+		font-weight: $medium;
+		white-space: nowrap;
+	}
+
+	.description {
+		color: var(--text-secondary);
+	}
+
+	.condition {
+		color: var(--text-tertiary);
+		font-style: italic;
+	}
+</style>

--- a/src/lib/features/database/weapon-skills/FamilyDataTab.svelte
+++ b/src/lib/features/database/weapon-skills/FamilyDataTab.svelte
@@ -1,0 +1,257 @@
+<script lang="ts">
+	import { entityAdapter } from '$lib/api/adapters/entity.adapter'
+	import Button from '$lib/components/ui/Button.svelte'
+	import type {
+		DeleteImpact,
+		WeaponSkillDatumRow,
+		WeaponSkillFamily
+	} from '$lib/types/api/weaponSkillFamily'
+
+	interface Props {
+		family: WeaponSkillFamily
+		canEdit: boolean
+		onMutated: () => Promise<void>
+		onDelete: (doDelete: (force: boolean) => Promise<DeleteImpact>) => Promise<boolean>
+	}
+
+	let { family, canEdit, onMutated, onDelete }: Props = $props()
+
+	const SL_FIELDS = ['sl1', 'sl10', 'sl15', 'sl20', 'sl25'] as const
+
+	let savingId = $state<string | null>(null)
+	let error = $state<string | null>(null)
+	// Per-row edit buffers keyed by row id
+	let edits = $state<Record<string, Record<string, string>>>({})
+
+	function buffer(row: WeaponSkillDatumRow): Record<string, string> {
+		if (!edits[row.id]) {
+			edits[row.id] = Object.fromEntries([
+				...SL_FIELDS.map((f) => [f, row[f]?.toString() ?? '']),
+				['coefficient', row.coefficient?.toString() ?? ''],
+				['maxValue', row.maxValue?.toString() ?? ''],
+				['formulaType', row.formulaType ?? 'flat']
+			])
+		}
+		return edits[row.id]!
+	}
+
+	async function saveRow(row: WeaponSkillDatumRow) {
+		const buf = edits[row.id]
+		if (!buf) return
+		savingId = row.id
+		error = null
+		try {
+			const num = (v: string) => (v === '' ? null : Number(v))
+			await entityAdapter.updateWeaponSkillDatum(row.id, {
+				sl1: num(buf.sl1 ?? ''),
+				sl10: num(buf.sl10 ?? ''),
+				sl15: num(buf.sl15 ?? ''),
+				sl20: num(buf.sl20 ?? ''),
+				sl25: num(buf.sl25 ?? ''),
+				coefficient: num(buf.coefficient ?? ''),
+				max_value: num(buf.maxValue ?? ''),
+				formula_type: buf.formulaType
+			})
+			delete edits[row.id]
+			await onMutated()
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to save'
+		} finally {
+			savingId = null
+		}
+	}
+
+	async function deleteRow(row: WeaponSkillDatumRow) {
+		error = null
+		try {
+			await onDelete((force) => entityAdapter.deleteWeaponSkillDatum(row.id, force))
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to delete'
+		}
+	}
+</script>
+
+<div class="data-tab">
+	{#if error}
+		<p class="error">{error}</p>
+	{/if}
+
+	{#if family.data.length === 0}
+		<p class="empty">No scaling data rows for this family.</p>
+	{:else}
+		<div class="table-wrapper">
+			<table class="edit-table">
+				<thead>
+					<tr>
+						<th>Boost</th>
+						<th>Series</th>
+						<th>Size</th>
+						<th>Formula</th>
+						{#each SL_FIELDS as f (f)}
+							<th class="num">{f.toUpperCase()}</th>
+						{/each}
+						<th class="num">Coef</th>
+						<th class="num">Max</th>
+						{#if canEdit}
+							<th></th>
+						{/if}
+					</tr>
+				</thead>
+				<tbody>
+					{#each family.data as row (row.id)}
+						{@const buf = buffer(row)}
+						<tr
+							class:version-linked={!!row.weaponSkillVersionId}
+							class:edited={!!row.manuallyEditedAt}
+						>
+							<td>
+								{row.boostType}
+								{#if row.weaponSkillVersionId}<span class="badge">version</span>{/if}
+								{#if row.manuallyEditedAt}<span class="badge edited-badge">edited</span>{/if}
+							</td>
+							<td>{row.series ?? 'any'}</td>
+							<td>{row.size ?? '—'}</td>
+							<td>
+								{#if canEdit}
+									<select bind:value={buf.formulaType}>
+										{#each ['flat', 'enmity', 'stamina', 'progression', 'garrison'] as ft (ft)}
+											<option value={ft}>{ft}</option>
+										{/each}
+									</select>
+								{:else}
+									{row.formulaType ?? '—'}
+								{/if}
+							</td>
+							{#each SL_FIELDS as f (f)}
+								<td class="num">
+									{#if canEdit}
+										<input type="number" step="any" bind:value={buf[f]} placeholder="—" />
+									{:else}
+										{row[f] ?? '—'}
+									{/if}
+								</td>
+							{/each}
+							<td class="num">
+								{#if canEdit}
+									<input type="number" step="any" bind:value={buf.coefficient} placeholder="—" />
+								{:else}
+									{row.coefficient ?? '—'}
+								{/if}
+							</td>
+							<td class="num">
+								{#if canEdit}
+									<input type="number" step="any" bind:value={buf.maxValue} placeholder="—" />
+								{:else}
+									{row.maxValue ?? '—'}
+								{/if}
+							</td>
+							{#if canEdit}
+								<td class="actions">
+									<Button
+										variant="secondary"
+										size="small"
+										onclick={() => saveRow(row)}
+										disabled={savingId === row.id}
+									>
+										{savingId === row.id ? 'Saving…' : 'Save'}
+									</Button>
+									<Button variant="ghost" size="small" onclick={() => deleteRow(row)}>Delete</Button
+									>
+								</td>
+							{/if}
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
+</div>
+
+<style lang="scss">
+	@use '$src/themes/layout' as layout;
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+
+	.data-tab {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+	}
+
+	.error {
+		color: var(--red);
+		font-size: typography.$font-small;
+		margin: 0;
+	}
+
+	.empty {
+		color: var(--text-tertiary);
+		font-size: typography.$font-regular;
+		text-align: center;
+		padding: spacing.$unit-4x 0;
+	}
+
+	.table-wrapper {
+		overflow-x: auto;
+	}
+
+	.edit-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: typography.$font-small;
+
+		th {
+			text-align: left;
+			font-weight: typography.$medium;
+			color: var(--text-secondary);
+			padding: spacing.$unit-half spacing.$unit;
+			border-bottom: 1px solid var(--table-border);
+			white-space: nowrap;
+		}
+
+		td {
+			padding: spacing.$unit-half spacing.$unit;
+			border-bottom: 1px solid var(--table-border);
+			vertical-align: middle;
+			white-space: nowrap;
+		}
+
+		.num {
+			text-align: right;
+
+			input {
+				width: 64px;
+				text-align: right;
+			}
+		}
+
+		input,
+		select {
+			padding: 2px spacing.$unit-half;
+			background: var(--input-bound-bg);
+			border: none;
+			border-radius: layout.$item-corner-small;
+			font-size: typography.$font-small;
+			color: var(--text-primary);
+		}
+
+		.actions {
+			display: flex;
+			gap: spacing.$unit-half;
+		}
+	}
+
+	.badge {
+		display: inline-block;
+		margin-left: spacing.$unit-half;
+		padding: 0 spacing.$unit-half;
+		border-radius: layout.$item-corner-small;
+		background: var(--button-bg);
+		color: var(--text-tertiary);
+		font-size: typography.$font-tiny;
+	}
+
+	.edited-badge {
+		color: var(--orange-text, #e08a00);
+	}
+</style>

--- a/src/lib/features/database/weapon-skills/FamilyEffectsTab.svelte
+++ b/src/lib/features/database/weapon-skills/FamilyEffectsTab.svelte
@@ -1,0 +1,322 @@
+<script lang="ts">
+	import { entityAdapter } from '$lib/api/adapters/entity.adapter'
+	import Button from '$lib/components/ui/Button.svelte'
+	import type {
+		DeleteImpact,
+		WeaponSkillEffectRow,
+		WeaponSkillFamily
+	} from '$lib/types/api/weaponSkillFamily'
+
+	interface Props {
+		family: WeaponSkillFamily
+		canEdit: boolean
+		onMutated: () => Promise<void>
+		onDelete: (doDelete: (force: boolean) => Promise<DeleteImpact>) => Promise<boolean>
+	}
+
+	let { family, canEdit, onMutated, onDelete }: Props = $props()
+
+	const groups = $derived([
+		{
+			key: 'canonical',
+			label: 'Family effects',
+			effects: family.effects.filter((e) => e.source === 'canonical')
+		},
+		{ key: 'key', label: 'Key-granted', effects: family.effects.filter((e) => e.source === 'key') },
+		{
+			key: 'version',
+			label: 'Version-linked',
+			effects: family.effects.filter((e) => e.source === 'version')
+		}
+	])
+
+	let savingId = $state<string | null>(null)
+	let error = $state<string | null>(null)
+	let edits = $state<
+		Record<string, { value: string; totalCap: string; perCopyCap: string; condition: string }>
+	>({})
+
+	function buffer(effect: WeaponSkillEffectRow) {
+		if (!edits[effect.id]) {
+			edits[effect.id] = {
+				value: effect.value?.toString() ?? '',
+				totalCap: effect.totalCap?.toString() ?? '',
+				perCopyCap: effect.perCopyCap?.toString() ?? '',
+				condition:
+					effect.condition && Object.keys(effect.condition).length > 0
+						? JSON.stringify(effect.condition)
+						: ''
+			}
+		}
+		return edits[effect.id]!
+	}
+
+	async function saveEffect(effect: WeaponSkillEffectRow) {
+		const buf = edits[effect.id]
+		if (!buf) return
+
+		let condition: Record<string, unknown> | null = null
+		if (buf.condition.trim()) {
+			try {
+				condition = JSON.parse(buf.condition)
+				if (typeof condition !== 'object' || Array.isArray(condition)) throw new Error()
+			} catch {
+				error = 'Condition must be a JSON object'
+				return
+			}
+		}
+
+		savingId = effect.id
+		error = null
+		try {
+			const num = (v: string) => (v === '' ? null : Number(v))
+			await entityAdapter.updateWeaponSkillEffect(effect.id, {
+				value: num(buf.value),
+				total_cap: num(buf.totalCap),
+				per_copy_cap: num(buf.perCopyCap),
+				condition: condition ?? {}
+			})
+			delete edits[effect.id]
+			await onMutated()
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to save'
+		} finally {
+			savingId = null
+		}
+	}
+
+	async function deleteEffect(effect: WeaponSkillEffectRow) {
+		error = null
+		try {
+			await onDelete((force) => entityAdapter.deleteWeaponSkillEffect(effect.id, force))
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to delete'
+		}
+	}
+</script>
+
+<div class="effects-tab">
+	{#if error}
+		<p class="error">{error}</p>
+	{/if}
+
+	{#if family.effects.length === 0}
+		<p class="empty">No effect rows for this family.</p>
+	{:else}
+		{#each groups as group (group.key)}
+			{#if group.effects.length > 0}
+				<section class="effect-group">
+					<h3>{group.label}</h3>
+					<div class="cards">
+						{#each group.effects as effect (effect.id)}
+							{@const buf = buffer(effect)}
+							<div class="card" class:edited={!!effect.manuallyEditedAt}>
+								<div class="card-header">
+									<span class="boost">{effect.boostType}</span>
+									<span class="kind">{effect.scalingKind}</span>
+									{#if effect.keySlug}<span class="key-slug">{effect.keySlug}</span>{/if}
+									{#if effect.series}<span class="series">{effect.series}</span>{/if}
+									{#if effect.manuallyEditedAt}<span class="edited-badge">edited</span>{/if}
+								</div>
+								<div class="fields">
+									<label>
+										Value
+										{#if canEdit}
+											<input type="number" step="any" bind:value={buf.value} placeholder="—" />
+										{:else}
+											<span>{effect.value ?? '—'}</span>
+										{/if}
+										<span class="unit">{effect.valueUnit ?? ''}</span>
+									</label>
+									<label>
+										Total cap
+										{#if canEdit}
+											<input type="number" step="any" bind:value={buf.totalCap} placeholder="—" />
+										{:else}
+											<span>{effect.totalCap ?? '—'}</span>
+										{/if}
+									</label>
+									<label>
+										Per-copy cap
+										{#if canEdit}
+											<input type="number" step="any" bind:value={buf.perCopyCap} placeholder="—" />
+										{:else}
+											<span>{effect.perCopyCap ?? '—'}</span>
+										{/if}
+									</label>
+									{#if effect.sharedCapGroup}
+										<label>Shared cap <span>{effect.sharedCapGroup}</span></label>
+									{/if}
+									<label class="condition">
+										Condition
+										{#if canEdit}
+											<input
+												type="text"
+												bind:value={buf.condition}
+												placeholder={'{"type": "arcarum", "eq": true}'}
+											/>
+										{:else}
+											<span>{buf.condition || '—'}</span>
+										{/if}
+									</label>
+								</div>
+								{#if effect.notes}
+									<p class="notes">{effect.notes}</p>
+								{/if}
+								{#if canEdit}
+									<div class="actions">
+										<Button
+											variant="secondary"
+											size="small"
+											onclick={() => saveEffect(effect)}
+											disabled={savingId === effect.id}
+										>
+											{savingId === effect.id ? 'Saving…' : 'Save'}
+										</Button>
+										<Button variant="ghost" size="small" onclick={() => deleteEffect(effect)}>
+											Delete
+										</Button>
+									</div>
+								{/if}
+							</div>
+						{/each}
+					</div>
+				</section>
+			{/if}
+		{/each}
+	{/if}
+</div>
+
+<style lang="scss">
+	@use '$src/themes/layout' as layout;
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+
+	.effects-tab {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-2x;
+	}
+
+	.error {
+		color: var(--red);
+		font-size: typography.$font-small;
+		margin: 0;
+	}
+
+	.empty {
+		color: var(--text-tertiary);
+		text-align: center;
+		padding: spacing.$unit-4x 0;
+	}
+
+	.effect-group {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+
+		h3 {
+			font-size: typography.$font-regular;
+			font-weight: typography.$medium;
+			margin: 0;
+		}
+	}
+
+	.cards {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+		gap: spacing.$unit;
+	}
+
+	.card {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+		padding: spacing.$unit;
+		border: 1px solid var(--table-border);
+		border-radius: layout.$item-corner;
+
+		&.edited {
+			border-color: var(--orange-text, #e08a00);
+		}
+	}
+
+	.card-header {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: spacing.$unit-half;
+		font-size: typography.$font-small;
+
+		.boost {
+			font-weight: typography.$medium;
+		}
+
+		.kind,
+		.series,
+		.key-slug {
+			padding: 0 spacing.$unit-half;
+			border-radius: layout.$item-corner-small;
+			background: var(--button-bg);
+			color: var(--text-secondary);
+			font-size: typography.$font-tiny;
+		}
+
+		.edited-badge {
+			color: var(--orange-text, #e08a00);
+			font-size: typography.$font-tiny;
+			font-weight: typography.$medium;
+		}
+	}
+
+	.fields {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-half;
+
+		label {
+			display: flex;
+			align-items: center;
+			gap: spacing.$unit;
+			font-size: typography.$font-small;
+			color: var(--text-secondary);
+
+			input {
+				padding: 2px spacing.$unit-half;
+				background: var(--input-bound-bg);
+				border: none;
+				border-radius: layout.$item-corner-small;
+				font-size: typography.$font-small;
+				color: var(--text-primary);
+				width: 90px;
+			}
+
+			&.condition input {
+				flex: 1;
+				width: auto;
+				font-family: monospace;
+				font-size: typography.$font-tiny;
+			}
+
+			span {
+				color: var(--text-primary);
+			}
+
+			.unit {
+				color: var(--text-tertiary);
+				font-size: typography.$font-tiny;
+			}
+		}
+	}
+
+	.notes {
+		margin: 0;
+		font-size: typography.$font-tiny;
+		color: var(--text-tertiary);
+	}
+
+	.actions {
+		display: flex;
+		gap: spacing.$unit-half;
+	}
+</style>

--- a/src/lib/features/database/weapon-skills/FamilyKeysTab.svelte
+++ b/src/lib/features/database/weapon-skills/FamilyKeysTab.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+	import { entityAdapter } from '$lib/api/adapters/entity.adapter'
+	import Button from '$lib/components/ui/Button.svelte'
+	import type { FamilyKey, WeaponSkillFamily } from '$lib/types/api/weaponSkillFamily'
+
+	interface Props {
+		family: WeaponSkillFamily
+		canEdit: boolean
+		onMutated: () => Promise<void>
+	}
+
+	let { family, canEdit, onMutated }: Props = $props()
+
+	let savingId = $state<string | null>(null)
+	let error = $state<string | null>(null)
+	let edits = $state<Record<string, { nameEn: string; nameJp: string }>>({})
+
+	function keyName(key: FamilyKey): { en: string; ja: string } {
+		return {
+			en: key.name?.en ?? key.nameEn ?? '',
+			ja: key.name?.ja ?? key.nameJp ?? ''
+		}
+	}
+
+	function buffer(key: FamilyKey) {
+		if (!edits[key.id]) {
+			const name = keyName(key)
+			edits[key.id] = { nameEn: name.en, nameJp: name.ja }
+		}
+		return edits[key.id]!
+	}
+
+	function effectsForKey(slug: string) {
+		return family.effects.filter((e) => e.keySlug === slug)
+	}
+
+	async function saveKey(key: FamilyKey) {
+		const buf = edits[key.id]
+		if (!buf) return
+		savingId = key.id
+		error = null
+		try {
+			await entityAdapter.updateWeaponKey(key.id, { name_en: buf.nameEn, name_jp: buf.nameJp })
+			delete edits[key.id]
+			await onMutated()
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to save'
+		} finally {
+			savingId = null
+		}
+	}
+</script>
+
+<div class="keys-tab">
+	{#if error}
+		<p class="error">{error}</p>
+	{/if}
+
+	{#if family.keys.length === 0}
+		<p class="empty">No weapon keys reference this family.</p>
+	{:else}
+		<div class="cards">
+			{#each family.keys as key (key.id)}
+				{@const buf = buffer(key)}
+				<div class="card">
+					<div class="card-header">
+						<span class="slug">{key.slug}</span>
+					</div>
+					<div class="fields">
+						{#if canEdit}
+							<input type="text" bind:value={buf.nameEn} placeholder="Name (en)" />
+							<input type="text" bind:value={buf.nameJp} placeholder="Name (ja)" />
+						{:else}
+							<span>{keyName(key).en || '—'}</span>
+							<span class="jp">{keyName(key).ja || ''}</span>
+						{/if}
+					</div>
+					{#if effectsForKey(key.slug).length > 0}
+						<ul class="key-effects">
+							{#each effectsForKey(key.slug) as effect (effect.id)}
+								<li>
+									{effect.boostType} · {effect.scalingKind}
+									{#if effect.value != null}
+										· {effect.value}{effect.valueUnit === 'percent' ? '%' : ''}
+									{/if}
+								</li>
+							{/each}
+						</ul>
+					{/if}
+					{#if canEdit}
+						<div class="actions">
+							<Button
+								variant="secondary"
+								size="small"
+								onclick={() => saveKey(key)}
+								disabled={savingId === key.id}
+							>
+								{savingId === key.id ? 'Saving…' : 'Save'}
+							</Button>
+						</div>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style lang="scss">
+	@use '$src/themes/layout' as layout;
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+
+	.keys-tab {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+	}
+
+	.error {
+		color: var(--red);
+		font-size: typography.$font-small;
+		margin: 0;
+	}
+
+	.empty {
+		color: var(--text-tertiary);
+		text-align: center;
+		padding: spacing.$unit-4x 0;
+	}
+
+	.cards {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+		gap: spacing.$unit;
+	}
+
+	.card {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+		padding: spacing.$unit;
+		border: 1px solid var(--table-border);
+		border-radius: layout.$item-corner;
+	}
+
+	.card-header .slug {
+		font-family: monospace;
+		font-size: typography.$font-tiny;
+		color: var(--text-tertiary);
+	}
+
+	.fields {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-half;
+		font-size: typography.$font-small;
+
+		input {
+			padding: 2px spacing.$unit-half;
+			background: var(--input-bound-bg);
+			border: none;
+			border-radius: layout.$item-corner-small;
+			font-size: typography.$font-small;
+			color: var(--text-primary);
+		}
+
+		.jp {
+			color: var(--text-tertiary);
+		}
+	}
+
+	.key-effects {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		font-size: typography.$font-tiny;
+		color: var(--text-secondary);
+	}
+
+	.actions {
+		display: flex;
+		gap: spacing.$unit-half;
+	}
+</style>

--- a/src/lib/features/database/weapon-skills/FamilyVersionsTab.svelte
+++ b/src/lib/features/database/weapon-skills/FamilyVersionsTab.svelte
@@ -1,0 +1,283 @@
+<script lang="ts">
+	import { entityAdapter } from '$lib/api/adapters/entity.adapter'
+	import Button from '$lib/components/ui/Button.svelte'
+	import type { FamilyVersion, WeaponSkillFamily } from '$lib/types/api/weaponSkillFamily'
+
+	interface Props {
+		family: WeaponSkillFamily
+		canEdit: boolean
+		onMutated: () => Promise<void>
+	}
+
+	let { family, canEdit, onMutated }: Props = $props()
+
+	let savingId = $state<string | null>(null)
+	let error = $state<string | null>(null)
+	let notice = $state<string | null>(null)
+	let edits = $state<
+		Record<
+			string,
+			{
+				skillSeries: string
+				skillSize: string
+				mainHandOnly: boolean
+				nameEn: string
+				nameJp: string
+			}
+		>
+	>({})
+
+	function buffer(version: FamilyVersion) {
+		if (!edits[version.id]) {
+			edits[version.id] = {
+				skillSeries: version.skillSeries ?? '',
+				skillSize: version.skillSize ?? '',
+				mainHandOnly: version.mainHandOnly ?? false,
+				nameEn: version.name?.en ?? '',
+				nameJp: version.name?.ja ?? ''
+			}
+		}
+		return edits[version.id]!
+	}
+
+	async function saveVersion(version: FamilyVersion) {
+		const buf = edits[version.id]
+		if (!buf) return
+		savingId = version.id
+		error = null
+		notice = null
+		try {
+			await entityAdapter.updateWeaponSkillVersion(version.id, {
+				skill_series: buf.skillSeries || null,
+				skill_size: buf.skillSize || null,
+				main_hand_only: buf.mainHandOnly
+			})
+			// Labels live on the shared skill row — only touch when actually changed.
+			if (buf.nameEn !== (version.name?.en ?? '') || buf.nameJp !== (version.name?.ja ?? '')) {
+				const result = await entityAdapter.updateSkillLabels(version.skillId, {
+					name_en: buf.nameEn,
+					name_jp: buf.nameJp
+				})
+				if (result.sharedByCount > 1) {
+					notice = `Label updated — shared by ${result.sharedByCount} skill versions.`
+				}
+			}
+			delete edits[version.id]
+			await onMutated()
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to save'
+		} finally {
+			savingId = null
+		}
+	}
+
+	function tierLabel(version: FamilyVersion): string {
+		if ((version.transcendenceStage ?? 0) > 0) return `Trans. ${version.transcendenceStage}`
+		switch (version.minUncap) {
+			case 4:
+				return 'FLB'
+			case 5:
+				return 'ULB'
+			default:
+				return 'Base'
+		}
+	}
+</script>
+
+<div class="versions-tab">
+	{#if error}
+		<p class="error">{error}</p>
+	{/if}
+	{#if notice}
+		<p class="notice">{notice}</p>
+	{/if}
+
+	{#if family.versions.length === 0}
+		<p class="empty">No skill versions are classified into this family.</p>
+	{:else}
+		<div class="table-wrapper">
+			<table class="edit-table">
+				<thead>
+					<tr>
+						<th>Weapon</th>
+						<th>Skill name (en / ja)</th>
+						<th>Tier</th>
+						<th>Series</th>
+						<th>Size</th>
+						<th>MH only</th>
+						{#if canEdit}
+							<th></th>
+						{/if}
+					</tr>
+				</thead>
+				<tbody>
+					{#each family.versions as version (version.id)}
+						{@const buf = buffer(version)}
+						<tr>
+							<td>
+								{#if version.weapon}
+									<a href={`/database/weapons/${version.weapon.granblueId}`}>
+										{version.weapon.nameEn}
+									</a>
+								{:else}
+									—
+								{/if}
+							</td>
+							<td class="labels">
+								{#if canEdit}
+									<input type="text" bind:value={buf.nameEn} placeholder="Name (en)" />
+									<input type="text" bind:value={buf.nameJp} placeholder="Name (ja)" class="jp" />
+								{:else}
+									<span>{version.name?.en ?? '—'}</span>
+									{#if version.name?.ja}<span class="jp">{version.name.ja}</span>{/if}
+								{/if}
+							</td>
+							<td><span class="tier">{tierLabel(version)}</span></td>
+							<td>
+								{#if canEdit}
+									<select bind:value={buf.skillSeries}>
+										<option value="">—</option>
+										{#each ['normal', 'omega', 'ex', 'odious'] as s (s)}
+											<option value={s}>{s}</option>
+										{/each}
+									</select>
+								{:else}
+									{version.skillSeries ?? '—'}
+								{/if}
+							</td>
+							<td>
+								{#if canEdit}
+									<select bind:value={buf.skillSize}>
+										<option value="">—</option>
+										{#each ['small', 'medium', 'big', 'big2', 'massive', 'ancestral'] as s (s)}
+											<option value={s}>{s}</option>
+										{/each}
+									</select>
+								{:else}
+									{version.skillSize ?? '—'}
+								{/if}
+							</td>
+							<td>
+								{#if canEdit}
+									<input type="checkbox" bind:checked={buf.mainHandOnly} />
+								{:else}
+									{version.mainHandOnly ? 'yes' : '—'}
+								{/if}
+							</td>
+							{#if canEdit}
+								<td>
+									<Button
+										variant="secondary"
+										size="small"
+										onclick={() => saveVersion(version)}
+										disabled={savingId === version.id}
+									>
+										{savingId === version.id ? 'Saving…' : 'Save'}
+									</Button>
+								</td>
+							{/if}
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
+</div>
+
+<style lang="scss">
+	@use '$src/themes/layout' as layout;
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+
+	.versions-tab {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit;
+	}
+
+	.error {
+		color: var(--red);
+		font-size: typography.$font-small;
+		margin: 0;
+	}
+
+	.notice {
+		color: var(--orange-text, #e08a00);
+		font-size: typography.$font-small;
+		margin: 0;
+	}
+
+	.empty {
+		color: var(--text-tertiary);
+		text-align: center;
+		padding: spacing.$unit-4x 0;
+	}
+
+	.table-wrapper {
+		overflow-x: auto;
+	}
+
+	.edit-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: typography.$font-small;
+
+		th {
+			text-align: left;
+			font-weight: typography.$medium;
+			color: var(--text-secondary);
+			padding: spacing.$unit-half spacing.$unit;
+			border-bottom: 1px solid var(--table-border);
+			white-space: nowrap;
+		}
+
+		td {
+			padding: spacing.$unit-half spacing.$unit;
+			border-bottom: 1px solid var(--table-border);
+			vertical-align: middle;
+		}
+
+		a {
+			color: var(--link-color, var(--blue));
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+
+		input[type='text'],
+		select {
+			padding: 2px spacing.$unit-half;
+			background: var(--input-bound-bg);
+			border: none;
+			border-radius: layout.$item-corner-small;
+			font-size: typography.$font-small;
+			color: var(--text-primary);
+		}
+	}
+
+	.labels {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+
+		input {
+			min-width: 180px;
+		}
+
+		.jp {
+			color: var(--text-tertiary);
+		}
+	}
+
+	.tier {
+		display: inline-block;
+		padding: 0 spacing.$unit-half;
+		border-radius: layout.$item-corner-small;
+		background: var(--button-bg);
+		color: var(--text-secondary);
+		font-size: typography.$font-tiny;
+		white-space: nowrap;
+	}
+</style>

--- a/src/lib/types/api/entities.ts
+++ b/src/lib/types/api/entities.ts
@@ -266,6 +266,19 @@ export interface CharacterSkillLink {
 }
 
 // Summon entity from SummonBlueprint
+/** One parsed summon aura row (main or sub) at a given uncap/transcendence tier */
+export interface SummonAura {
+	id: string
+	slot: 'main' | 'sub' | string
+	target: string
+	element?: string | null
+	value?: number | null
+	uncapLevel: number
+	transcendenceStage: number
+	condition?: string | null
+	description: { en?: string | null; ja?: string | null }
+}
+
 export interface Summon {
 	id: string
 	granblueId: string
@@ -279,6 +292,8 @@ export interface Summon {
 		transcendence: boolean
 	}
 	subaura?: boolean
+	/** Structured per-tier auras parsed from the wiki (the calculator's source) */
+	summonAuras?: SummonAura[]
 	limit?: boolean
 	/** Whether this summon can be set as a support (friend) summon. Defaults
 	 * to true server-side; only certain summons are explicitly excluded. */

--- a/src/lib/types/api/weaponSkillFamily.ts
+++ b/src/lib/types/api/weaponSkillFamily.ts
@@ -1,0 +1,118 @@
+/**
+ * Weapon-skill family types — the modifier-keyed aggregates the grid damage
+ * calculator resolves values through, served by /weapon_skill_families.
+ */
+
+export interface WeaponSkillFamilySummary {
+	modifier: string
+	displayName: { en?: string | null; ja?: string | null } | null
+	boostTypes: string[]
+	series: string[]
+	sizes: string[]
+	formulaTypes: string[]
+	counts: { dataRows: number; effectRows: number; versions: number; weapons: number }
+	manuallyEdited: boolean
+}
+
+export interface WeaponSkillDatumRow {
+	id: string
+	modifier: string
+	boostType: string
+	series?: string | null
+	size?: string | null
+	formulaType?: string | null
+	sl1?: number | null
+	sl10?: number | null
+	sl15?: number | null
+	sl20?: number | null
+	sl25?: number | null
+	coefficient?: number | null
+	maxValue?: number | null
+	auraBoostable?: boolean | null
+	weaponSkillVersionId?: string | null
+	manuallyEditedAt?: string | null
+}
+
+export interface WeaponSkillEffectRow {
+	id: string
+	modifier: string
+	boostType: string
+	series?: string | null
+	scalingKind: string
+	value?: number | null
+	valueUnit?: string | null
+	perCopyCap?: number | null
+	totalCap?: number | null
+	sharedCapGroup?: string | null
+	capFormula?: string | null
+	countBasis?: string | null
+	countCap?: number | null
+	condition?: Record<string, unknown> | null
+	targetInstance?: string | null
+	auraBoostable?: boolean | null
+	stacking?: string | null
+	appliesTo?: string | null
+	notes?: string | null
+	keySlug?: string | null
+	frameRule?: string | null
+	weaponSkillVersionId?: string | null
+	manuallyEditedAt?: string | null
+	/** canonical | key | version */
+	source: string
+}
+
+export interface FamilyVersion {
+	id: string
+	skillId: string
+	name: { en?: string | null; ja?: string | null }
+	description: { en?: string | null; ja?: string | null }
+	iconStem?: string | null
+	ordinal: number
+	minUncap?: number | null
+	transcendenceStage?: number | null
+	skillModifier?: string | null
+	skillSeries?: string | null
+	skillSize?: string | null
+	mainHandOnly?: boolean
+	mcOnly?: boolean
+	scalesWithSkillLevel?: boolean
+	weapon?: { granblueId: string; nameEn: string; element?: number } | null
+}
+
+export interface FamilyKey {
+	id: string
+	nameEn?: string
+	nameJp?: string
+	name?: { en?: string; ja?: string }
+	slug: string
+}
+
+export interface WeaponSkillFamily {
+	modifier: string
+	displayName: { en?: string | null; ja?: string | null }
+	iconStem?: string | null
+	data: WeaponSkillDatumRow[]
+	effects: WeaponSkillEffectRow[]
+	versions: FamilyVersion[]
+	keys: FamilyKey[]
+	usage: { versionCount: number; weaponCount: number }
+}
+
+/** Blast-radius payload returned by guarded deletes (409) */
+export interface DeleteImpact {
+	error?: string
+	affectedVersions: number
+	affectedWeapons: number
+	sampleWeapons: string[]
+	deleted?: boolean
+}
+
+export interface PanelValidation {
+	ok: boolean
+	panels: Array<{
+		party: string
+		capturedOn?: string
+		ok: boolean
+		mismatches: Array<{ label: string; ours: number | null; expected: number | string }>
+	}>
+}

--- a/src/routes/(app)/database/characters/[granblueId]/+page.svelte
+++ b/src/routes/(app)/database/characters/[granblueId]/+page.svelte
@@ -560,6 +560,13 @@
 					gameRawJp={rawDataQuery.data?.gameRawJp}
 					isLoading={rawDataQuery.isLoading}
 					{canEdit}
+					onReparse={canEdit && character?.id
+						? async (refetch) => {
+								await entityAdapter.reparseCharacter(character.id, refetch)
+								characterQuery.refetch()
+								rawDataQuery.refetch()
+							}
+						: undefined}
 					onFetchWiki={canEdit && character?.id && character?.wiki?.en
 						? async () => {
 								// Fetch wiki data client-side (bypasses CloudFlare)

--- a/src/routes/(app)/database/summons/[granblueId]/+page.svelte
+++ b/src/routes/(app)/database/summons/[granblueId]/+page.svelte
@@ -25,6 +25,7 @@
 	import SummonStatsSection from '$lib/features/database/summons/sections/SummonStatsSection.svelte'
 	import EntityImagesTab from '$lib/features/database/detail/tabs/EntityImagesTab.svelte'
 	import EntityRawDataTab from '$lib/features/database/detail/tabs/EntityRawDataTab.svelte'
+	import SummonAurasTab from '$lib/features/database/summons/tabs/SummonAurasTab.svelte'
 	import DetailsContainer from '$lib/components/ui/DetailsContainer.svelte'
 	import DetailItem from '$lib/components/ui/DetailItem.svelte'
 	import { getSummonImage, getSummonTransformationStages } from '$lib/utils/images'
@@ -193,6 +194,8 @@
 			image={getSummonGridImage(summon)}
 			{currentTab}
 			onTabChange={handleTabChange}
+			showSkills={(summon.summonAuras?.length ?? 0) > 0}
+			skillsLabel="Auras"
 			onDownloadAllImages={canEdit ? handleDownloadAllImages : undefined}
 			onDownloadSize={canEdit ? handleDownloadSize : undefined}
 			availableSizes={summonSizes}
@@ -346,6 +349,8 @@
 						{/if}
 					</div>
 				</section>
+			{:else if currentTab === 'skills'}
+				<SummonAurasTab auras={summon.summonAuras ?? []} />
 			{:else if currentTab === 'images'}
 				<EntityImagesTab
 					images={summonImages}
@@ -360,6 +365,13 @@
 					gameRawJp={rawDataQuery.data?.gameRawJp}
 					isLoading={rawDataQuery.isLoading}
 					{canEdit}
+					onReparse={canEdit && summon?.id
+						? async (refetch) => {
+								await entityAdapter.reparseSummon(summon.id, refetch)
+								summonQuery.refetch()
+								rawDataQuery.refetch()
+							}
+						: undefined}
 					onFetchWiki={canEdit && summon?.id && summon?.wiki?.en
 						? async () => {
 								// Fetch wiki data client-side (bypasses CloudFlare)

--- a/src/routes/(app)/database/weapon-skills/+page.server.ts
+++ b/src/routes/(app)/database/weapon-skills/+page.server.ts
@@ -1,0 +1,7 @@
+import type { PageServerLoad } from './$types'
+
+// The database layout already gates on role >= 7; pass role through for edit affordances.
+export const load: PageServerLoad = async ({ parent }) => {
+	const { role } = await parent()
+	return { role }
+}

--- a/src/routes/(app)/database/weapon-skills/+page.svelte
+++ b/src/routes/(app)/database/weapon-skills/+page.svelte
@@ -1,0 +1,315 @@
+<script lang="ts">
+	import { goto } from '$app/navigation'
+	import { createQuery } from '@tanstack/svelte-query'
+	import { entityAdapter } from '$lib/api/adapters/entity.adapter'
+	import PageMeta from '$lib/components/PageMeta.svelte'
+	import type { WeaponSkillFamilySummary } from '$lib/types/api/weaponSkillFamily'
+
+	const familiesQuery = createQuery(() => ({
+		queryKey: ['weaponSkillFamilies'],
+		queryFn: () => entityAdapter.getWeaponSkillFamilies()
+	}))
+
+	let searchTerm = $state('')
+	let seriesFilter = $state('')
+	let sizeFilter = $state('')
+	let boostTypeFilter = $state('')
+
+	const allFamilies = $derived(familiesQuery.data ?? [])
+
+	const boostTypeOptions = $derived([...new Set(allFamilies.flatMap((f) => f.boostTypes))].sort())
+
+	const filteredFamilies = $derived.by(() => {
+		let families = allFamilies
+		if (searchTerm.trim()) {
+			const term = searchTerm.toLowerCase()
+			families = families.filter(
+				(f) =>
+					f.modifier.toLowerCase().includes(term) ||
+					f.displayName?.en?.toLowerCase().includes(term) ||
+					f.displayName?.ja?.toLowerCase().includes(term)
+			)
+		}
+		if (seriesFilter) families = families.filter((f) => f.series.includes(seriesFilter))
+		if (sizeFilter) families = families.filter((f) => f.sizes.includes(sizeFilter))
+		if (boostTypeFilter) families = families.filter((f) => f.boostTypes.includes(boostTypeFilter))
+		return families
+	})
+
+	const editedCount = $derived(allFamilies.filter((f) => f.manuallyEdited).length)
+
+	function handleRowClick(family: WeaponSkillFamilySummary) {
+		goto(`/database/weapon-skills/${encodeURIComponent(family.modifier)}`)
+	}
+</script>
+
+<PageMeta title="Weapon Skills" description="Weapon skill families and calculator data" />
+
+<div class="page">
+	<div class="grid-container">
+		<div class="controls">
+			<input
+				type="text"
+				placeholder="Search skill families..."
+				bind:value={searchTerm}
+				class="search"
+			/>
+			<select bind:value={seriesFilter} class="filter-select">
+				<option value="">All series</option>
+				<option value="normal">Normal</option>
+				<option value="omega">Omega</option>
+				<option value="ex">EX</option>
+				<option value="odious">Odious</option>
+			</select>
+			<select bind:value={sizeFilter} class="filter-select">
+				<option value="">All sizes</option>
+				{#each ['small', 'medium', 'big', 'big2', 'massive', 'ancestral'] as size (size)}
+					<option value={size}>{size}</option>
+				{/each}
+			</select>
+			<select bind:value={boostTypeFilter} class="filter-select">
+				<option value="">All boost types</option>
+				{#each boostTypeOptions as bt (bt)}
+					<option value={bt}>{bt}</option>
+				{/each}
+			</select>
+		</div>
+
+		{#if editedCount > 0}
+			<div class="export-reminder">
+				{editedCount}
+				{editedCount === 1 ? 'family carries' : 'families carry'} manual edits — run
+				<code>rake granblue:export_weapon_skill_data</code> /
+				<code>granblue:export_weapon_skill_effects</code> to snapshot them.
+			</div>
+		{/if}
+
+		{#if familiesQuery.isLoading}
+			<div class="loading">Loading skill families...</div>
+		{:else if familiesQuery.isError}
+			<div class="error">Failed to load skill families</div>
+		{:else}
+			<div class="table-wrapper">
+				<table class="data-table">
+					<thead>
+						<tr>
+							<th>Family</th>
+							<th>Boost Types</th>
+							<th>Series</th>
+							<th>Sizes</th>
+							<th class="num">Data</th>
+							<th class="num">Effects</th>
+							<th class="num">Weapons</th>
+							<th></th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each filteredFamilies as family (family.modifier)}
+							<tr onclick={() => handleRowClick(family)} class="clickable">
+								<td>
+									<div class="name-cell">
+										<span class="name-en">{family.displayName?.en ?? family.modifier}</span>
+										<span class="modifier">{family.modifier}</span>
+									</div>
+								</td>
+								<td>
+									<div class="chips">
+										{#each family.boostTypes.slice(0, 4) as bt (bt)}
+											<span class="chip">{bt}</span>
+										{/each}
+										{#if family.boostTypes.length > 4}
+											<span class="chip more">+{family.boostTypes.length - 4}</span>
+										{/if}
+									</div>
+								</td>
+								<td>{family.series.join(', ') || '—'}</td>
+								<td>{family.sizes.join(', ') || '—'}</td>
+								<td class="num">{family.counts.dataRows}</td>
+								<td class="num">{family.counts.effectRows}</td>
+								<td class="num">{family.counts.weapons}</td>
+								<td>
+									{#if family.manuallyEdited}
+										<span class="edited-badge">edited</span>
+									{/if}
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+
+			<div class="footer">
+				Showing {filteredFamilies.length} of {allFamilies.length} skill families
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style lang="scss">
+	@use '$src/themes/effects' as effects;
+	@use '$src/themes/layout' as layout;
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+
+	.page {
+		padding: spacing.$unit-2x 0;
+		margin: 0 auto;
+	}
+
+	.grid-container {
+		background: var(--card-bg);
+		border: 0.5px solid rgba(0, 0, 0, 0.18);
+		border-radius: layout.$page-corner;
+		box-shadow: effects.$page-elevation;
+		overflow: hidden;
+	}
+
+	.controls {
+		display: flex;
+		align-items: center;
+		padding: spacing.$unit;
+		border-bottom: 1px solid var(--table-border);
+		gap: spacing.$unit;
+
+		.search {
+			padding: spacing.$unit spacing.$unit-2x;
+			background: var(--input-bound-bg);
+			border: none;
+			border-radius: layout.$item-corner;
+			font-size: typography.$font-medium;
+			flex: 1;
+
+			&:hover {
+				background: var(--input-bound-bg-hover);
+			}
+
+			&:focus {
+				outline: none;
+				box-shadow: 0 0 0 2px var(--blue);
+			}
+		}
+
+		.filter-select {
+			padding: spacing.$unit;
+			background: var(--input-bound-bg);
+			border: none;
+			border-radius: layout.$item-corner;
+			font-size: typography.$font-small;
+			color: var(--text-primary);
+		}
+	}
+
+	.export-reminder {
+		padding: spacing.$unit spacing.$unit-2x;
+		background: var(--notice-yellow-bg, rgba(224, 138, 0, 0.1));
+		color: var(--text-secondary);
+		font-size: typography.$font-small;
+		border-bottom: 1px solid var(--table-border);
+
+		code {
+			font-size: typography.$font-tiny;
+		}
+	}
+
+	.loading,
+	.error {
+		text-align: center;
+		padding: spacing.$unit * 4;
+		color: var(--text-secondary);
+	}
+
+	.error {
+		color: var(--red);
+	}
+
+	.table-wrapper {
+		overflow-x: auto;
+	}
+
+	.data-table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: typography.$font-small;
+
+		th {
+			text-align: left;
+			font-weight: typography.$medium;
+			color: var(--text-secondary);
+			padding: spacing.$unit spacing.$unit-2x;
+			border-bottom: 1px solid var(--table-border);
+			white-space: nowrap;
+		}
+
+		td {
+			padding: spacing.$unit spacing.$unit-2x;
+			border-bottom: 1px solid var(--table-border);
+			vertical-align: middle;
+			color: var(--text-primary);
+		}
+
+		.num {
+			text-align: right;
+			font-variant-numeric: tabular-nums;
+		}
+
+		tr.clickable {
+			cursor: pointer;
+
+			&:hover {
+				background: var(--button-bg);
+			}
+		}
+	}
+
+	.name-cell {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+
+		.name-en {
+			font-weight: typography.$medium;
+		}
+
+		.modifier {
+			font-family: monospace;
+			font-size: typography.$font-tiny;
+			color: var(--text-tertiary);
+		}
+	}
+
+	.chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: spacing.$unit-half;
+	}
+
+	.chip {
+		display: inline-block;
+		padding: 0 spacing.$unit-half;
+		border-radius: layout.$item-corner-small;
+		background: var(--button-bg);
+		color: var(--text-secondary);
+		font-size: typography.$font-tiny;
+		white-space: nowrap;
+
+		&.more {
+			color: var(--text-tertiary);
+		}
+	}
+
+	.edited-badge {
+		display: inline-block;
+		padding: 0 spacing.$unit-half;
+		border-radius: layout.$item-corner-small;
+		background: var(--notice-yellow-bg, rgba(224, 138, 0, 0.15));
+		color: var(--orange-text, #e08a00);
+		font-size: typography.$font-tiny;
+		font-weight: typography.$medium;
+	}
+
+	.footer {
+		padding: spacing.$unit spacing.$unit-2x;
+		color: var(--text-tertiary);
+		font-size: typography.$font-small;
+	}
+</style>

--- a/src/routes/(app)/database/weapon-skills/[modifier]/+page.server.ts
+++ b/src/routes/(app)/database/weapon-skills/[modifier]/+page.server.ts
@@ -1,0 +1,6 @@
+import type { PageServerLoad } from './$types'
+
+export const load: PageServerLoad = async ({ parent, params }) => {
+	const { role } = await parent()
+	return { role, modifier: params.modifier }
+}

--- a/src/routes/(app)/database/weapon-skills/[modifier]/+page.svelte
+++ b/src/routes/(app)/database/weapon-skills/[modifier]/+page.svelte
@@ -1,0 +1,341 @@
+<script lang="ts">
+	import { createQuery, useQueryClient } from '@tanstack/svelte-query'
+	import { entityAdapter } from '$lib/api/adapters/entity.adapter'
+	import { ApiError } from '$lib/api/adapters/errors'
+	import PageMeta from '$lib/components/PageMeta.svelte'
+	import Button from '$lib/components/ui/Button.svelte'
+	import SegmentedControl from '$lib/components/ui/segmented-control/SegmentedControl.svelte'
+	import Segment from '$lib/components/ui/segmented-control/Segment.svelte'
+	import NotFoundPlaceholder from '$lib/components/database/NotFoundPlaceholder.svelte'
+	import FamilyDataTab from '$lib/features/database/weapon-skills/FamilyDataTab.svelte'
+	import FamilyEffectsTab from '$lib/features/database/weapon-skills/FamilyEffectsTab.svelte'
+	import FamilyVersionsTab from '$lib/features/database/weapon-skills/FamilyVersionsTab.svelte'
+	import FamilyKeysTab from '$lib/features/database/weapon-skills/FamilyKeysTab.svelte'
+	import type { DeleteImpact, PanelValidation } from '$lib/types/api/weaponSkillFamily'
+
+	let { data } = $props()
+
+	const queryClient = useQueryClient()
+	const modifier = $derived(data.modifier ?? '')
+	const canEdit = $derived((data.role || 0) >= 7)
+
+	const familyQuery = createQuery(() => ({
+		queryKey: ['weaponSkillFamily', data.modifier],
+		queryFn: () => entityAdapter.getWeaponSkillFamily(data.modifier ?? '')
+	}))
+	const family = $derived(familyQuery.data)
+
+	type Tab = 'overview' | 'data' | 'effects' | 'versions' | 'keys'
+	let currentTab = $state<Tab>('overview')
+
+	// --- Calculator-impact tracking: any data/effect mutation arms the banner
+	let dirty = $state(false)
+	let validating = $state(false)
+	let validation = $state<PanelValidation | null>(null)
+
+	async function afterMutation() {
+		dirty = true
+		validation = null
+		await queryClient.invalidateQueries({ queryKey: ['weaponSkillFamily', data.modifier] })
+		await queryClient.invalidateQueries({ queryKey: ['weaponSkillFamilies'] })
+	}
+
+	async function runValidation() {
+		validating = true
+		try {
+			validation = await entityAdapter.validatePanels()
+			if (validation.ok) dirty = false
+		} finally {
+			validating = false
+		}
+	}
+
+	/** Guarded delete helper shared by the tabs: 409 → confirm with blast radius */
+	async function guardedDelete(
+		doDelete: (force: boolean) => Promise<DeleteImpact>
+	): Promise<boolean> {
+		try {
+			await doDelete(false)
+			await afterMutation()
+			return true
+		} catch (err) {
+			if (err instanceof ApiError && err.status === 409) {
+				const impact = err.details as DeleteImpact
+				const samples = impact.sampleWeapons?.join(', ') || 'none'
+				const message =
+					`This row affects ${impact.affectedVersions} skill version(s) on ` +
+					`${impact.affectedWeapons} weapon(s) (${samples}). Delete anyway?`
+				if (confirm(message)) {
+					await doDelete(true)
+					await afterMutation()
+					return true
+				}
+				return false
+			}
+			throw err
+		}
+	}
+</script>
+
+<PageMeta title={family?.displayName?.en ?? modifier} description="Weapon skill family" />
+
+<div class="page">
+	{#if familyQuery.isLoading}
+		<div class="state">Loading skill family...</div>
+	{:else if familyQuery.isError || !family}
+		<NotFoundPlaceholder
+			title="Skill Family Not Found"
+			message="No weapon skill data exists for this modifier."
+			backHref="/database/weapon-skills"
+			backLabel="Back to Weapon Skills"
+		/>
+	{:else}
+		<header class="header">
+			<div class="title">
+				<Button variant="ghost" size="small" href="/database/weapon-skills">← Back</Button>
+				<div class="names">
+					<h1>{family.displayName?.en ?? family.modifier}</h1>
+					<span class="modifier">{family.modifier}</span>
+				</div>
+			</div>
+			<div class="usage">
+				{family.usage.weaponCount} weapon{family.usage.weaponCount === 1 ? '' : 's'} ·
+				{family.usage.versionCount} version{family.usage.versionCount === 1 ? '' : 's'}
+			</div>
+		</header>
+
+		{#if dirty}
+			<div class="validation-banner" class:failed={validation && !validation.ok}>
+				<span>
+					{#if validation && !validation.ok}
+						Golden panel validation FAILED — review the mismatches below or revert the edit.
+					{:else}
+						Calculator inputs changed — validate the golden panels before moving on.
+					{/if}
+				</span>
+				<Button variant="secondary" size="small" onclick={runValidation} disabled={validating}>
+					{validating ? 'Validating…' : 'Run validation'}
+				</Button>
+			</div>
+			{#if validation}
+				<div class="validation-results">
+					{#each validation.panels as panel (panel.party)}
+						<div class="panel-result" class:ok={panel.ok}>
+							<strong>{panel.party}</strong>
+							{panel.ok ? 'ok' : ''}
+							{#each panel.mismatches as m (m.label)}
+								<span class="mismatch">{m.label}: {m.ours ?? '—'} vs {m.expected}</span>
+							{/each}
+						</div>
+					{/each}
+				</div>
+			{/if}
+		{/if}
+
+		<SegmentedControl value={currentTab} onValueChange={(v) => (currentTab = v as Tab)}>
+			<Segment value="overview">Overview</Segment>
+			<Segment value="data">Scaling Data</Segment>
+			<Segment value="effects">Effects</Segment>
+			<Segment value="versions">Versions</Segment>
+			{#if family.keys.length > 0}
+				<Segment value="keys">Keys</Segment>
+			{/if}
+		</SegmentedControl>
+
+		<div class="tab-content">
+			{#if currentTab === 'overview'}
+				<section class="overview">
+					<div class="summary">
+						<dl>
+							<dt>Boost types</dt>
+							<dd>
+								{[...new Set([...family.data, ...family.effects].map((r) => r.boostType))].join(
+									', '
+								) || '—'}
+							</dd>
+							<dt>Series</dt>
+							<dd>
+								{[...new Set(family.data.map((r) => r.series).filter(Boolean))].join(', ') || '—'}
+							</dd>
+							<dt>Sizes</dt>
+							<dd>
+								{[...new Set(family.data.map((r) => r.size).filter(Boolean))].join(', ') || '—'}
+							</dd>
+						</dl>
+					</div>
+					{#if family.versions.length > 0}
+						<h3>Carried by</h3>
+						<ul class="weapon-list">
+							{#each [...new Map(family.versions
+										.filter((v) => v.weapon)
+										.map( (v) => [v.weapon!.granblueId, v.weapon!] )).values()] as weapon (weapon.granblueId)}
+								<li>
+									<a href={`/database/weapons/${weapon.granblueId}`}>{weapon.nameEn}</a>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+				</section>
+			{:else if currentTab === 'data'}
+				<FamilyDataTab {family} {canEdit} onMutated={afterMutation} onDelete={guardedDelete} />
+			{:else if currentTab === 'effects'}
+				<FamilyEffectsTab {family} {canEdit} onMutated={afterMutation} onDelete={guardedDelete} />
+			{:else if currentTab === 'versions'}
+				<FamilyVersionsTab {family} {canEdit} onMutated={afterMutation} />
+			{:else if currentTab === 'keys'}
+				<FamilyKeysTab {family} {canEdit} onMutated={afterMutation} />
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<style lang="scss">
+	@use '$src/themes/effects' as effects;
+	@use '$src/themes/layout' as layout;
+	@use '$src/themes/spacing' as spacing;
+	@use '$src/themes/typography' as typography;
+
+	.page {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-2x;
+		padding: spacing.$unit-2x 0;
+		margin: 0 auto;
+	}
+
+	.state {
+		text-align: center;
+		padding: spacing.$unit * 4;
+		color: var(--text-secondary);
+	}
+
+	.header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: spacing.$unit;
+
+		.title {
+			display: flex;
+			align-items: center;
+			gap: spacing.$unit-2x;
+		}
+
+		.names {
+			display: flex;
+			align-items: baseline;
+			gap: spacing.$unit;
+
+			h1 {
+				font-size: typography.$font-large;
+				margin: 0;
+			}
+
+			.modifier {
+				font-family: monospace;
+				font-size: typography.$font-small;
+				color: var(--text-tertiary);
+			}
+		}
+
+		.usage {
+			color: var(--text-secondary);
+			font-size: typography.$font-small;
+		}
+	}
+
+	.validation-banner {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: spacing.$unit;
+		padding: spacing.$unit spacing.$unit-2x;
+		border-radius: layout.$item-corner;
+		background: var(--notice-yellow-bg, rgba(224, 138, 0, 0.12));
+		color: var(--text-primary);
+		font-size: typography.$font-small;
+
+		&.failed {
+			background: var(--notice-red-bg, rgba(220, 60, 60, 0.12));
+		}
+	}
+
+	.validation-results {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-half;
+		padding: 0 spacing.$unit-2x;
+		font-size: typography.$font-small;
+
+		.panel-result {
+			display: flex;
+			flex-wrap: wrap;
+			gap: spacing.$unit;
+			color: var(--text-secondary);
+
+			&.ok strong {
+				color: var(--text-tertiary);
+			}
+		}
+
+		.mismatch {
+			color: var(--red);
+			font-variant-numeric: tabular-nums;
+		}
+	}
+
+	.tab-content {
+		background: var(--card-bg);
+		border: 0.5px solid rgba(0, 0, 0, 0.18);
+		border-radius: layout.$page-corner;
+		box-shadow: effects.$page-elevation;
+		padding: spacing.$unit-2x;
+	}
+
+	.overview {
+		display: flex;
+		flex-direction: column;
+		gap: spacing.$unit-2x;
+
+		dl {
+			display: grid;
+			grid-template-columns: auto 1fr;
+			gap: spacing.$unit-half spacing.$unit-2x;
+			margin: 0;
+
+			dt {
+				color: var(--text-secondary);
+				font-size: typography.$font-small;
+			}
+
+			dd {
+				margin: 0;
+				font-size: typography.$font-small;
+			}
+		}
+
+		h3 {
+			font-size: typography.$font-regular;
+			margin: 0;
+		}
+
+		.weapon-list {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+			display: flex;
+			flex-wrap: wrap;
+			gap: spacing.$unit;
+
+			a {
+				color: var(--link-color, var(--blue));
+				font-size: typography.$font-small;
+				text-decoration: none;
+
+				&:hover {
+					text-decoration: underline;
+				}
+			}
+		}
+	}
+</style>

--- a/src/routes/(app)/database/weapons/[granblueId]/+page.svelte
+++ b/src/routes/(app)/database/weapons/[granblueId]/+page.svelte
@@ -464,6 +464,13 @@
 					gameRawJp={rawDataQuery.data?.gameRawJp}
 					isLoading={rawDataQuery.isLoading}
 					{canEdit}
+					onReparse={canEdit && weapon?.id
+						? async (refetch) => {
+								await entityAdapter.reparseWeapon(weapon.id, refetch)
+								weaponQuery.refetch()
+								rawDataQuery.refetch()
+							}
+						: undefined}
 					onFetchWiki={canEdit && weapon?.id && weapon?.wiki?.en
 						? async () => {
 								// Fetch wiki data client-side (bypasses CloudFlare)


### PR DESCRIPTION
## Summary

Database UI for skills accuracy: a **structured summon Auras tab**, **per-entity Re-parse actions**, and a new **/database/weapon-skills section** where editors browse every weapon-skill family and edit the calculator's values, labels, and keys in a structured way. Frontend half of hensei-api#448. Stacks on #885.

## What's included

### Summon Auras tab
Summon detail pages gain an Auras tab (the flat wiki text stays on Info): per-tier rows grouped main vs sub with tier badges, target chips (frame/elemental/multiattack classification), values, conditions, and descriptions — the same rows the calculator consumes, finally visible.

### Re-parse from the Raw Data tab
Weapons, summons, and characters get a Re-parse button next to Fetch Wiki (editor-gated), with a "fetch fresh wikitext first" checkbox. Calls the new reparse endpoints and refreshes both the entity and raw-data queries.

### /database/weapon-skills
- **List**: every skill family with display name + modifier slug, boost-type chips, series/sizes, row counts, weapon usage, and an "edited" badge; search plus series/size/boost-type filters; an export reminder when manual edits haven't been snapshotted to JSON. Added to the Database navigation dropdown.
- **Family detail** (tabs):
  - *Overview* — classification summary and the weapons carrying the family (linked).
  - *Scaling Data* — SL anchors, coefficient, max, formula type editable per row.
  - *Effects* — cards grouped canonical / key-granted / version-linked; value, caps, and condition (validated JSON) editable.
  - *Versions* — per-weapon classification (series/size/main-hand) and shared skill labels, with a "shared by N versions" warning.
  - *Keys* — weapon key names plus their granted effect rows.
- **Safety**: deletes surface the API's blast radius (affected versions/weapons) before forcing; any data mutation arms a banner with **Run validation**, which executes the golden-panel check inline and lists mismatches per party.

## Testing
`pnpm check` green. API-side behavior (reparse idempotence, golden validation, guarded deletes) covered by hensei-api#448's request specs and live smoke tests.
