### PR TITLE
Befoulment editor: current value + Permeation

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1736,5 +1736,8 @@
 	"calculator_hp_value": "HP: {percent}%",
 	"calculator_turn_value": "Turn {turn}",
 	"calculator_alpha_notice": "This feature is in alpha and may display incorrect data. If you find incorrect calculations, please report in Discord.",
-	"nav_weapon_skills": "Weapon Skills"
+	"nav_weapon_skills": "Weapon Skills",
+	"details_permeation": "Permeation",
+	"befoulment_permeation": "Permeation",
+	"befoulment_permeation_hint": "Implied base roll: {min} to {max}"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1735,6 +1735,8 @@
 	"calculator_foe_element": "Foe Element",
 	"calculator_hp_value": "HP: {percent}%",
 	"calculator_turn_value": "Turn {turn}",
+	"calculator_max_hp": "Max HP",
+	"calculator_arcarum": "Arcarum",
 	"calculator_alpha_notice": "This feature is in alpha and may display incorrect data. If you find incorrect calculations, please report in Discord.",
 	"nav_weapon_skills": "Weapon Skills",
 	"details_permeation": "Permeation",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1716,6 +1716,8 @@
 	"calculator_foe_element": "敵の属性",
 	"calculator_hp_value": "HP: {percent}%",
 	"calculator_turn_value": "{turn}ターン目",
+	"calculator_max_hp": "最大HP",
+	"calculator_arcarum": "アーカルム",
 	"calculator_alpha_notice": "この機能はアルファ版のため、正しくないデータが表示される場合があります。計算の誤りを見つけた場合は、Discordでご報告ください。",
 	"nav_weapon_skills": "武器スキル",
 	"details_permeation": "深度",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1717,5 +1717,8 @@
 	"calculator_hp_value": "HP: {percent}%",
 	"calculator_turn_value": "{turn}ターン目",
 	"calculator_alpha_notice": "この機能はアルファ版のため、正しくないデータが表示される場合があります。計算の誤りを見つけた場合は、Discordでご報告ください。",
-	"nav_weapon_skills": "武器スキル"
+	"nav_weapon_skills": "武器スキル",
+	"details_permeation": "深度",
+	"befoulment_permeation": "深度",
+	"befoulment_permeation_hint": "推定初期値: {min}〜{max}"
 }

--- a/src/lib/api/adapters/__tests__/app-environment-mock.ts
+++ b/src/lib/api/adapters/__tests__/app-environment-mock.ts
@@ -1,0 +1,5 @@
+/** Test-only replacement for SvelteKit's virtual $app/environment module. */
+export const browser = false
+export const building = false
+export const dev = false
+export const version = 'test'

--- a/src/lib/api/adapters/__tests__/auth-store-mock.ts
+++ b/src/lib/api/adapters/__tests__/auth-store-mock.ts
@@ -1,0 +1,4 @@
+/** Test-only replacement for the browser auth store used by BaseAdapter. */
+export const authStore = {
+	checkAndRefresh: async () => null
+}

--- a/src/lib/api/adapters/__tests__/party.adapter.test.ts
+++ b/src/lib/api/adapters/__tests__/party.adapter.test.ts
@@ -172,6 +172,50 @@ describe('PartyAdapter', () => {
 		})
 	})
 
+	describe('skill boosts', () => {
+		it('serializes the complete calculator state and camel-cases the response', async () => {
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					enhancements: { optimus: 0, omega: 0, taboo: 0 },
+					lines: [],
+					state: {
+						hp_percent: 50,
+						ally_max_hp: 25_425,
+						turn: 3,
+						foe_element: 'water',
+						arcarum: false
+					}
+				})
+			})
+
+			const result = await adapter.getSkillBoosts('ABC123', {
+				hpPercent: 50,
+				allyMaxHp: 25_425,
+				turn: 3,
+				foeElement: 'water',
+				arcarum: false
+			})
+
+			const requestUrl = new URL(String(vi.mocked(global.fetch).mock.calls[0]?.[0]))
+			expect(requestUrl.pathname).toBe('/parties/ABC123/skill_boosts')
+			expect(Object.fromEntries(requestUrl.searchParams)).toEqual({
+				hp_percent: '50',
+				ally_max_hp: '25425',
+				turn: '3',
+				foe_element: 'water',
+				arcarum: 'false'
+			})
+			expect(result.state).toEqual({
+				hpPercent: 50,
+				allyMaxHp: 25_425,
+				turn: 3,
+				foeElement: 'water',
+				arcarum: false
+			})
+		})
+	})
+
 	describe('user parties listing', () => {
 		it('should list user parties and extract pagination from meta', async () => {
 			global.fetch = vi.fn().mockResolvedValue({

--- a/src/lib/api/adapters/party.adapter.ts
+++ b/src/lib/api/adapters/party.adapter.ts
@@ -14,7 +14,7 @@ import { DEFAULT_ADAPTER_CONFIG } from './config'
 import type { Party } from '$lib/types/api/party'
 import type { PartyShare } from '$lib/types/api/partyShare'
 import type { PartyVisibility } from '$lib/types/visibility'
-import type { SkillBoosts } from '$lib/types/api/skillBoosts'
+import type { SkillBoostRequestState, SkillBoosts } from '$lib/types/api/skillBoosts'
 
 /**
  * Parameters for creating a new party
@@ -181,13 +181,15 @@ export class PartyAdapter extends BaseAdapter {
 	 */
 	async getSkillBoosts(
 		shortcode: string,
-		state?: { hpPercent?: number; turn?: number; foeElement?: string },
+		state?: SkillBoostRequestState,
 		options?: RequestOptions
 	): Promise<SkillBoosts> {
 		const query = new URLSearchParams()
 		if (state?.hpPercent != null) query.set('hp_percent', String(state.hpPercent))
+		if (state?.allyMaxHp != null) query.set('ally_max_hp', String(state.allyMaxHp))
 		if (state?.turn != null) query.set('turn', String(state.turn))
 		if (state?.foeElement) query.set('foe_element', state.foeElement)
+		if (state?.arcarum != null) query.set('arcarum', String(state.arcarum))
 		const qs = query.size > 0 ? `?${query.toString()}` : ''
 		return this.request<SkillBoosts>(`/parties/${shortcode}/skill_boosts${qs}`, options)
 	}

--- a/src/lib/components/collection/CollectionWeaponPane.svelte
+++ b/src/lib/components/collection/CollectionWeaponPane.svelte
@@ -154,6 +154,7 @@
 			if (updates.befoulmentModifierId !== undefined) {
 				input.befoulmentModifierId = updates.befoulmentModifierId
 				input.befoulmentStrength = updates.befoulmentStrength
+				input.befoulmentPermeation = updates.befoulmentPermeation
 				input.exorcismLevel = updates.exorcismLevel
 			}
 

--- a/src/lib/components/sidebar/CalculatorPane.svelte
+++ b/src/lib/components/sidebar/CalculatorPane.svelte
@@ -8,6 +8,8 @@
 	import SkillLabel from '$lib/components/SkillLabel.svelte'
 	import Notice from '$lib/components/ui/Notice.svelte'
 	import Slider from '$lib/components/ui/Slider.svelte'
+	import Input from '$lib/components/ui/Input.svelte'
+	import Switch from '$lib/components/ui/switch/Switch.svelte'
 	import ElementPicker from '$lib/components/ui/element-picker/ElementPicker.svelte'
 	import { skillHighlight } from '$lib/stores/skillHighlight.svelte'
 	import { getWeaponSkillIcon } from '$lib/utils/images'
@@ -30,8 +32,10 @@
 	// initializes from the server's advantaged-foe default on first load.
 	// HP runs 1%, then 5% steps (1, 5, 10, … 100): slider stop 0 → 1%, stop n → n×5.
 	let hpStop = $state(20)
+	let allyMaxHp = $state<number | undefined>(undefined)
 	let turn = $state(1)
 	let foeElement = $state<string | undefined>(undefined)
+	let arcarum = $state(false)
 
 	const hpPercent = $derived(hpStop === 0 ? 1 : hpStop * 5)
 
@@ -61,18 +65,29 @@
 		try {
 			const result = await partyAdapter.getSkillBoosts(shortcode, {
 				hpPercent,
+				...(allyMaxHp != null ? { allyMaxHp } : {}),
 				turn,
-				...(foeElement ? { foeElement } : {})
+				...(foeElement ? { foeElement } : {}),
+				arcarum
 			})
 			if (id !== requestId) return // a newer request superseded this one
 			boosts = result
+			allyMaxHp = result.state.allyMaxHp
 			foeElement = result.state.foeElement
+			arcarum = result.state.arcarum
 			error = false
 		} catch {
 			if (id === requestId) error = true
 		} finally {
 			if (id === requestId) loading = false
 		}
+	}
+
+	function handleMaxHpChange() {
+		if (allyMaxHp != null) {
+			allyMaxHp = Number.isFinite(allyMaxHp) ? Math.min(999_999, Math.max(0, allyMaxHp)) : undefined
+		}
+		refetch()
 	}
 
 	onMount(refetch)
@@ -132,6 +147,21 @@
 				</div>
 				<div class="filter-group">
 					<div class="filter-header">
+						<span class="filter-label">{m.calculator_max_hp()}</span>
+					</div>
+					<Input
+						bind:value={allyMaxHp}
+						type="number"
+						min={0}
+						max={999999}
+						step={1}
+						contained
+						fullWidth
+						onchange={handleMaxHpChange}
+					/>
+				</div>
+				<div class="filter-group">
+					<div class="filter-header">
 						<span class="filter-label">{m.calculator_turn_value({ turn: String(turn) })}</span>
 					</div>
 					<Slider
@@ -163,6 +193,21 @@
 							}
 						}}
 					/>
+				</div>
+				<div class="filter-group">
+					<div class="filter-header">
+						<span class="filter-label">{m.calculator_arcarum()}</span>
+						<Switch
+							checked={arcarum}
+							size="small"
+							element={partyElement}
+							onCheckedChange={(value) => {
+								if (value === arcarum) return
+								arcarum = value
+								refetch()
+							}}
+						/>
+					</div>
 				</div>
 			</div>
 		</DetailsSection>

--- a/src/lib/components/sidebar/WeaponEditPane.svelte
+++ b/src/lib/components/sidebar/WeaponEditPane.svelte
@@ -252,7 +252,7 @@
 		{#if hasAxSkills}
 			<DetailsSection title={m.details_ax_skills()}>
 				<div class="section-content">
-					<AxSkillSelect bind:currentSkills={axSkills} />
+					<AxSkillSelect bind:currentSkills={axSkills} axType={series?.axType ?? 'standard'} />
 				</div>
 			</DetailsSection>
 		{/if}

--- a/src/lib/components/sidebar/WeaponEditPane.svelte
+++ b/src/lib/components/sidebar/WeaponEditPane.svelte
@@ -59,6 +59,7 @@
 		axStrength2?: number
 		befoulmentModifierId?: string
 		befoulmentStrength?: number
+		befoulmentPermeation?: number | null
 		exorcismLevel?: number
 		bullets?: BulletLoadout[]
 	}
@@ -186,6 +187,7 @@
 			if (befoulment?.modifier?.id) {
 				updates.befoulmentModifierId = befoulment.modifier.id
 				updates.befoulmentStrength = befoulment.strength
+				updates.befoulmentPermeation = befoulment.permeation ?? 1
 				updates.exorcismLevel = befoulment.exorcismLevel
 			}
 		}

--- a/src/lib/components/sidebar/details/SyncFieldDiff.svelte
+++ b/src/lib/components/sidebar/details/SyncFieldDiff.svelte
@@ -97,6 +97,7 @@
 		if (fieldKey === 'element') return m.sync_diff_element()
 		if (fieldKey === 'befoulmentModifier') return m.sync_diff_befoulment_modifier()
 		if (fieldKey === 'befoulmentStrength') return m.sync_diff_befoulment_strength()
+		if (fieldKey === 'befoulmentPermeation') return m.details_permeation()
 		if (fieldKey === 'exorcismLevel') return m.sync_diff_exorcism_level()
 		if (fieldKey.startsWith('overMastery.')) {
 			const i = Number(fieldKey.split('.')[1])
@@ -222,6 +223,14 @@
 				<Icon name="arrow-right" size={14} class="diff-arrow" />
 				<span class="text-value">
 					{(gridItem as GridWeapon).befoulment?.strength ?? m.sync_diff_empty()}
+				</span>
+			{:else if fieldKey === 'befoulmentPermeation'}
+				<span class="text-value">
+					{(collectionItem as CollectionWeapon).befoulment?.permeation ?? m.sync_diff_empty()}
+				</span>
+				<Icon name="arrow-right" size={14} class="diff-arrow" />
+				<span class="text-value">
+					{(gridItem as GridWeapon).befoulment?.permeation ?? m.sync_diff_empty()}
 				</span>
 			{:else if fieldKey === 'exorcismLevel'}
 				<span class="text-value">

--- a/src/lib/components/sidebar/details/TeamView.svelte
+++ b/src/lib/components/sidebar/details/TeamView.svelte
@@ -179,7 +179,12 @@
 	const ELEMENT_KEYS = ['element'] as const
 	const WEAPON_KEY_KEYS = ['weaponKey1', 'weaponKey2', 'weaponKey3', 'weaponKey4'] as const
 	const AX_KEYS = ['ax.0', 'ax.1'] as const
-	const BEFOULMENT_KEYS = ['befoulmentModifier', 'befoulmentStrength', 'exorcismLevel'] as const
+	const BEFOULMENT_KEYS = [
+		'befoulmentModifier',
+		'befoulmentStrength',
+		'befoulmentPermeation',
+		'exorcismLevel'
+	] as const
 
 	const uncapSectionOOS = $derived(hasAnyField(outOfSyncFields, UNCAP_KEYS))
 	const awakeningSectionOOS = $derived(hasAnyField(outOfSyncFields, AWAKENING_KEYS))
@@ -481,9 +486,15 @@
 					label={weapon.befoulment.modifier.nameEn}
 					value={`${weapon.befoulment.strength}${weapon.befoulment.modifier.suffix ?? ''}`}
 				/>
+				{#if weapon.befoulment.permeation != null}
+					<DetailRow
+						label={m.details_permeation()}
+						value={`${weapon.befoulment.permeation}${weapon.befoulment.modifier.suffix ?? ''}`}
+					/>
+				{/if}
 				<DetailRow
 					label={m.details_exorcism_level()}
-					value={`${weapon.befoulment.exorcismLevel ?? 0}`}
+					value={`${Math.max(weapon.befoulment.exorcismLevel ?? 1, 1)}`}
 				/>
 			</DetailsSection>
 		{/if}

--- a/src/lib/components/sidebar/edit/AxSkillSelect.svelte
+++ b/src/lib/components/sidebar/edit/AxSkillSelect.svelte
@@ -6,16 +6,31 @@
 	import Select from '$lib/components/ui/Select.svelte'
 	import Input from '$lib/components/ui/Input.svelte'
 
+	// Fallback when the API hasn't populated axGroup yet
 	const PRIMARY_AX_SLUGS = ['ax_atk', 'ax_def', 'ax_hp', 'ax_ca_dmg', 'ax_multiattack']
+	const UTILITY_AX_SLUGS = ['ax_exp', 'ax_rupie']
 
 	interface Props {
 		/** Current AX skills on the weapon (bindable) */
 		currentSkills?: AugmentSkill[]
 		/** Language for display */
 		locale?: 'en' | 'ja'
+		/** The weapon's AX slot rules per gbf.wiki/AX_Skills */
+		axType?: 'standard' | 'xeno' | 'primal' | 'utility'
 	}
 
-	let { currentSkills = $bindable<AugmentSkill[]>([]), locale = 'en' }: Props = $props()
+	let {
+		currentSkills = $bindable<AugmentSkill[]>([]),
+		locale = 'en',
+		axType = 'standard'
+	}: Props = $props()
+
+	function groupOf(skill: WeaponStatModifier): string {
+		if (skill.axGroup) return skill.axGroup
+		if (PRIMARY_AX_SLUGS.includes(skill.slug)) return 'primary'
+		if (UTILITY_AX_SLUGS.includes(skill.slug)) return 'utility'
+		return 'secondary'
+	}
 
 	const axQuery = createQuery(() => entityQueries.axSkills())
 
@@ -32,13 +47,21 @@
 		selectedSecondaryId ? (axQuery.data ?? []).find((m) => m.id === selectedSecondaryId) : undefined
 	)
 
-	const showSecondary = $derived(!!selectedPrimary)
+	// Utility weapons (Ancient series) carry a single EXP/Rupie slot
+	const showSecondary = $derived(axType !== 'utility' && !!selectedPrimary)
 
 	// Build primary skill options
 	const primaryOptions = $derived.by(() => {
 		const items: Array<{ value: string; label: string }> = [{ value: '', label: m.ax_no_skill() }]
 
-		for (const skill of (axQuery.data ?? []).filter((s) => PRIMARY_AX_SLUGS.includes(s.slug))) {
+		// primal weapons roll standard primaries AND EXP/Rupie; utility rolls only the latter
+		const wanted =
+			axType === 'utility'
+				? ['utility']
+				: axType === 'primal'
+					? ['primary', 'utility']
+					: ['primary']
+		for (const skill of (axQuery.data ?? []).filter((s) => wanted.includes(groupOf(s)))) {
 			items.push({
 				value: skill.id,
 				label: locale === 'ja' ? skill.nameJp : skill.nameEn
@@ -48,11 +71,19 @@
 		return items
 	})
 
-	// Build secondary skill options
+	// Build secondary skill options: the pool is keyed by (AX type, chosen primary)
+	// per gbf.wiki/AX_Skills — a Magna weapon's ATK primary offers Skill DMG Cap,
+	// a Xeno's offers Supplemental Skill DMG. Falls back to the flat group split
+	// until the API exposes axSecondaries.
 	const secondaryOptions = $derived.by(() => {
 		const items: Array<{ value: string; label: string }> = [{ value: '', label: m.ax_no_skill() }]
 
-		for (const skill of (axQuery.data ?? []).filter((s) => !PRIMARY_AX_SLUGS.includes(s.slug))) {
+		const poolKey = axType === 'xeno' ? 'xeno' : 'standard'
+		const pool = selectedPrimary?.axSecondaries?.[poolKey]
+		const candidates = (axQuery.data ?? []).filter((s) =>
+			pool ? pool.includes(s.slug) : ['secondary', 'extended'].includes(groupOf(s))
+		)
+		for (const skill of candidates) {
 			items.push({
 				value: skill.id,
 				label: locale === 'ja' ? skill.nameJp : skill.nameEn

--- a/src/lib/components/sidebar/edit/BefoulmentSelect.svelte
+++ b/src/lib/components/sidebar/edit/BefoulmentSelect.svelte
@@ -26,7 +26,9 @@
 	// Derive display values directly from the bound prop
 	const selectedModifierId = $derived(currentBefoulment?.modifier?.id ?? '')
 	const strength = $derived(currentBefoulment?.strength ?? 0)
-	const exorcismLevel = $derived(currentBefoulment?.exorcismLevel ?? 0)
+	const permeation = $derived(currentBefoulment?.permeation ?? 1)
+	// The game starts every weapon at Exorcision Lvl 1; stored 0 is legacy data.
+	const exorcismLevel = $derived(Math.max(currentBefoulment?.exorcismLevel ?? 1, 1))
 
 	// Get selected modifier from query data
 	const selectedModifier = $derived(
@@ -34,6 +36,46 @@
 			? (befoulmentQuery.data ?? []).find((m) => m.id === selectedModifierId)
 			: undefined
 	)
+
+	// Each level-up past the starting Lvl 1 (up to 4 of them) weakens the befoulment
+	// by 1x, 2x, or 3x the modifier's reduction step (gbf.wiki/Befoulments).
+	const reductions = $derived(Math.max(exorcismLevel - 1, 0))
+	const step = $derived(selectedModifier?.reductionStep ?? 0)
+	// Debuffs are negative and weaken toward zero; Turn DMG is positive and weakens downward.
+	const towardZero = $derived((selectedModifier?.baseMax ?? -1) > 0 ? -1 : 1)
+	// The stored value's sign — shown OUTSIDE the input so the box only ever holds the
+	// magnitude (typing "-" mid-edit used to parse as 0 and snap back to the bound).
+	const sign = $derived(towardZero === 1 ? -1 : 1)
+
+	// The range of CURRENT values reachable at this exorcision level: worst case keeps
+	// the strongest base roll with minimum reductions, best case the weakest base roll
+	// with maximum reductions.
+	const currentBounds = $derived.by(() => {
+		if (!selectedModifier) return { min: -999, max: 999 }
+		const lo = (selectedModifier.baseMin ?? 0) + towardZero * reductions * step
+		const hi = (selectedModifier.baseMax ?? 0) + towardZero * reductions * step * 3
+		return { min: Math.min(lo, hi), max: Math.max(lo, hi) }
+	})
+	// The same bounds as positive magnitudes, for the unsigned input. Without a
+	// reduction step (API not yet serving it) the level-aware lower bound can't be
+	// computed — fall back to accepting any magnitude below the base maximum rather
+	// than wrongly clamping to the Lvl 1 range.
+	const magnitudeBounds = $derived.by(() => {
+		const lo = Math.min(Math.abs(currentBounds.min), Math.abs(currentBounds.max))
+		const hi = Math.max(Math.abs(currentBounds.min), Math.abs(currentBounds.max))
+		return step > 0 ? { min: lo, max: hi } : { min: 0, max: hi }
+	})
+
+	// With no level-ups the current value IS the base roll; past that, the base can
+	// only be bounded (each of the `reductions` rolls was 1-3 steps).
+	const impliedBaseRange = $derived.by(() => {
+		if (!selectedModifier || reductions === 0 || !strength) return null
+		const a = strength - towardZero * reductions * step
+		const b = strength - towardZero * reductions * step * 3
+		const min = Math.max(Math.min(a, b), selectedModifier.baseMin ?? -999)
+		const max = Math.min(Math.max(a, b), selectedModifier.baseMax ?? 999)
+		return { min: Math.round(min * 10) / 10, max: Math.round(max * 10) / 10 }
+	})
 
 	// Build befoulment options
 	const befoulmentOptions = $derived.by(() => {
@@ -51,18 +93,22 @@
 		return items
 	})
 
-	// Exorcism level options (0 to maxExorcismLevel, fallback to 5)
+	// Exorcism level options (1 to maxExorcismLevel, fallback to 5 — weapons start at 1)
 	const exorcismOptions = $derived.by(() => {
 		const max = maxExorcismLevel ?? 5
-		return Array.from({ length: max + 1 }, (_, i) => ({
-			value: i,
-			label: m.befoulment_level({ level: String(i) })
+		return Array.from({ length: max }, (_, i) => ({
+			value: i + 1,
+			label: m.befoulment_level({ level: String(i + 1) })
 		}))
 	})
 
 	// Get suffix for display
 	function getSuffix(modifier: WeaponStatModifier | undefined): string {
 		return modifier?.suffix ?? ''
+	}
+
+	function clamp(val: number, min: number, max: number): number {
+		return Math.min(Math.max(val, min), max)
 	}
 
 	function handleModifierChange(value: string | undefined) {
@@ -74,25 +120,56 @@
 		currentBefoulment = {
 			modifier,
 			strength: currentBefoulment?.strength ?? 0,
-			exorcismLevel: currentBefoulment?.exorcismLevel ?? 0
+			permeation: currentBefoulment?.permeation ?? 1,
+			exorcismLevel: Math.max(currentBefoulment?.exorcismLevel ?? 1, 1)
 		}
 	}
 
-	function handleStrengthChange(event: Event) {
+	// While typing: track the value without rewriting the box (rewriting mid-edit made
+	// it impossible to delete and retype). Clamp and normalize only on blur.
+	function handleStrengthInput(event: Event) {
 		const input = event.target as HTMLInputElement
-		const val = parseFloat(input.value) || 0
-		const max = selectedModifier?.baseMax ?? 999
-		const clamped = Math.min(val, max)
-		if (val > max) input.value = String(clamped)
+		const magnitude = parseFloat(input.value)
+		if (Number.isNaN(magnitude) || !currentBefoulment) return
+		currentBefoulment = { ...currentBefoulment, strength: sign * Math.abs(magnitude) }
+	}
+
+	function handleStrengthBlur(event: Event) {
+		const input = event.target as HTMLInputElement
+		const magnitude = Math.abs(parseFloat(input.value) || 0)
+		const clamped = clamp(magnitude, magnitudeBounds.min, magnitudeBounds.max)
+		input.value = String(clamped)
 		if (currentBefoulment) {
-			currentBefoulment = { ...currentBefoulment, strength: clamped }
+			currentBefoulment = { ...currentBefoulment, strength: sign * clamped }
 		}
+	}
+
+	// Permeation (深度): the game's 1-6 severity depth of the base roll. 1 = weakest
+	// befoulment, 6 = strongest. Every befouled weapon has one, so it defaults to 1.
+	const permeationOptions = Array.from({ length: 6 }, (_, i) => ({
+		value: i + 1,
+		label: String(i + 1)
+	}))
+
+	function handlePermeationChange(value: number | undefined) {
+		if (!currentBefoulment) return
+		currentBefoulment = { ...currentBefoulment, permeation: value ?? 1 }
 	}
 
 	function handleExorcismChange(value: number | undefined) {
-		if (currentBefoulment) {
-			currentBefoulment = { ...currentBefoulment, exorcismLevel: value ?? 0 }
+		if (!currentBefoulment) return
+		const level = Math.max(value ?? 1, 1)
+		if (step <= 0) {
+			currentBefoulment = { ...currentBefoulment, exorcismLevel: level }
+			return
 		}
+		// Re-clamp the current value into the new level's reachable range
+		const r = Math.max(level - 1, 0)
+		const lo = (selectedModifier?.baseMin ?? 0) + towardZero * r * step
+		const hi = (selectedModifier?.baseMax ?? 0) + towardZero * r * step * 3
+		const bounds = { min: Math.min(lo, hi), max: Math.max(lo, hi) }
+		const clamped = clamp(currentBefoulment.strength ?? 0, bounds.min, bounds.max)
+		currentBefoulment = { ...currentBefoulment, exorcismLevel: level, strength: clamped }
 	}
 </script>
 
@@ -106,7 +183,7 @@
 	</div>
 {:else}
 	<div class="befoulment-select">
-		<!-- Befoulment Type + Strength -->
+		<!-- Befoulment Type + current in-game value -->
 		<div class="skill-row">
 			<div class="skill-fields">
 				<div class="skill-select">
@@ -123,17 +200,21 @@
 
 				{#if selectedModifier}
 					<div class="skill-value-group">
+						{#if sign < 0}
+							<span class="sign">&minus;</span>
+						{/if}
 						<div class="skill-value-input">
 							<Input
 								type="number"
-								min={selectedModifier.baseMin}
-								max={selectedModifier.baseMax}
-								step={0.5}
-								value={strength || ''}
-								oninput={handleStrengthChange}
+								min={magnitudeBounds.min}
+								max={magnitudeBounds.max}
+								step={0.1}
+								value={strength ? Math.abs(strength) : ''}
+								oninput={handleStrengthInput}
+								onblur={handleStrengthBlur}
 								contained
 								variant="number"
-								placeholder="{selectedModifier.baseMin}~{selectedModifier.baseMax}"
+								placeholder="{magnitudeBounds.min}~{magnitudeBounds.max}"
 							/>
 						</div>
 						<span class="suffix">{getSuffix(selectedModifier) ?? ''}</span>
@@ -142,8 +223,8 @@
 			</div>
 		</div>
 
-		<!-- Exorcism Level -->
 		{#if selectedModifier}
+			<!-- Exorcision Level -->
 			<div class="skill-row">
 				<div class="skill-fields">
 					<div class="skill-select">
@@ -157,6 +238,31 @@
 						/>
 					</div>
 				</div>
+			</div>
+
+			<!-- Permeation (深度): 1-6 severity depth of the base roll -->
+			<div class="skill-row">
+				<div class="skill-fields">
+					<span class="field-label">{m.befoulment_permeation()}</span>
+					<div class="skill-select permeation-select">
+						<Select
+							options={permeationOptions}
+							value={permeation}
+							onValueChange={handlePermeationChange}
+							size="medium"
+							fullWidth
+							contained
+						/>
+					</div>
+				</div>
+				{#if impliedBaseRange}
+					<span class="hint"
+						>{m.befoulment_permeation_hint({
+							min: String(impliedBaseRange.min),
+							max: String(impliedBaseRange.max)
+						})}</span
+					>
+				{/if}
 			</div>
 		{/if}
 	</div>
@@ -211,10 +317,28 @@
 		min-width: 0;
 	}
 
+	.field-label {
+		flex: 1;
+		min-width: 0;
+		color: var(--text-secondary);
+		font-size: typography.$font-small;
+	}
+
+	.permeation-select {
+		flex: 0 0 auto;
+		width: 96px;
+	}
+
 	.skill-value-group {
 		display: flex;
 		align-items: center;
 		flex-shrink: 0;
+	}
+
+	.sign {
+		color: var(--text-secondary);
+		font-size: typography.$font-regular;
+		margin-right: spacing.$unit-half;
 	}
 
 	.suffix {
@@ -222,6 +346,11 @@
 		font-size: typography.$font-small;
 		min-width: 1.5em;
 		text-align: right;
+	}
+
+	.hint {
+		color: var(--text-secondary);
+		font-size: typography.$font-small;
 	}
 
 	.error {

--- a/src/lib/types/api/collection.ts
+++ b/src/lib/types/api/collection.ts
@@ -136,6 +136,7 @@ export interface CollectionWeaponInput {
 	// Befoulment (for Odiant weapons)
 	befoulmentModifierId?: string
 	befoulmentStrength?: number
+	befoulmentPermeation?: number | null
 	exorcismLevel?: number
 }
 

--- a/src/lib/types/api/skillBoosts.ts
+++ b/src/lib/types/api/skillBoosts.ts
@@ -41,13 +41,30 @@ export interface SkillBoostEntry {
 	count: number
 }
 
+export interface SkillBoostRequestState {
+	/** Party HP percent to evaluate (0-100) */
+	hpPercent?: number
+	/** Displayed party Max HP used by Vitality-style effects */
+	allyMaxHp?: number
+	/** Battle turn (1+) */
+	turn?: number
+	/** Foe element ("fire" | "water" | ... ) */
+	foeElement?: string
+	/** Whether Arcarum/Replicard-only effects are active */
+	arcarum?: boolean
+}
+
 export interface SkillBoostState {
 	/** Party HP percent the panel is evaluated at (0-100) */
 	hpPercent: number
+	/** Displayed party Max HP, omitted until the user supplies it */
+	allyMaxHp?: number
 	/** Battle turn (1+) */
 	turn: number
 	/** Foe element ("fire" | "water" | ... ), server-defaulted to the advantaged foe */
 	foeElement?: string
+	/** Whether Arcarum/Replicard-only effects are active */
+	arcarum: boolean
 }
 
 export interface SkillBoosts {

--- a/src/lib/types/api/weaponSeries.ts
+++ b/src/lib/types/api/weaponSeries.ts
@@ -23,6 +23,8 @@ export interface WeaponSeriesRef {
 	hasAwakening: boolean
 	/** Type of augment this series supports: "ax", "befoulment", or "no_augment" */
 	augmentType: AugmentType
+	/** AX slot rules: 'standard' = primary + secondary/extended slots; 'utility' = one EXP/Rupie slot */
+	axType?: 'standard' | 'xeno' | 'primal' | 'utility' | null
 	extra: boolean
 	elementChangeable: boolean
 	/** Number of weapon key slots this series supports (null if no keys) */

--- a/src/lib/types/api/weaponStatModifier.ts
+++ b/src/lib/types/api/weaponStatModifier.ts
@@ -38,6 +38,8 @@ export interface WeaponStatModifier {
 	baseMin: number
 	/** Maximum valid strength value */
 	baseMax: number
+	/** Smallest exorcision reduction roll (befoulments; each level-up reduces by 1-3x this) */
+	reductionStep?: number | null
 }
 
 /**
@@ -58,8 +60,10 @@ export interface AugmentSkill {
 export interface Befoulment {
 	/** The befoulment modifier definition */
 	modifier: WeaponStatModifier
-	/** The strength/value of this befoulment */
+	/** The CURRENT (post-exorcision) value the game displays on the skill */
 	strength: number
-	/** Exorcism level (0-5) - higher levels reduce the negative effect */
+	/** Permeation (深度): the game's 1-6 severity depth of the base roll, unaffected by exorcision */
+	permeation?: number | null
+	/** Exorcism level (0-5; the game starts weapons at 1) - higher levels reduce the negative effect */
 	exorcismLevel: number
 }

--- a/src/lib/types/api/weaponStatModifier.ts
+++ b/src/lib/types/api/weaponStatModifier.ts
@@ -34,6 +34,13 @@ export interface WeaponStatModifier {
 	polarity: 1 | -1
 	/** Display suffix for values (e.g., "%") */
 	suffix: string | null
+	/** AX pool this skill rolls from: primary | secondary | extended | utility (null for befoulments) */
+	axGroup?: 'primary' | 'secondary' | 'extended' | 'utility' | null
+	/** Secondary-roll value range (differs from the primary base range) */
+	secondaryMin?: number | null
+	secondaryMax?: number | null
+	/** On primaries: the 4-option secondary pools keyed by AX type (standard/xeno) */
+	axSecondaries?: Record<string, string[]>
 	/** Minimum valid strength value */
 	baseMin: number
 	/** Maximum valid strength value */

--- a/vitest.config.adapter.ts
+++ b/vitest.config.adapter.ts
@@ -22,8 +22,12 @@ export default defineConfig({
 	},
 	resolve: {
 		alias: {
+			'$lib/stores/auth.store.svelte': resolve(
+				'./src/lib/api/adapters/__tests__/auth-store-mock.ts'
+			),
 			$lib: resolve('./src/lib'),
 			$types: resolve('./src/lib/types'),
+			'$app/environment': resolve('./src/lib/api/adapters/__tests__/app-environment-mock.ts'),
 			'$env/static/public': resolve('./src/lib/api/adapters/__tests__/env-mock.ts')
 		}
 	}


### PR DESCRIPTION
Companion to the hensei-api befoulment changes on #452's branch.

The befoulment pane asked for the base roll and clamped input to the base range, so the post-exorcision value the game actually displays could not be entered. Per [gbf.wiki/Befoulments](https://gbf.wiki/Befoulments), each Exorcision level-up (1→5, so up to 4) weakens the befoulment by a random roll of 1×/2×/3× the modifier's reduction step — so current values sit outside the base range, and the base is not uniquely recoverable from them.

- **Current value input**: takes what the game displays on the skill, clamped to the range reachable at the selected Exorcision level (base range widened by the possible reduction rolls).
- **Permeation (深度)**: the game's integer severity depth of the base roll, 1 (weakest) to 6 (strongest), unaffected by exorcision — a 1–6 select. Stored on grid and collection weapons and flows through the collection sync diff and team details view.
- **Implied base roll hint**: worked backwards from the current value at the selected level — `[current − 3·(L−1)·step, current − (L−1)·step]` intersected with the base range.
- Requires the API side (migration + wiki-corrected base ranges + reduction steps on `weapon_stat_modifiers`): base ranges were outdated (e.g. ATK −12..−6 vs the wiki's −16..−6, C.A. −38..−26 vs −22..−50).

`svelte-check` 0 errors; prettier clean.