### PR TITLE
Center calculator loading spinner

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1727,6 +1727,7 @@
 	"calculator_open": "Open skill calculator",
 	"calculator_enhancements": "Weapon Skill Enhancements",
 	"calculator_empty": "No weapon skill boosts to show.",
+	"calculator_loading": "Loading weapon skill boosts",
 	"calculator_error": "Couldn't load skill boosts.",
 	"calculator_enh_optimus": "Optimus",
 	"calculator_enh_omega": "Omega",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1708,6 +1708,7 @@
 	"calculator_open": "スキル計算機を開く",
 	"calculator_enhancements": "武器スキル効果加護",
 	"calculator_empty": "表示できる武器スキル効果がありません。",
+	"calculator_loading": "武器スキル効果を読み込み中",
 	"calculator_error": "スキル効果を読み込めませんでした。",
 	"calculator_enh_optimus": "オプティマス",
 	"calculator_enh_omega": "マグナ",

--- a/src/lib/components/sidebar/CalculatorPane.svelte
+++ b/src/lib/components/sidebar/CalculatorPane.svelte
@@ -15,6 +15,7 @@
 	import { getWeaponSkillIcon } from '$lib/utils/images'
 	import { getLocale } from '$lib/paraglide/runtime.js'
 	import { localizedName } from '$lib/utils/locale'
+	import Icon from '$lib/components/Icon.svelte'
 
 	interface Props {
 		shortcode: string
@@ -118,7 +119,9 @@
 
 <div class="calculator-pane">
 	{#if loading}
-		<div class="state">…</div>
+		<div class="loading-state" role="status" aria-label={m.calculator_loading()}>
+			<Icon name="loader-2" size={24} />
+		</div>
 	{:else if error}
 		<div class="state">{m.calculator_error()}</div>
 	{:else if boosts}
@@ -294,8 +297,21 @@
 	.calculator-pane {
 		display: flex;
 		flex-direction: column;
+		flex: 1;
 		gap: $unit-3x;
 		padding: $unit-2x 0;
+	}
+
+	.loading-state {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex: 1;
+		color: var(--text-tertiary);
+
+		:global(svg) {
+			animation: spin 1s linear infinite;
+		}
 	}
 
 	.notice {
@@ -454,6 +470,12 @@
 
 		&.capped {
 			color: var(--orange-text, #e08a00);
+		}
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
 		}
 	}
 </style>


### PR DESCRIPTION
## Summary

- replace the calculator loading ellipsis with the shared rotating loader icon
- vertically and horizontally center the spinner in the available pane space
- add localized accessible loading labels for English and Japanese

## Testing

- corepack pnpm lint
- corepack pnpm check (0 errors)
- corepack pnpm test (105 files, 1,697 tests)